### PR TITLE
Revert "chore(deps): update dependency uvicorn to v0.18.1 (#127)"

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -19,7 +19,7 @@ routeros-diff==0.5.3
 sushy==4.2.0
 tabulate==0.8.10
 transitions==0.8.11
-uvicorn[standard]==0.18.1
+uvicorn[standard]==0.17.6
 watchdog==2.1.9
 
 # https://github.com/ktbyers/netmiko/pull/2362


### PR DESCRIPTION
This reverts commit be0354c463be309d7b798f79060b68c132b594f1.

AttributeError: module 'uvicorn' has no attribute 'logging'. Did you mean: '_logging'?

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/usr/local/lib/python3.10/logging/config.py", line 392, in resolve
    self.importer(used)
ModuleNotFoundError: No module named 'uvicorn.logging'

Signed-off-by: Christian Berendt <berendt@osism.tech>