### PR TITLE
Add some basic error handling

### DIFF
--- a/osism/tasks/__init__.py
+++ b/osism/tasks/__init__.py
@@ -114,6 +114,9 @@ def run_ansible_in_environment(request_id, environment, role, arguments):
             # NOTE: use task_id or request_id in future
             redis.publish(f"{environment}-{role}", line)
 
+        rc = p.wait(timeout=60)
+        redis.publish(f"{environment}-{role}", f"RC: {rc}\n")
+
         # NOTE: use task_id or request_id in future
         redis.publish(f"{environment}-{role}", "QUIT")
         lock.release()


### PR DESCRIPTION
Catch the returncode from subprocesses that are executed and propagate
it to the client.

Closes: #122
Signed-off-by: Dr. Jens Harbott <harbott@osism.tech>