### PR TITLE
Set task_track_started = True

### DIFF
--- a/osism/tasks/__init__.py
+++ b/osism/tasks/__init__.py
@@ -20,6 +20,7 @@ class Config:
     result_backend = "redis://redis"
     task_create_missing_queues = True
     task_default_queue = "default"
+    task_track_started = True,
     task_routes = {
         'osism.tasks.ceph.*': {
             'queue': 'ceph-ansible'


### PR DESCRIPTION
Task will report its status as ‘started’ when the task is executed by a worker.

https://docs.celeryq.dev/en/latest/userguide/configuration.html#task-track-started

Signed-off-by: Christian Berendt <berendt@osism.tech>