### PR TITLE
Also update version in requirements.ansible.txt

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -1,7 +1,12 @@
 {
   "extends": [
     "github>osism/renovate-config",
-    "github>osism/renovate-config:docker",
-    "github>osism/renovate-config:python"
-  ]
+    "github>osism/renovate-config:docker"
+  ],
+  "pip_requierements": {
+    "fileMatch": [
+      "requirements.ansible.txt",
+      "requirements.txt"
+    ]
+  }
 }


### PR DESCRIPTION
With aac4327dcc0b6f72df69b4fb55cf689d1c94a74e the Ansible requirements were moved into a separate requirements file. This file is not recogniced by default by the Renovate bot.

Signed-off-by: Christian Berendt <berendt@osism.tech>