### PR TITLE
Fix typo in renovate.json

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -3,7 +3,7 @@
     "github>osism/renovate-config",
     "github>osism/renovate-config:docker"
   ],
-  "pip_requierements": {
+  "pip_requirements": {
     "fileMatch": [
       "requirements.ansible.txt",
       "requirements.txt"


### PR DESCRIPTION
Was transferred by copy & paste from osism/renovate-config. It was also fixed there.

Signed-off-by: Christian Berendt <berendt@osism.tech>