### PR TITLE
Add manage command

### DIFF
--- a/osism/commands/manage.py
+++ b/osism/commands/manage.py
@@ -1,0 +1,27 @@
+import argparse
+import subprocess
+
+from cliff.command import Command
+
+
+class Images(Command):
+    def get_parser(self, prog_name):
+        parser = super(Images, self).get_parser(prog_name)
+        parser.add_argument(
+            "arguments",
+            nargs=argparse.REMAINDER,
+            type=str,
+            help="Arguments to add (all arguments of the openstack-image-manager-command are possible)",
+        )
+        return parser
+
+    def take_action(self, parsed_args):
+        joined_arguments = " ".join(parsed_args.arguments)
+        arguments = joined_arguments.replace("-- ", "")
+        subprocess.call(
+            f"/usr/local/bin/openstack-image-manager --images=/etc/images {arguments}",
+            shell=True,
+            env={
+                "OS_CLIENT_CONFIG_FILE": "/opt/configuration/environments/openstack/clouds.yml"
+            },
+        )

--- a/setup.cfg
+++ b/setup.cfg
@@ -44,6 +44,10 @@ osism.commands:
     console = osism.commands.console:Run
     container = osism.commands.container:Run
     docker = osism.commands.container:Run
+    log ansible = osism.commands.log:Ansible
+    log container = osism.commands.log:Container
+    log file = osism.commands.log:File
+    manage images = osism.commands.manage:Images
     netbox = osism.commands.netbox:Run
     netbox check = osism.commands.netbox:Check
     netbox connect = osism.commands.netbox:Connect
@@ -58,9 +62,6 @@ osism.commands:
     netbox sync = osism.commands.netbox:Sync
     netbox sync bifrost = osism.commands.netbox:Bifrost
     netbox sync ironic = osism.commands.netbox:Ironic
-    log ansible = osism.commands.log:Ansible
-    log container = osism.commands.log:Container
-    log file = osism.commands.log:File
     reconciler = osism.commands.reconciler:Run
     reconciler sync = osism.commands.reconciler:Sync
     service = osism.commands.service:Run


### PR DESCRIPTION
The managed command is a wrapper command for the openstack-image-manager tool. With osism manage images you can call the openstack-image-manager, installed in the python-osism container image.

Signed-off-by: Christian Berendt <berendt@osism.tech>