### PR TITLE
Rename the cli argument target to host

### DIFF
--- a/osism/commands/compose.py
+++ b/osism/commands/compose.py
@@ -7,7 +7,7 @@ from cliff.command import Command
 class Run(Command):
     def get_parser(self, prog_name):
         parser = super(Run, self).get_parser(prog_name)
-        parser.add_argument("target", nargs=1, type=str, help="Hostname or address")
+        parser.add_argument("host", nargs=1, type=str, help="Hostname or address")
         parser.add_argument("environment", nargs=1, type=str, help="Environment")
         parser.add_argument(
             "arguments",
@@ -17,7 +17,7 @@ class Run(Command):
         return parser
 
     def take_action(self, parsed_args):
-        target_hostname = parsed_args.target[0]
+        host = parsed_args.host[0]
         environment = parsed_args.environment[0]
         arguments = "".join(parsed_args.arguments)
 
@@ -28,6 +28,6 @@ class Run(Command):
 
         # FIXME: use paramiko or something else more Pythonic + make operator user + key configurable
         subprocess.call(
-            f"/usr/bin/ssh -i /ansible/secrets/id_rsa.operator {ssh_options} dragon@{target_hostname} '{ssh_command}'",
+            f"/usr/bin/ssh -i /ansible/secrets/id_rsa.operator {ssh_options} dragon@{host} '{ssh_command}'",
             shell=True,
         )

--- a/osism/commands/console.py
+++ b/osism/commands/console.py
@@ -13,7 +13,7 @@ class Run(Command):
             help="Type of the console (default: %(default)s)",
         )
         parser.add_argument(
-            "target",
+            "host",
             nargs=1,
             type=str,
             help="Hostname or address of the console to connect",
@@ -22,19 +22,19 @@ class Run(Command):
 
     def take_action(self, parsed_args):
         type_console = parsed_args.type
-        target = parsed_args.target[0]
+        host = parsed_args.host[0]
 
         if type_console == "ansible":
-            subprocess.call(f"/run-ansible-console.sh {target}", shell=True)
+            subprocess.call(f"/run-ansible-console.sh {host}", shell=True)
         elif type_console == "ssh":
             # FIXME: use paramiko or something else more Pythonic + make operator user + key configurable
             subprocess.call(
-                f"/usr/bin/ssh -i /ansible/secrets/id_rsa.operator -o StrictHostKeyChecking=no -o LogLevel=ERROR dragon@{target}",
+                f"/usr/bin/ssh -i /ansible/secrets/id_rsa.operator -o StrictHostKeyChecking=no -o LogLevel=ERROR dragon@{host}",
                 shell=True,
             )
         elif type_console == "container":
-            target_containername = target.split("/")[1]
-            target_hostname = target.split("/")[0]
+            target_containername = host.split("/")[1]
+            target_host = host.split("/")[0]
             target_command = "bash"
 
             ssh_command = f"docker exec -it {target_containername} {target_command}"
@@ -44,6 +44,6 @@ class Run(Command):
 
             # FIXME: use paramiko or something else more Pythonic + make operator user + key configurable
             subprocess.call(
-                f"/usr/bin/ssh -i /ansible/secrets/id_rsa.operator {ssh_options} dragon@{target_hostname} {ssh_command}",
+                f"/usr/bin/ssh -i /ansible/secrets/id_rsa.operator {ssh_options} dragon@{target_host} {ssh_command}",
                 shell=True,
             )

--- a/osism/commands/container.py
+++ b/osism/commands/container.py
@@ -7,7 +7,7 @@ from cliff.command import Command
 class Run(Command):
     def get_parser(self, prog_name):
         parser = super(Run, self).get_parser(prog_name)
-        parser.add_argument("target", nargs=1, type=str, help="Hostname or address")
+        parser.add_argument("host", nargs=1, type=str, help="Hostname or address")
         parser.add_argument(
             "command",
             nargs=argparse.REMAINDER,
@@ -17,7 +17,7 @@ class Run(Command):
         return parser
 
     def take_action(self, parsed_args):
-        target_hostname = parsed_args.target[0]
+        host = parsed_args.host[0]
         command = " ".join(parsed_args.command)
 
         ssh_command = f"docker {command}"
@@ -25,6 +25,6 @@ class Run(Command):
 
         # FIXME: use paramiko or something else more Pythonic + make operator user + key configurable
         subprocess.call(
-            f"/usr/bin/ssh -i /ansible/secrets/id_rsa.operator {ssh_options} dragon@{target_hostname} {ssh_command}",
+            f"/usr/bin/ssh -i /ansible/secrets/id_rsa.operator {ssh_options} dragon@{host} {ssh_command}",
             shell=True,
         )

--- a/osism/commands/log.py
+++ b/osism/commands/log.py
@@ -26,7 +26,7 @@ class Ansible(Command):
 class Container(Command):
     def get_parser(self, prog_name):
         parser = super(Container, self).get_parser(prog_name)
-        parser.add_argument("target", nargs=1, type=str, help="Hostname or address")
+        parser.add_argument("host", nargs=1, type=str, help="Hostname or address")
         parser.add_argument(
             "container", nargs=1, type=str, help="Name of the container"
         )
@@ -39,7 +39,7 @@ class Container(Command):
         return parser
 
     def take_action(self, parsed_args):
-        target_hostname = parsed_args.target[0]
+        host = parsed_args.host[0]
         container_name = parsed_args.container[0]
         parameters = " ".join(parsed_args.parameter)
 
@@ -48,7 +48,7 @@ class Container(Command):
 
         # FIXME: use paramiko or something else more Pythonic + make operator user + key configurable
         subprocess.call(
-            f"/usr/bin/ssh -i /ansible/secrets/id_rsa.operator {ssh_options} dragon@{target_hostname} {ssh_command}",
+            f"/usr/bin/ssh -i /ansible/secrets/id_rsa.operator {ssh_options} dragon@{host} {ssh_command}",
             shell=True,
         )
 
@@ -56,7 +56,7 @@ class Container(Command):
 class File(Command):
     def get_parser(self, prog_name):
         parser = super(File, self).get_parser(prog_name)
-        parser.add_argument("target", nargs=1, type=str, help="Hostname or address")
+        parser.add_argument("host", nargs=1, type=str, help="Hostname or address")
         return parser
 
     def take_action(self, parsed_args):


### PR DESCRIPTION
The target of the commands is always a host. Because of that host makes more sense than target as cli argument name.

Signed-off-by: Christian Berendt <berendt@osism.tech>