### PR TITLE
Use /etc/openstack symlink instead of OS_CLIENT_CONFIG_FILE

### DIFF
--- a/Containerfile
+++ b/Containerfile
@@ -40,6 +40,7 @@ RUN apt-get update \
     && mkdir -p /ansible/logs \
     && git clone --depth 1 https://github.com/osism/openstack-image-manager.git /openstack-image-manager \
     && mkdir -p /etc/images \
+    && ln -s /opt/configuration/environments/openstack /etc/openstack \
     && cp /openstack-image-manager/etc/images/* /etc/images \
     && rm -rf /openstack-image-manager \
     && git clone --depth 1 https://github.com/osism/openstack-project-manager.git /openstack-project-manager \

--- a/osism/commands/manage.py
+++ b/osism/commands/manage.py
@@ -57,7 +57,4 @@ class Images(Command):
         subprocess.call(
             f"/usr/local/bin/openstack-image-manager --images=/etc/images {joined_arguments}",
             shell=True,
-            env={
-                "OS_CLIENT_CONFIG_FILE": "/opt/configuration/environments/openstack/clouds.yml"
-            },
         )


### PR DESCRIPTION
An explicit path to a clouds.yml must be set in OS_CLIENT_CONFIG_FILE. This means that no secure.yml can be used. By using /etc/openstack, one of the default locations for the configuration files of the OpenStack SDK, the use of OS_CLIENT_CONFIG_FILE is not necessary. This way there is no limitation that you cannot use the secure.yml.

Signed-off-by: Christian Berendt <berendt@osism.tech>