### PR TITLE
Add kolla ovn role mappings for Zed

### DIFF
--- a/osism/core/enums.py
+++ b/osism/core/enums.py
@@ -305,6 +305,8 @@ MAP_ROLE2ENVIRONMENT = {
     "octavia": "kolla",
     "openvswitch": "kolla",
     "ovn": "kolla",
+    "ovn-controller": "kolla",
+    "ovn-db": "kolla",
     "ovs-dpdk": "kolla",
     "panko": "kolla",
     "placement": "kolla",


### PR DESCRIPTION
For the Zed cycle, kolla split the ovn role into ovn-controller and ovn-db roles, add the needed mappings for them.

Signed-off-by: Dr. Jens Harbott <harbott@osism.tech>