### PR TITLE
Collect facts every 12 hours

### DIFF
--- a/osism/tasks/ansible.py
+++ b/osism/tasks/ansible.py
@@ -8,7 +8,8 @@ app.config_from_object(Config)
 
 @app.on_after_configure.connect
 def setup_periodic_tasks(sender, **kwargs):
-    sender.add_periodic_task(600.0, gather_facts.s(), expires=10)
+    # 43200 seconds = 12 hours
+    sender.add_periodic_task(43200.0, gather_facts.s(), expires=10)
 
 
 @app.task(bind=True, name="osism.tasks.ansible.gather_facts")


### PR DESCRIPTION
So far, the facts have been updated every 10 minutes. This is not necessary. Through the standard use of Redis as a cache backend, the facts are kept 24 hours. It is sufficient to update every 12 hours.

During deployment, the facts are updated as documented, if necessary.

Signed-off-by: Christian Berendt <berendt@osism.tech>