### PR TITLE
Do not run sync_inventory_with_netbox.s every 10 seconds

### DIFF
--- a/osism/tasks/reconciler.py
+++ b/osism/tasks/reconciler.py
@@ -24,7 +24,6 @@ def celery_init_worker(**kwargs):
 @app.on_after_configure.connect
 def setup_periodic_tasks(sender, **kwargs):
     sender.add_periodic_task(600.0, run.s(), expires=10)
-    sender.add_periodic_task(600.0, sync_inventory_with_netbox.s(), expires=10)
 
 
 @app.task(bind=True, name="osism.tasks.reconciler.run")


### PR DESCRIPTION
The script is now always call when running the inventory reconciler script.

Signed-off-by: Christian Berendt <berendt@osism.tech>