### PR TITLE
Environment argument not required with ceph/kolla tasks

### DIFF
--- a/osism/commands/validate.py
+++ b/osism/commands/validate.py
@@ -88,7 +88,6 @@ class Run(Command):
         timeout = parsed_args.timeout
         wait = not parsed_args.no_wait
 
-        environment = VALIDATE_PLAYBOOKS[validator]["environment"]
         runtime = VALIDATE_PLAYBOOKS[validator]["runtime"]
 
         if "playbook" in VALIDATE_PLAYBOOKS[validator]:
@@ -97,10 +96,11 @@ class Run(Command):
             playbook = f"validate-{validator}"
 
         if runtime == "ceph-ansible":
-            t = ceph.run.delay(environment, playbook, arguments)
+            t = ceph.run.delay(playbook, arguments)
         elif runtime == "kolla-ansible":
-            t = kolla.run.delay(environment, playbook, arguments)
+            t = kolla.run.delay(playbook, arguments)
         else:
+            environment = VALIDATE_PLAYBOOKS[validator]["environment"]
             t = ansible.run.delay(environment, playbook, arguments)
 
         rc = self._handle_task(t, wait, format, timeout)

--- a/osism/core/enums.py
+++ b/osism/core/enums.py
@@ -50,9 +50,8 @@ VALIDATE_PLAYBOOKS = {
     # deploys the Ceph configuration itself. So this is rewritten from
     # ceph-config to ceph-validate.
     "ceph-config": {
-        "environment": "ceph",
         "runtime": "ceph-ansible",
-        "playbook": "ceph-validate",
+        "playbook": "validate",
     },
     # NOTE: The playbooks for validating the Ceph deployment are currently
     # in osism/ansible-playbooks. Therefore, they are not executed in


### PR DESCRIPTION
Signed-off-by: Christian Berendt <berendt@osism.tech>