### PR TITLE
Cleanup ansible collections

### DIFF
--- a/Containerfile
+++ b/Containerfile
@@ -22,6 +22,7 @@ FROM python:${PYTHON_VERSION}-slim as osism
 COPY --from=builder /wheels /wheels
 COPY . /src
 COPY files/change.sh /change.sh
+COPY files/cleanup-ansible-collections.sh /cleanup-ansible-collections.sh
 COPY files/run-ansible-console.sh /run-ansible-console.sh
 
 # hadolint ignore=DL3008
@@ -44,7 +45,9 @@ RUN apt-get update \
     && cp /openstack-image-manager/etc/images/* /etc/images \
     && rm -rf /openstack-image-manager \
     && git clone --depth 1 https://github.com/osism/openstack-project-manager.git /openstack-project-manager \
-    && python3 -m pip --no-cache-dir install --no-index --find-links=/wheels -r /openstack-project-manager/requirements.txt
+    && python3 -m pip --no-cache-dir install --no-index --find-links=/wheels -r /openstack-project-manager/requirements.txt \
+    && bash /cleanup-ansible-collections.sh \
+    && rm cleanup-ansible-collections.sh
 
 LABEL "org.opencontainers.image.documentation"="https://docs.osism.tech" \
       "org.opencontainers.image.licenses"="ASL 2.0" \

--- a/files/cleanup-ansible-collections.sh
+++ b/files/cleanup-ansible-collections.sh
@@ -1,0 +1,72 @@
+#!/usr/bin/env bash
+set -x
+
+ANSIBLE_COLLECTIONS_PATH=/usr/local/lib/python3.11/site-packages/ansible_collections
+
+COLLECTIONS=(
+amazon
+arista
+awx
+azure
+check_point
+chocolatey
+cisco
+cloudscale_ch
+cyberark
+dellemc
+f5networks
+fortinet
+gluster
+google
+hetzner
+hpe
+ibm
+infinidat
+infoblox
+inspur
+junipernetworks
+lowlydba
+mellanox
+netapp
+netapp_eseries
+ngine_io
+ovirt
+purestorage
+sensu
+servicenow
+splunk
+t_systems_mms
+theforeman
+vmware
+vultr
+vyos
+wti
+)
+
+COLLECTIONS_COMMUNITY=(
+aws
+azure
+ciscosmb
+digitalocean
+fortios
+google
+hrobot
+mongodb
+okd
+routeros
+sap
+sap_libs
+skydive
+sops
+vmware
+windows
+zabbix
+)
+
+for collection in ${COLLECTIONS[@]}; do
+    rm -rf $ANSIBLE_COLLECTIONS_PATH/$collection
+done
+
+for collection in ${COLLECTIONS_COMMUNITY[@]}; do
+    rm -rf $ANSIBLE_COLLECTIONS_PATH/community/$collection
+done


### PR DESCRIPTION
The ansible package installs a lot of collections that are not really needed in our context. Therefore, these are removed to save storage space.

It currently has to be done with rm -rf as there is no uninstall/remove command in ansible-galaxy.

Closes osism/python-osism#305

Signed-off-by: Christian Berendt <berendt@osism.tech>