### PR TITLE
Use /usr/local/bin/clush instead of /usr/bin/clush

### DIFF
--- a/osism/commands/console.py
+++ b/osism/commands/console.py
@@ -49,7 +49,7 @@ class Run(Command):
             subprocess.call(f"/run-ansible-console.sh {host}", shell=True)
         elif type_console == "clush":
             subprocess.call(
-                f"/usr/bin/clush -l dragon -w {host}",
+                f"/usr/local/bin/clush -l dragon -w {host}",
                 shell=True,
             )
         elif type_console == "ssh":


### PR DESCRIPTION
We now install Clush directly via Pypi and no longer via the package manager.

Signed-off-by: Christian Berendt <berendt@osism.tech>