### PR TITLE
bump fastapi version

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -6,7 +6,7 @@ ara==1.6.1
 celery[redis]==5.2.7
 cliff==4.1.0
 deepdiff==6.2.3
-fastapi==0.91.0
+fastapi==0.92.0
 flower==1.2.0
 hiredis==2.2.2
 kombu==5.2.4


### PR DESCRIPTION
version 0.92.0 includes a security fix.

Signed-off-by: Tim Beermann <beermann@osism.tech>
