### PR TITLE
feat(get.py): add support for limiting selected hosts to an additiona…

### DIFF
--- a/osism/commands/get.py
+++ b/osism/commands/get.py
@@ -219,12 +219,22 @@ class Facts(Command):
 class Hosts(Command):
     def get_parser(self, prog_name):
         parser = super(Hosts, self).get_parser(prog_name)
+        parser.add_argument(
+            "-l",
+            "--limit",
+            type=str,
+            help="Limit selected hosts to an additional pattern",
+        )
         return parser
 
     def take_action(self, parsed_args):
         try:
+            command = ["ansible-inventory -i /ansible/inventory/hosts.yml --list"]
+            if parsed_args.limit:
+                command.append(f"--limit {parsed_args.limit}")
+
             result = subprocess.check_output(
-                "ansible-inventory -i /ansible/inventory/hosts.yml --list",
+                " ".join(command),
                 shell=True,
                 stderr=subprocess.DEVNULL,
             )


### PR DESCRIPTION
…l pattern

The `Hosts` command now accepts an optional `limit` argument, which allows users to specify an additional pattern to limit the selected hosts. This is useful when users want to narrow down the hosts based on specific criteria. The `limit` argument is passed to the `ansible-inventory` command as `--limit` option.