### PR TITLE
Remove openstacksdk package

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -14,7 +14,6 @@ kombu==5.3.1
 loguru==0.7.0
 napalm==4.1.0
 netmiko==4.2.0
-openstacksdk==1.3.1
 pottery==3.0.0
 prompt-toolkit==3.0.39
 pydantic==1.10.12


### PR DESCRIPTION
Will be installed via openstack-image-manager. This way we do not have failed CI jobs when there is a mismatch between the version used in osism/openstack-image-manager and here.