### PR TITLE
Revert "chore(deps): update dependency fastapi to v0.103.1"

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -7,7 +7,7 @@ celery[redis]==5.3.3
 cliff==4.3.0
 deepdiff==6.4.1
 docker==6.1.3
-fastapi==0.103.1
+fastapi==0.103.0
 flower==2.0.1
 hiredis==2.2.3
 kombu==5.3.2


### PR DESCRIPTION
This reverts commit 804925f2df57030226eabe36b016dfb0a1d973fb.