### PR TITLE
Revert "zuul: rebuild container images that are using this repository…

### DIFF
--- a/.zuul.yaml
+++ b/.zuul.yaml
@@ -75,16 +75,6 @@
       jobs:
         - container-image-python-osism-push:
             branches: main
-        - container-image-ceph-ansible-push-quincy:
-            branches: main
-        - container-image-inventory-reconciler-push:
-            branches: main
-        - container-image-kolla-ansible-push-antelope:
-            branches: main
-        - container-image-kolla-ansible-push-zed:
-            branches: main
-        - container-image-osism-ansible-push:
-            branches: main
     tag:
       jobs:
         - container-image-python-osism-push


### PR DESCRIPTION
… (#640)"

This reverts commit 447629d511117ed00bb1c4244911518d4a4b556d.

Reason for revert: Zuul does not allow to include secret-using jobs from other repos.