### PR TITLE
Set broker_connection_retry_on_startup = True

### DIFF
--- a/osism/tasks/__init__.py
+++ b/osism/tasks/__init__.py
@@ -14,6 +14,7 @@ redis = None
 
 
 class Config:
+    broker_connection_retry_on_startup = True
     enable_utc = True
     enable_bifrost = os.environ.get("ENABLE_BIFROST", "False")
     enable_ironic = os.environ.get("ENABLE_IRONIC", "True")


### PR DESCRIPTION
The broker_connection_retry configuration setting will no longer determine whether broker connection retries are made during startup in Celery 6.0 and above. If you wish to retain the existing behavior for retrying connections on startup, you should set broker_connection_retry_on_startup to True.