### PR TITLE
Do not set a timeout of 60 seconds for custom plays

### DIFF
--- a/osism/commands/apply.py
+++ b/osism/commands/apply.py
@@ -191,16 +191,7 @@ class Run(Command):
                 environment = overwrite
 
             if environment in ["custom"] or role not in MAP_ROLE2ENVIRONMENT:
-                task_timeout = 60
-                timeout = 60
-
-                logger.info(
-                    "An attempt is made to execute a role that is provided in the "
-                    "configuration repository. If there is no further output "
-                    f"following this output, the role {role} in the environment "
-                    f"{environment} was not found. The timeout is explicitly "
-                    f"set to {timeout} seconds."
-                )
+                logger.info(f"Trying to run play {role} in environment {environment}")
 
             t = ansible.run.delay(
                 environment, role, arguments, auto_release_time=task_timeout

--- a/releasenotes/notes/custom-plays-timeout-9fd5f0452a11aae5.yaml
+++ b/releasenotes/notes/custom-plays-timeout-9fd5f0452a11aae5.yaml
@@ -1,4 +1,0 @@
----
-features:
-  - |
-    Timeout on custom plays explicitly set to 60 seconds.


### PR DESCRIPTION
This was only a workaround because missing plays were not recognized correctly. This has now been resolved.