### PR TITLE
Remove release notes

### DIFF
--- a/releasenotes/notes/OSISM_APPLY_RETRY-997fffd5d3cd844e.yaml
+++ b/releasenotes/notes/OSISM_APPLY_RETRY-997fffd5d3cd844e.yaml
@@ -1,5 +1,0 @@
----
-features:
-  - |
-    It is possible to set the number of retries of the apply command
-    via the environment variable `OSISM_APPLY_RETRY`.

--- a/releasenotes/notes/apply-retry-5faa8a2d82d21d0a.yaml
+++ b/releasenotes/notes/apply-retry-5faa8a2d82d21d0a.yaml
@@ -1,7 +1,0 @@
----
-features:
-  - |
-    Sometimes it is sufficient to run a play again if it could not be
-    completed successfully on the first run. The `--retry` argument for
-    the `apply` command can be used to specify the number of retries to
-    be attempted.

--- a/releasenotes/notes/command-set-noset-6c803c26c0ed5666.yaml
+++ b/releasenotes/notes/command-set-noset-6c803c26c0ed5666.yaml
@@ -1,5 +1,0 @@
----
-features:
-  - |
-    With the new commands set/noset it is possible to set certain properties of nodes.
-    First of all, it will be possible to put a node into maintenance.

--- a/releasenotes/notes/command-set-noset-boostrap-8ae8277a4ce31186.yaml
+++ b/releasenotes/notes/command-set-noset-boostrap-8ae8277a4ce31186.yaml
@@ -1,5 +1,0 @@
----
-features:
-  - |
-    With the new commands set/noset bootstrap it is possible to set if
-    a node is bootstrapped or not.

--- a/releasenotes/notes/configuration-sync-command-eba1d53513154e54.yaml
+++ b/releasenotes/notes/configuration-sync-command-eba1d53513154e54.yaml
@@ -1,5 +1,0 @@
----
-features:
-  - |
-    With `configuration sync` it is possible to sync the configuration repository.
-    This is an alias for the command `apply configuration`.

--- a/releasenotes/notes/do-not-write-states-of-all-roles-0c68ba11a9d2f387.yaml
+++ b/releasenotes/notes/do-not-write-states-of-all-roles-0c68ba11a9d2f387.yaml
@@ -1,8 +1,0 @@
----
-other:
-  - |
-    After each execution, the status of a role is currently saved as a
-    local fact on the systems. In future, this will be stored in a central
-    location and not as a local fact. Since the feature itself is not used
-    anywhere and was only prepared, it is now removed to save resources
-    during execution.

--- a/releasenotes/notes/get-status-command-747d6885fd157a86.yaml
+++ b/releasenotes/notes/get-status-command-747d6885fd157a86.yaml
@@ -1,4 +1,0 @@
----
-features:
-  - |
-    The `status` command is now available as `get status`.

--- a/releasenotes/notes/merge-stdout-and-stderr-49cc1ea54d16fa4b.yaml
+++ b/releasenotes/notes/merge-stdout-and-stderr-49cc1ea54d16fa4b.yaml
@@ -1,5 +1,0 @@
----
-features:
-  - |
-    STDERR of Ansible runs is now merged with STDOUT. This way the STDERR of Ansible runs
-    is also visible in the STDOUT of the OSISM CLI.

--- a/releasenotes/notes/netbox-ansible-output-cfd92b84505fbf5d.yaml
+++ b/releasenotes/notes/netbox-ansible-output-cfd92b84505fbf5d.yaml
@@ -1,4 +1,0 @@
----
-features:
-  - |
-    The output of the Ansible playbooks for `netbox manage` and `netbox init` is now visible.

--- a/releasenotes/notes/new-vault-password-commands-48db1885ef2519f1.yaml
+++ b/releasenotes/notes/new-vault-password-commands-48db1885ef2519f1.yaml
@@ -1,8 +1,0 @@
----
-features:
-  - |
-    Add noset/set commands for `vault password`.
-deprecations:
-  - |
-    The old `vault password set` and `vault password noset`
-    commands will be removed in the future.

--- a/releasenotes/notes/number-of-workers-f55a3422c0b976cc.yaml
+++ b/releasenotes/notes/number-of-workers-f55a3422c0b976cc.yaml
@@ -1,7 +1,0 @@
----
-features:
-  - |
-    With the new parameter `--number-of-workers` for the worker command, it
-    is now possible to increase the number of workers that can be used
-    simultaneously. The value is set to the number of usable CPUs by default.
-    If the number of usable CPUs is higher than 8, the default value is 8.

--- a/releasenotes/notes/opensearch-protocol-c222c86a24ac594c.yaml
+++ b/releasenotes/notes/opensearch-protocol-c222c86a24ac594c.yaml
@@ -1,6 +1,0 @@
----
-features:
-  - |
-    With the `OPENSEARCH_PROTOCOL` environment variable it is now possible
-    to configure the protocol (`http` or `https`) that should be used by
-    `osism log opensearch`.

--- a/releasenotes/notes/reconciler-logs-a1e260ae5d637709.yaml
+++ b/releasenotes/notes/reconciler-logs-a1e260ae5d637709.yaml
@@ -1,5 +1,0 @@
----
-features:
-  - |
-    Logs from the reconciler are now returned. This makes it easier
-    to identify errors in the inventory from a configuration repository.

--- a/releasenotes/notes/reconciler-on-change-92c9127be6b4dfb1.yaml
+++ b/releasenotes/notes/reconciler-on-change-92c9127be6b4dfb1.yaml
@@ -1,5 +1,0 @@
----
-features:
-  - |
-    When periodically running the reconciler, it now checks for changes in
-    advance and only does a reconcilation if there were changes in /opt/configuration.

--- a/releasenotes/notes/redis-ping-41b24ebd67461cd9.yaml
+++ b/releasenotes/notes/redis-ping-41b24ebd67461cd9.yaml
@@ -1,5 +1,0 @@
----
-features:
-  - |
-    After establishing a connection to Redis, send a ping to ensure that the
-    connection is functional.

--- a/releasenotes/notes/redis-streams-2c1ece0ebfaed996.yaml
+++ b/releasenotes/notes/redis-streams-2c1ece0ebfaed996.yaml
@@ -1,6 +1,0 @@
----
-features:
-  - |
-    The transfer of console outputs was changed from Redis PubSub to Redis Streams.
-    This means that no more console outputs will be lost in the future. Furthermore,
-    it is possible to transmit STDOUT and STDERR separately in the future.

--- a/releasenotes/notes/task-timeout-parameter-for-apply-command-3acc410ecafc3965.yaml
+++ b/releasenotes/notes/task-timeout-parameter-for-apply-command-3acc410ecafc3965.yaml
@@ -1,7 +1,0 @@
----
-features:
-  - |
-    Until now it was not possible to configure the timeout of tasks that are not yet executed.
-    It was set to 3600 seconds (1h) by default. With the new parameter `--task-timeout` for
-    the `apply` command it is now possible to adjust this timeout as desired. The default of
-    3600 seconds remains.

--- a/releasenotes/notes/vault-view-command-09887cfd02679002.yaml
+++ b/releasenotes/notes/vault-view-command-09887cfd02679002.yaml
@@ -1,7 +1,0 @@
----
-features:
-  - |
-    With `vault view` it is possible to view an encrypted file
-    inside the configuration repository. It is possible to use
-    absolute (`/opt/configuration/environments/..`) and relative
-    (`environments/..`) paths.

--- a/releasenotes/notes/workaround-celery-kombu-gh1804-e0f1b3d38691d561.yaml
+++ b/releasenotes/notes/workaround-celery-kombu-gh1804-e0f1b3d38691d561.yaml
@@ -1,6 +1,0 @@
----
-fixes:
-  - |
-    Add workaround for https://github.com/celery/kombu/issues/1804 to solve the
-    `after fork raised exception: AttributeError("'cached_property' object has no attribute 'lock'")`
-    issue for services already using Python 3.12.


### PR DESCRIPTION
We manage the release notes again in the central osism/release and osism/osism.github.io repository.