### PR TITLE
Ignore all Python UserWarnings

### DIFF
--- a/Containerfile
+++ b/Containerfile
@@ -37,6 +37,8 @@ EOF
 
 FROM python:${PYTHON_VERSION}-slim AS osism
 
+ENV PYTHONWARNINGS="ignore::UserWarning"
+
 COPY --from=builder /wheels /wheels
 
 COPY . /src


### PR DESCRIPTION
It looks like this is the only way to get rid of the CryptographyDeprecationWarning warnings.