### PR TITLE
Improve management of CAPI images

### DIFF
--- a/osism/commands/manage.py
+++ b/osism/commands/manage.py
@@ -27,7 +27,7 @@ class ImageClusterapi(Command):
             default="https://swift.services.a.regiocloud.tech/swift/v1/AUTH_b182637428444b9aa302bb8d5a5a418c/openstack-k8s-capi-images/",
         )
         parser.add_argument(
-            "--cloud", type=str, help="Cloud name in clouds.yaml", default="openstack"
+            "--cloud", type=str, help="Cloud name in clouds.yaml (will be overruled by OS_AUTH_URL envvar)", default="admin"
         )
         parser.add_argument(
             "--filter",
@@ -82,7 +82,7 @@ class ImageClusterapi(Command):
             "openstack-image-manager",
             "--images=/tmp/clusterapi",
             "--cloud",
-            "admin",
+            cloud,
             "--filter",
             "Kubernetes CAPI",
         ]

--- a/osism/commands/manage.py
+++ b/osism/commands/manage.py
@@ -78,10 +78,15 @@ class ImageClusterapi(Command):
             with open(f"/tmp/clusterapi/k8s-{kubernetes_release}.yml", "w+") as fp:
                 fp.write(result)
 
-        subprocess.call(
-            "/usr/local/bin/openstack-image-manager --images=/tmp/clusterapi --cloud admin --filter 'Kubernetes CAPI'",
-            shell=True,
-        )
+        args = [
+            "openstack-image-manager",
+            "--images=/tmp/clusterapi",
+            "--cloud",
+            "admin",
+            "--filter",
+            "Kubernetes CAPI",
+        ]
+        subprocess.call(args)
 
 
 class ImageOctavia(Command):

--- a/osism/commands/manage.py
+++ b/osism/commands/manage.py
@@ -96,7 +96,7 @@ class ImageClusterapi(Command):
             "--cloud",
             cloud,
             "--filter",
-            "Kubernetes CAPI",
+            "ubuntu-capi-image",
         ]
         if tag is not None:
             args.extend(["--tag", tag])

--- a/osism/commands/manage.py
+++ b/osism/commands/manage.py
@@ -35,6 +35,12 @@ class ImageClusterapi(Command):
             help="Do not perform any changes (--dry-run passed to openstack-image-manager)",
         )
         parser.add_argument(
+            "--tag",
+            type=str,
+            help="Name of the tag used to identify managed images (use openstack-image-manager's default if unset)",
+            default=None,
+        )
+        parser.add_argument(
             "--filter",
             type=str,
             help="Filter the version to be managed (e.g. 1.28)",
@@ -46,6 +52,7 @@ class ImageClusterapi(Command):
         base_url = parsed_args.base_url
         cloud = parsed_args.cloud
         filter = parsed_args.filter
+        tag = parsed_args.tag
 
         if filter:
             supported_cluterapi_k8s_images = [filter]
@@ -91,6 +98,8 @@ class ImageClusterapi(Command):
             "--filter",
             "Kubernetes CAPI",
         ]
+        if tag is not None:
+            args.extend(["--tag", tag])
         if parsed_args.dry_run:
             args.append("--dry-run")
         subprocess.call(args)

--- a/osism/commands/manage.py
+++ b/osism/commands/manage.py
@@ -27,7 +27,10 @@ class ImageClusterapi(Command):
             default="https://swift.services.a.regiocloud.tech/swift/v1/AUTH_b182637428444b9aa302bb8d5a5a418c/openstack-k8s-capi-images/",
         )
         parser.add_argument(
-            "--cloud", type=str, help="Cloud name in clouds.yaml (will be overruled by OS_AUTH_URL envvar)", default="admin"
+            "--cloud",
+            type=str,
+            help="Cloud name in clouds.yaml (will be overruled by OS_AUTH_URL envvar)",
+            default="admin",
         )
         parser.add_argument(
             "--dry-run",

--- a/osism/commands/manage.py
+++ b/osism/commands/manage.py
@@ -30,6 +30,11 @@ class ImageClusterapi(Command):
             "--cloud", type=str, help="Cloud name in clouds.yaml (will be overruled by OS_AUTH_URL envvar)", default="admin"
         )
         parser.add_argument(
+            "--dry-run",
+            action="store_true",
+            help="Do not perform any changes (--dry-run passed to openstack-image-manager)",
+        )
+        parser.add_argument(
             "--filter",
             type=str,
             help="Filter the version to be managed (e.g. 1.28)",
@@ -86,6 +91,8 @@ class ImageClusterapi(Command):
             "--filter",
             "Kubernetes CAPI",
         ]
+        if parsed_args.dry_run:
+            args.append("--dry-run")
         subprocess.call(args)
 
 

--- a/osism/data/__init__.py
+++ b/osism/data/__init__.py
@@ -55,7 +55,7 @@ images:
       provided_until: none
     tags: []
     versions:
-      - version: "{{ image_version }}"
+      - version: "v{{ image_version }}"
         url: "{{ image_url }}"
         checksum: "{{ image_checksum }}"
         build_date: {{ image_builddate }}

--- a/osism/data/__init__.py
+++ b/osism/data/__init__.py
@@ -44,7 +44,7 @@ images:
     multi: false
     meta:
       architecture: x86_64
-      hw_disk_bus: virtio
+      hw_disk_bus: scsi
       hw_rng_model: virtio
       hw_scsi_model: virtio-scsi
       hw_watchdog_action: reset

--- a/osism/data/__init__.py
+++ b/osism/data/__init__.py
@@ -32,7 +32,7 @@ images:
 
 TEMPLATE_IMAGE_CLUSTERAPI = """---
 images:
-  - name: Kubernetes CAPI
+  - name: ubuntu-capi-image
     enable: true
     keep: true
     format: qcow2

--- a/osism/data/__init__.py
+++ b/osism/data/__init__.py
@@ -48,6 +48,7 @@ images:
       hw_rng_model: virtio
       hw_scsi_model: virtio-scsi
       hw_watchdog_action: reset
+      hypervisor_type: qemu
       os_distro: ubuntu
       replace_frequency: never
       uuid_validity: none


### PR DESCRIPTION
Hi, as part of https://github.com/SovereignCloudStack/standards/pull/643, I want to make it as easy as possible to get the latest CAPI images in an SCS compliant way and found `osism manage image clusterapi` to be the best way to do it, with the following adjustments.

(Potentially) breaking changes:

* Changed the absolute invocation of `openstack-image-manager`, to make it work if installed in other places. So now it depends on `PATH`. I *think* this shouldn't hurt. (Actually, it will even improve things in case someone installs stuff into a virtualenv, for example.)
* Changed image name `Kubernetes CAPI` to `ubuntu-capi-image` as recommended by SCS.

Otherwise it just fixes bugs (hard-coded `--cloud`) and adds new features (`--dry-run`, `--tag`) in a backwards compatible way.

Resulting help output:

```
$ osism manage image clusterapi --help                                      
[... some unrelated TripleDES deprecation warnings ...]
usage: osism manage image clusterapi [-h] [--base-url BASE_URL] [--cloud CLOUD] [--dry-run] [--tag TAG] [--filter FILTER]

options:
  -h, --help            show this help message and exit
  --base-url BASE_URL
                        Base URL
  --cloud CLOUD
                        Cloud name in clouds.yaml (will be overruled by OS_AUTH_URL envvar)
  --dry-run             Do not perform any changes (--dry-run passed to openstack-image-manager)
  --tag TAG     Name of the tag used to identify managed images (use openstack-image-manager's default if unset)
  --filter FILTER
                        Filter the version to be managed (e.g. 1.28)
```

Example invocation:

```
$ osism manage image clusterapi --dry-run --cloud l1a --tag 'managed_by_C&H'
[... some unrelated TripleDES deprecation warnings ...]
2024-08-07 12:34:06 | INFO     | date: 2024-07-18
2024-08-07 12:34:06 | INFO     | image: ubuntu-2204-kube-v1.28/ubuntu-2204-kube-v1.28.12.qcow2
2024-08-07 12:34:06 | INFO     | version: 1.28.12
2024-08-07 12:34:06 | INFO     | url: https://swift.services.a.regiocloud.tech/swift/v1/AUTH_b182637428444b9aa302bb8d5a5a418c/openstack-k8s-capi-images/ubuntu-2204-kube-v1.28/ubuntu-2204-kube-v1.28.12.qcow2
2024-08-07 12:34:06 | INFO     | checksum_url: https://swift.services.a.regiocloud.tech/swift/v1/AUTH_b182637428444b9aa302bb8d5a5a418c/openstack-k8s-capi-images/ubuntu-2204-kube-v1.28/ubuntu-2204-kube-v1.28.12.qcow2.CHECKSUM
2024-08-07 12:34:06 | INFO     | checksum: 45c75763bdb53c17d3482abd6d0a55b2429efd7df7927fd2a1d68c4cf859b146
2024-08-07 12:34:06 | INFO     | date: 2024-07-18
2024-08-07 12:34:06 | INFO     | image: ubuntu-2204-kube-v1.29/ubuntu-2204-kube-v1.29.7.qcow2
2024-08-07 12:34:06 | INFO     | version: 1.29.7
2024-08-07 12:34:06 | INFO     | url: https://swift.services.a.regiocloud.tech/swift/v1/AUTH_b182637428444b9aa302bb8d5a5a418c/openstack-k8s-capi-images/ubuntu-2204-kube-v1.29/ubuntu-2204-kube-v1.29.7.qcow2
2024-08-07 12:34:06 | INFO     | checksum_url: https://swift.services.a.regiocloud.tech/swift/v1/AUTH_b182637428444b9aa302bb8d5a5a418c/openstack-k8s-capi-images/ubuntu-2204-kube-v1.29/ubuntu-2204-kube-v1.29.7.qcow2.CHECKSUM
2024-08-07 12:34:07 | INFO     | checksum: 35d3f1e124c0a3f428487d2266923bbed066f87da78ad45245075cb00cfbd33f
2024-08-07 12:34:07 | INFO     | date: 2024-07-18
2024-08-07 12:34:07 | INFO     | image: ubuntu-2204-kube-v1.30/ubuntu-2204-kube-v1.30.3.qcow2
2024-08-07 12:34:07 | INFO     | version: 1.30.3
2024-08-07 12:34:07 | INFO     | url: https://swift.services.a.regiocloud.tech/swift/v1/AUTH_b182637428444b9aa302bb8d5a5a418c/openstack-k8s-capi-images/ubuntu-2204-kube-v1.30/ubuntu-2204-kube-v1.30.3.qcow2
2024-08-07 12:34:07 | INFO     | checksum_url: https://swift.services.a.regiocloud.tech/swift/v1/AUTH_b182637428444b9aa302bb8d5a5a418c/openstack-k8s-capi-images/ubuntu-2204-kube-v1.30/ubuntu-2204-kube-v1.30.3.qcow2.CHECKSUM
2024-08-07 12:34:07 | INFO     | checksum: c248a2def6110e65dd93c7fb8fd3d9d51904efce7aa54f0581200339ef849386
2024-08-07 12:34:09 | INFO     | Processing image 'ubuntu-capi-image 1.30.3'
2024-08-07 12:34:09 | INFO     | Tested URL https://swift.services.a.regiocloud.tech/swift/v1/AUTH_b182637428444b9aa302bb8d5a5a418c/openstack-k8s-capi-images/ubuntu-2204-kube-v1.30/ubuntu-2204-kube-v1.30.3.qcow2: 200
2024-08-07 12:34:09 | INFO     | Skipping required import of image 'ubuntu-capi-image 1.30.3', running in dry-run mode
2024-08-07 12:34:09 | INFO     | Processing image 'ubuntu-capi-image 1.29.7'
2024-08-07 12:34:09 | INFO     | Tested URL https://swift.services.a.regiocloud.tech/swift/v1/AUTH_b182637428444b9aa302bb8d5a5a418c/openstack-k8s-capi-images/ubuntu-2204-kube-v1.29/ubuntu-2204-kube-v1.29.7.qcow2: 200
2024-08-07 12:34:09 | INFO     | Skipping required import of image 'ubuntu-capi-image 1.29.7', running in dry-run mode
2024-08-07 12:34:09 | INFO     | Processing image 'ubuntu-capi-image 1.28.12'
2024-08-07 12:34:10 | INFO     | Tested URL https://swift.services.a.regiocloud.tech/swift/v1/AUTH_b182637428444b9aa302bb8d5a5a418c/openstack-k8s-capi-images/ubuntu-2204-kube-v1.28/ubuntu-2204-kube-v1.28.12.qcow2: 200
2024-08-07 12:34:10 | INFO     | Skipping required import of image 'ubuntu-capi-image 1.28.12', running in dry-run mode
```