### PR TITLE
Remove k8s capi image 1.28

### DIFF
--- a/osism/commands/manage.py
+++ b/osism/commands/manage.py
@@ -13,7 +13,7 @@ import requests
 
 from osism.data import TEMPLATE_IMAGE_CLUSTERAPI, TEMPLATE_IMAGE_OCTAVIA
 
-SUPPORTED_CLUSTERAPI_K8S_IMAGES = ["1.28", "1.29", "1.30", "1.31"]
+SUPPORTED_CLUSTERAPI_K8S_IMAGES = ["1.29", "1.30", "1.31"]
 
 
 class ImageClusterapi(Command):
@@ -46,7 +46,7 @@ class ImageClusterapi(Command):
         parser.add_argument(
             "--filter",
             type=str,
-            help="Filter the version to be managed (e.g. 1.28)",
+            help="Filter the version to be managed (e.g. 1.31)",
             default=None,
         )
         return parser


### PR DESCRIPTION
Kubernetes 1.28 is end of life.