### PR TITLE
Remove the netbox device type library

### DIFF
--- a/Containerfile
+++ b/Containerfile
@@ -143,9 +143,6 @@ apt-get install -y --no-install-recommends \
   tini
 
 mkdir -p /import
-git clone --depth 1 https://github.com/netbox-community/devicetype-library /devicetype-library
-rm -rf /devicetype-library/.git
-rm -rf /devicetype-library/elevation-images
 
 apt-get clean
 rm -rf \


### PR DESCRIPTION
In the future we'll only support device types provided in the configuration repository or in the netbox configuration repository.