### PR TITLE
Revert "Temp workaround for celery/kombu#1804 issue (#652)"

### DIFF
--- a/osism/tasks/ansible.py
+++ b/osism/tasks/ansible.py
@@ -1,24 +1,9 @@
 # SPDX-License-Identifier: Apache-2.0
 
-import functools
-from threading import RLock
-
 from celery import Celery
-import kombu.utils
 
 from osism import settings
 from osism.tasks import Config, run_ansible_in_environment
-
-# https://github.com/celery/kombu/issues/1804
-if not getattr(kombu.utils.cached_property, "lock", None):
-    setattr(
-        kombu.utils.cached_property,
-        "lock",
-        functools.cached_property(lambda _: RLock()),
-    )
-    # Must call __set_name__ here since this cached property is not defined in the context of a class
-    # Refer to https://docs.python.org/3/reference/datamodel.html#object.__set_name__
-    kombu.utils.cached_property.lock.__set_name__(kombu.utils.cached_property, "lock")
 
 app = Celery("ansible")
 app.config_from_object(Config)

--- a/osism/tasks/openstack.py
+++ b/osism/tasks/openstack.py
@@ -1,15 +1,12 @@
 # SPDX-License-Identifier: Apache-2.0
 
-import functools
 import copy
 import ipaddress
-from threading import RLock
 
 from celery import Celery
 from celery.signals import worker_process_init
 import jinja2
 import keystoneauth1
-import kombu.utils
 import openstack
 from pottery import Redlock
 from redis import Redis
@@ -18,17 +15,6 @@ import tempfile
 from osism import settings
 from osism.tasks import Config, conductor, netbox, run_command
 from osism import utils
-
-# https://github.com/celery/kombu/issues/1804
-if not getattr(kombu.utils.cached_property, "lock", None):
-    setattr(
-        kombu.utils.cached_property,
-        "lock",
-        functools.cached_property(lambda _: RLock()),
-    )
-    # Must call __set_name__ here since this cached property is not defined in the context of a class
-    # Refer to https://docs.python.org/3/reference/datamodel.html#object.__set_name__
-    kombu.utils.cached_property.lock.__set_name__(kombu.utils.cached_property, "lock")
 
 app = Celery("openstack")
 app.config_from_object(Config)

--- a/osism/tasks/reconciler.py
+++ b/osism/tasks/reconciler.py
@@ -1,31 +1,15 @@
 # SPDX-License-Identifier: Apache-2.0
 
-import functools
 import io
 import subprocess
-from threading import RLock
 
 from celery import Celery
 from celery.signals import worker_process_init
-import kombu.utils
 from loguru import logger
 from pottery import Redlock
 from redis import Redis
-
 from osism import settings
 from osism.tasks import Config
-
-
-# https://github.com/celery/kombu/issues/1804
-if not getattr(kombu.utils.cached_property, "lock", None):
-    setattr(
-        kombu.utils.cached_property,
-        "lock",
-        functools.cached_property(lambda _: RLock()),
-    )
-    # Must call __set_name__ here since this cached property is not defined in the context of a class
-    # Refer to https://docs.python.org/3/reference/datamodel.html#object.__set_name__
-    kombu.utils.cached_property.lock.__set_name__(kombu.utils.cached_property, "lock")
 
 app = Celery("reconciler")
 app.config_from_object(Config)


### PR DESCRIPTION
This reverts commit f77a2bec9f297b39502a2f03aed5038cb9b9da41.

The fix for the underlying issue is part of kombu version 5.5, which is currently used ([1]).

[1]
https://github.com/celery/kombu/commit/3ad075a536d177170a7a5d7b04d81e94bd5bf404