### PR TITLE
Fix netbox ironic sync

### DIFF
--- a/osism/tasks/conductor.py
+++ b/osism/tasks/conductor.py
@@ -147,7 +147,7 @@ def sync_netbox_with_ironic(self, force_update=False):
             if (
                 not node["Instance UUID"]
                 and node["Provisioning State"] in ["enroll", "manageable", "available"]
-                and node["Power State"] == "power off"
+                and node["Power State"] in ["power off", None]
             ):
                 logger.info(
                     f"Cleaning up baremetal node not found in netbox: {node['Name']}"


### PR DESCRIPTION
Allow power state to be None during removal of nodes from ironic. If the node has not been properly configured yet its power state cannot be determined.