### PR TITLE
Remove `redfish_port` from netbox/ironic sync

### DIFF
--- a/osism/tasks/conductor.py
+++ b/osism/tasks/conductor.py
@@ -131,7 +131,6 @@ def sync_netbox_with_ironic(self, force_update=False):
         },
         "redfish": {
             "address": "redfish_address",
-            "port": "redfish_port",
             "password": "redfish_password",
         },
     }
@@ -210,7 +209,11 @@ def sync_netbox_with_ironic(self, force_update=False):
                     else:
                         logger.error(f"Could not find out-of-band address for {device}")
                         node_attributes["driver_info"].pop(address_key, None)
-                if "oob_port" in device.custom_fields:
+                if (
+                    "port" in driver_params[node_attributes["driver"]]
+                    and "oob_port" in device.custom_fields
+                    and device.custom_fields["oob_port"]
+                ):
                     port_key = driver_params[node_attributes["driver"]]["port"]
                     node_attributes["driver_info"].update(
                         {port_key: device.custom_fields["oob_port"]}


### PR DESCRIPTION
The redfish driver does not have an attribute `redfish_port` and is therefore removed.