### PR TITLE
Do not reinitialize netbox API

### DIFF
--- a/osism/api.py
+++ b/osism/api.py
@@ -7,11 +7,10 @@ from uuid import UUID
 
 from fastapi import FastAPI, Header, Request, Response
 from pydantic import BaseModel
-import pynetbox
 from starlette.middleware.cors import CORSMiddleware
 
 from osism.tasks import reconciler
-from osism import settings, utils
+from osism import utils
 from osism.services.listener import BaremetalEvents
 
 
@@ -76,20 +75,6 @@ dictConfig(LogConfig().dict())
 logger = logging.getLogger("api")
 
 baremetal_events = BaremetalEvents()
-
-
-@app.on_event("startup")
-async def startup_event():
-    if settings.NETBOX_URL and settings.NETBOX_TOKEN:
-        utils.nb = pynetbox.api(settings.NETBOX_URL, token=settings.NETBOX_TOKEN)
-
-        if settings.IGNORE_SSL_ERRORS:
-            import requests
-
-            requests.packages.urllib3.disable_warnings()
-            session = requests.Session()
-            session.verify = False
-            utils.nb.http_session = session
 
 
 @app.get("/")

--- a/osism/tasks/netbox.py
+++ b/osism/tasks/netbox.py
@@ -1,30 +1,14 @@
 # SPDX-License-Identifier: Apache-2.0
 
 from celery import Celery
-from celery.signals import worker_process_init
 from loguru import logger
 from pottery import Redlock
-import pynetbox
 
 from osism import settings, utils
 from osism.tasks import Config, run_command
 
 app = Celery("netbox")
 app.config_from_object(Config)
-
-
-@worker_process_init.connect
-def celery_init_worker(**kwargs):
-    if settings.NETBOX_URL and settings.NETBOX_TOKEN:
-        utils.nb = pynetbox.api(settings.NETBOX_URL, token=settings.NETBOX_TOKEN)
-
-        if settings.IGNORE_SSL_ERRORS:
-            import requests
-
-            requests.packages.urllib3.disable_warnings()
-            session = requests.Session()
-            session.verify = False
-            utils.nb.http_session = session
 
 
 @app.on_after_configure.connect


### PR DESCRIPTION
Do not reinitialize the netbox api object in `api` and `netbox` task. It is already initialized in `utils`