### PR TITLE
Cleanup ansible requirements

### DIFF
--- a/requirements.yml
+++ b/requirements.yml
@@ -1,34 +1,10 @@
 ---
 collections:
-  - name: ansible.netcommon
-    version: 8.0.0
   - name: ansible.posix
     version: 2.0.0
   - name: ansible.utils
     version: 6.0.0
-  - name: cloud.common
-    version: 4.1.0
-  - name: community.crypto
-    version: 2.26.2
   - name: community.docker
     version: 4.6.0
-  - name: community.general
-    version: 10.7.0
-  - name: community.grafana
-    version: 2.2.0
-  - name: community.hashi_vault
-    version: 6.2.0
-  - name: community.mysql
-    version: 3.14.0
-  - name: community.network
-    version: 5.1.0
-  - name: community.rabbitmq
-    version: 1.4.0
-  - name: containers.podman
-    version: 1.16.3
-  - name: kubernetes.core
-    version: 5.3.0
   - name: netbox.netbox
     version: 3.21.0
-  - name: openstack.cloud
-    version: 2.4.1


### PR DESCRIPTION
The ansible collections are only required by the integrated netbox-manager and the osism console --type ansible command. For netbox-manager we only need the netbox collection. For the osism console --type ansible command it's sufficient to provide basic Ansible modules. Everything more complex should be handled in custom plays (custom plays are executed in the osism-ansible environment).