### PR TITLE
refactor: use positional argument for baremetal node names

### DIFF
--- a/osism/commands/baremetal.py
+++ b/osism/commands/baremetal.py
@@ -70,18 +70,17 @@ class BaremetalDeploy(Command):
     def get_parser(self, prog_name):
         parser = super(BaremetalDeploy, self).get_parser(prog_name)
 
-        parser_exc_group = parser.add_mutually_exclusive_group(required=True)
-        parser_exc_group.add_argument(
+        parser.add_argument(
+            "name",
+            nargs="?",
+            type=str,
+            help="Deploy given baremetal node when in provision state available",
+        )
+        parser.add_argument(
             "--all",
             default=False,
             help="Deploy all baremetal nodes in provision state available",
             action="store_true",
-        )
-        parser_exc_group.add_argument(
-            "--name",
-            default=[],
-            help="Deploy given baremetal node when in provision state available. May be specified multiple times",
-            action="append",
         )
         parser.add_argument(
             "--rebuild",
@@ -99,9 +98,13 @@ class BaremetalDeploy(Command):
 
     def take_action(self, parsed_args):
         all_nodes = parsed_args.all
-        names = parsed_args.name
+        name = parsed_args.name
         rebuild = parsed_args.rebuild
         yes_i_really_really_mean_it = parsed_args.yes_i_really_really_mean_it
+
+        if not all_nodes and not name:
+            logger.error("Please specify a node name or use --all")
+            return
 
         if all_nodes and rebuild and not yes_i_really_really_mean_it:
             logger.error(
@@ -114,14 +117,14 @@ class BaremetalDeploy(Command):
         if all_nodes:
             deploy_nodes = list(conn.baremetal.nodes(details=True))
         else:
-            deploy_nodes = [
-                conn.baremetal.find_node(name, ignore_missing=True, details=True)
-                for name in names
-            ]
-
-        for node_idx, node in enumerate(deploy_nodes):
+            node = conn.baremetal.find_node(name, ignore_missing=True, details=True)
             if not node:
-                logger.warning(f"Could not find node {names[node_idx]}")
+                logger.warning(f"Could not find node {name}")
+                return
+            deploy_nodes = [node]
+
+        for node in deploy_nodes:
+            if not node:
                 continue
 
             if node.provision_state in ["available", "deploy failed"]:
@@ -176,18 +179,17 @@ class BaremetalUndeploy(Command):
     def get_parser(self, prog_name):
         parser = super(BaremetalUndeploy, self).get_parser(prog_name)
 
-        parser_exc_group = parser.add_mutually_exclusive_group(required=True)
-        parser_exc_group.add_argument(
+        parser.add_argument(
+            "name",
+            nargs="?",
+            type=str,
+            help="Undeploy given baremetal node",
+        )
+        parser.add_argument(
             "--all",
             default=False,
             help="Undeploy all baremetal nodes",
             action="store_true",
-        )
-        parser_exc_group.add_argument(
-            "--name",
-            default=[],
-            help="Undeploy given baremetal node. May be specified multiple times",
-            action="append",
         )
         parser.add_argument(
             "--yes-i-really-really-mean-it",
@@ -199,8 +201,12 @@ class BaremetalUndeploy(Command):
 
     def take_action(self, parsed_args):
         all_nodes = parsed_args.all
-        names = parsed_args.name
+        name = parsed_args.name
         yes_i_really_really_mean_it = parsed_args.yes_i_really_really_mean_it
+
+        if not all_nodes and not name:
+            logger.error("Please specify a node name or use --all")
+            return
 
         if all_nodes and not yes_i_really_really_mean_it:
             logger.error(
@@ -213,14 +219,14 @@ class BaremetalUndeploy(Command):
         if all_nodes:
             deploy_nodes = list(conn.baremetal.nodes())
         else:
-            deploy_nodes = [
-                conn.baremetal.find_node(name, ignore_missing=True, details=False)
-                for name in names
-            ]
-
-        for node_idx, node in enumerate(deploy_nodes):
+            node = conn.baremetal.find_node(name, ignore_missing=True, details=False)
             if not node:
-                logger.warning(f"Could not find node {names[node_idx]}")
+                logger.warning(f"Could not find node {name}")
+                return
+            deploy_nodes = [node]
+
+        for node in deploy_nodes:
+            if not node:
                 continue
 
             if node.provision_state in ["active", "deploy failed", "error"]:


### PR DESCRIPTION
Replace --name parameter with positional argument in baremetal deploy and undeploy commands for consistency with compute commands. This changes the command syntax from:

  osism baremetal deploy --name <node>
  osism baremetal undeploy --name <node>

to:

  osism baremetal deploy <node>
  osism baremetal undeploy <node>

The --all flag remains available for operating on all nodes. Added validation to ensure either a node name or --all is specified.

BREAKING CHANGE: The --name parameter is removed. Users must update scripts to use positional arguments instead.

AI-assisted: Claude Code