### PR TITLE
Only convert image names to UUIDs when not already a UUID

### DIFF
--- a/osism/tasks/conductor/config.py
+++ b/osism/tasks/conductor/config.py
@@ -1,9 +1,20 @@
 # SPDX-License-Identifier: Apache-2.0
 
+import uuid
+
 from loguru import logger
 import yaml
 
 from osism.tasks import Config, openstack
+
+
+def is_uuid(value):
+    """Check if a string is a valid UUID."""
+    try:
+        uuid.UUID(value)
+        return True
+    except (ValueError, AttributeError):
+        return False
 
 
 def get_configuration():
@@ -25,29 +36,35 @@ def get_configuration():
 
         if "instance_info" in configuration["ironic_parameters"]:
             if "image_source" in configuration["ironic_parameters"]["instance_info"]:
-                result = openstack.image_get(
-                    configuration["ironic_parameters"]["instance_info"]["image_source"]
-                )
-                configuration["ironic_parameters"]["instance_info"][
+                image_source = configuration["ironic_parameters"]["instance_info"][
                     "image_source"
-                ] = result.id
+                ]
+                if not is_uuid(image_source):
+                    result = openstack.image_get(image_source)
+                    configuration["ironic_parameters"]["instance_info"][
+                        "image_source"
+                    ] = result.id
 
         if "driver_info" in configuration["ironic_parameters"]:
             if "deploy_kernel" in configuration["ironic_parameters"]["driver_info"]:
-                result = openstack.image_get(
-                    configuration["ironic_parameters"]["driver_info"]["deploy_kernel"]
-                )
-                configuration["ironic_parameters"]["driver_info"][
+                deploy_kernel = configuration["ironic_parameters"]["driver_info"][
                     "deploy_kernel"
-                ] = result.id
+                ]
+                if not is_uuid(deploy_kernel):
+                    result = openstack.image_get(deploy_kernel)
+                    configuration["ironic_parameters"]["driver_info"][
+                        "deploy_kernel"
+                    ] = result.id
 
             if "deploy_ramdisk" in configuration["ironic_parameters"]["driver_info"]:
-                result = openstack.image_get(
-                    configuration["ironic_parameters"]["driver_info"]["deploy_ramdisk"]
-                )
-                configuration["ironic_parameters"]["driver_info"][
+                deploy_ramdisk = configuration["ironic_parameters"]["driver_info"][
                     "deploy_ramdisk"
-                ] = result.id
+                ]
+                if not is_uuid(deploy_ramdisk):
+                    result = openstack.image_get(deploy_ramdisk)
+                    configuration["ironic_parameters"]["driver_info"][
+                        "deploy_ramdisk"
+                    ] = result.id
 
             if "cleaning_network" in configuration["ironic_parameters"]["driver_info"]:
                 result = openstack.network_get(


### PR DESCRIPTION
Previously, the conductor config always attempted to convert image_source, deploy_kernel, and deploy_ramdisk values to UUIDs via OpenStack API calls, even when these values were already UUIDs. This change adds a check to skip the conversion when the value is already a valid UUID, reducing unnecessary API calls and improving performance.

AI-assisted: Claude Code