### PR TITLE
Add STDIN support for vault password set command

### DIFF
--- a/osism/commands/vault.py
+++ b/osism/commands/vault.py
@@ -5,6 +5,7 @@
 
 import os
 import subprocess
+import sys
 
 from cliff.command import Command
 from cryptography.fernet import Fernet
@@ -31,7 +32,14 @@ class SetPassword(Command):
 
         f = Fernet(key)
 
-        ansible_vault_password = prompt("Ansible Vault password: ", is_password=True)
+        # Check if password is being piped from STDIN
+        if not sys.stdin.isatty():
+            ansible_vault_password = sys.stdin.read().strip()
+        else:
+            ansible_vault_password = prompt(
+                "Ansible Vault password: ", is_password=True
+            )
+
         redis.set(
             "ansible_vault_password", f.encrypt(ansible_vault_password.encode("utf-8"))
         )


### PR DESCRIPTION
Enable reading vault passwords from STDIN to allow piping passwords directly to the command (e.g., echo password | osism vault password set). The command now checks if input is being piped and reads from STDIN, otherwise falls back to the interactive prompt.

AI-assisted: Claude Code