### PR TITLE
Fix deep_decrypt to handle None values and support lists

### DIFF
--- a/osism/tasks/conductor/ironic.py
+++ b/osism/tasks/conductor/ironic.py
@@ -82,7 +82,7 @@ def sync_ironic(get_ironic_parameters, force_update=False):
         vault = get_vault()
         deep_decrypt(node_attributes, vault)
 
-        node_secrets = device.custom_fields["secrets"]
+        node_secrets = device.custom_fields.get("secrets", {})
         deep_decrypt(node_secrets, vault)
 
         if (

--- a/osism/tasks/conductor/utils.py
+++ b/osism/tasks/conductor/utils.py
@@ -39,15 +39,26 @@ def deep_merge(a, b):
 
 
 def deep_decrypt(a, vault):
-    for key, value in list(a.items()):
-        if not isinstance(value, dict):
-            if vault.is_encrypted(value):
+    if a is None:
+        return
+    if isinstance(a, dict):
+        for key, value in list(a.items()):
+            if isinstance(value, (dict, list)):
+                deep_decrypt(a[key], vault)
+            elif vault.is_encrypted(value):
                 try:
                     a[key] = vault.decrypt(value).decode()
                 except Exception:
                     a.pop(key, None)
-        else:
-            deep_decrypt(a[key], vault)
+    elif isinstance(a, list):
+        for i, item in enumerate(a):
+            if isinstance(item, (dict, list)):
+                deep_decrypt(item, vault)
+            elif vault.is_encrypted(item):
+                try:
+                    a[i] = vault.decrypt(item).decode()
+                except Exception:
+                    pass
 
 
 def get_vault():


### PR DESCRIPTION
- Add None check to prevent AttributeError when secrets field is missing
- Extend deep_decrypt to handle list/array structures in addition to dicts
- Use safe dict access with .get() for custom_fields["secrets"] to avoid KeyError
- Fixes AttributeError: 'NoneType' object has no attribute 'items'

AI-assisted: Claude Code