### PR TITLE
Fix AttributeError when NetBox device secrets field is None

### DIFF
--- a/osism/tasks/conductor/ironic.py
+++ b/osism/tasks/conductor/ironic.py
@@ -83,6 +83,8 @@ def sync_ironic(get_ironic_parameters, force_update=False):
         deep_decrypt(node_attributes, vault)
 
         node_secrets = device.custom_fields.get("secrets", {})
+        if node_secrets is None:
+            node_secrets = {}
         deep_decrypt(node_secrets, vault)
 
         if (


### PR DESCRIPTION
When a NetBox device has its custom field "secrets" explicitly set to None, the sync_ironic task crashes with AttributeError when trying to call .get() on the None value. This fix ensures node_secrets is always a dictionary.