### PR TITLE
Add sync sonic command for SONIC configuration preparation

### DIFF
--- a/osism/commands/sync.py
+++ b/osism/commands/sync.py
@@ -1,8 +1,9 @@
 # SPDX-License-Identifier: Apache-2.0
 
 from cliff.command import Command
+from loguru import logger
 
-from osism.tasks import ansible, handle_task
+from osism.tasks import ansible, conductor, handle_task
 
 
 class Facts(Command):
@@ -17,3 +18,29 @@ class Facts(Command):
         )
         rc = handle_task(t)
         return rc
+
+
+class Sonic(Command):
+    def get_parser(self, prog_name):
+        parser = super(Sonic, self).get_parser(prog_name)
+        parser.add_argument(
+            "--no-wait",
+            default=False,
+            help="Do not wait until the sync has been completed",
+            action="store_true",
+        )
+        return parser
+
+    def take_action(self, parsed_args):
+        wait = not parsed_args.no_wait
+
+        task = conductor.sync_sonic.delay()
+        if wait:
+            logger.info(
+                f"Task {task.task_id} (sync sonic) is running. Wait. No more output."
+            )
+            task.wait(timeout=None, interval=0.5)
+        else:
+            logger.info(
+                f"Task {task.task_id} (sync sonic) is running in background. No more output."
+            )

--- a/osism/tasks/conductor.py
+++ b/osism/tasks/conductor.py
@@ -5,6 +5,7 @@ from osism.tasks.conductor import (
     get_ironic_parameters,
     sync_netbox,
     sync_ironic,
+    sync_sonic,
 )
 
 __all__ = [
@@ -12,4 +13,5 @@ __all__ = [
     "get_ironic_parameters",
     "sync_netbox",
     "sync_ironic",
+    "sync_sonic",
 ]

--- a/osism/tasks/conductor/__init__.py
+++ b/osism/tasks/conductor/__init__.py
@@ -46,9 +46,17 @@ def sync_ironic(self, force_update=False):
     _sync_ironic(self.request.id, get_ironic_parameters, force_update)
 
 
+@app.task(bind=True, name="osism.tasks.conductor.sync_sonic")
+def sync_sonic(self):
+    logger.info("Preparing SONIC configuration files")
+    # TODO: Implement SONIC configuration file preparation
+    logger.info("SONIC sync task not yet implemented")
+
+
 __all__ = [
     "app",
     "get_ironic_parameters",
     "sync_netbox",
     "sync_ironic",
+    "sync_sonic",
 ]

--- a/setup.cfg
+++ b/setup.cfg
@@ -96,6 +96,7 @@ osism.commands:
     sync inventory = osism.commands.reconciler:Sync
     sync ironic = osism.commands.netbox:Ironic
     sync netbox = osism.commands.netbox:Sync
+    sync sonic = osism.commands.sync:Sonic
     task list = osism.commands.get:Tasks
     task revoke = osism.commands.task:Revoke
     validate = osism.commands.validate:Run


### PR DESCRIPTION
This commit introduces a new 'sync sonic' command that will prepare SONIC configuration files. The command follows the existing sync command pattern with a Celery task backend and --no-wait option.

The actual implementation for SONIC configuration file preparation is marked as TODO and will be added in a future commit.

AI-assisted: Claude Code