### PR TITLE
Add get_port_config method for SONiC HWSKU configuration parsing

### DIFF
--- a/Containerfile
+++ b/Containerfile
@@ -18,6 +18,8 @@ ENV CLUSTERSHELL_CFGDIR=/etc/clustershell/
 COPY files/clustershell/clush.conf /etc/clustershell/clush.conf
 COPY files/clustershell/groups.conf /etc/clustershell/groups.conf
 
+COPY files/sonic/port_config/ /etc/sonic/port_config/
+
 COPY files/netbox-manager/settings.toml /usr/local/config/settings.toml
 
 RUN apk add --no-cache bash

--- a/osism/tasks/conductor.py
+++ b/osism/tasks/conductor.py
@@ -3,6 +3,7 @@
 from osism.tasks.conductor import (
     app,
     get_ironic_parameters,
+    get_port_config,
     sync_netbox,
     sync_ironic,
     sync_sonic,
@@ -11,6 +12,7 @@ from osism.tasks.conductor import (
 __all__ = [
     "app",
     "get_ironic_parameters",
+    "get_port_config",
     "sync_netbox",
     "sync_ironic",
     "sync_sonic",

--- a/osism/tasks/conductor/__init__.py
+++ b/osism/tasks/conductor/__init__.py
@@ -1,6 +1,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 import copy
+import os
 from celery import Celery
 from celery.signals import worker_process_init
 from loguru import logger
@@ -23,6 +24,46 @@ def celery_init_worker(**kwargs):
 @app.on_after_configure.connect
 def setup_periodic_tasks(sender, **kwargs):
     pass
+
+
+def get_port_config(hwsku):
+    """Get port configuration for a given HWSKU.
+
+    Args:
+        hwsku: Hardware SKU name (e.g., 'Accton-AS5835-54T')
+
+    Returns:
+        dict: Port configuration with port names as keys and their properties as values
+              Example: {'Ethernet0': {'lanes': '2', 'alias': 'tenGigE1', 'index': '1', 'speed': '10000'}}
+    """
+    port_config = {}
+    config_path = f"/etc/sonic/port_config/{hwsku}.ini"
+
+    if not os.path.exists(config_path):
+        logger.error(f"Port config file not found: {config_path}")
+        return port_config
+
+    try:
+        with open(config_path, "r") as f:
+            for line in f:
+                line = line.strip()
+                # Skip comments and empty lines
+                if not line or line.startswith("#"):
+                    continue
+
+                parts = line.split()
+                if len(parts) >= 5:
+                    port_name = parts[0]
+                    port_config[port_name] = {
+                        "lanes": parts[1],
+                        "alias": parts[2],
+                        "index": parts[3],
+                        "speed": parts[4],
+                    }
+    except Exception as e:
+        logger.error(f"Error parsing port config file {config_path}: {e}")
+
+    return port_config
 
 
 # Tasks
@@ -67,6 +108,7 @@ def sync_sonic(self):
 __all__ = [
     "app",
     "get_ironic_parameters",
+    "get_port_config",
     "sync_netbox",
     "sync_ironic",
     "sync_sonic",


### PR DESCRIPTION
This commit introduces a new get_port_config method that parses SONiC port configuration files based on hardware SKU. The method reads INI files from /etc/sonic/port_config/ and returns a dictionary with port properties (lanes, alias, index, speed) accessible by port name.

Additionally, the Containerfile has been updated to copy all port configuration files from files/sonic/port_config/ to /etc/sonic/port_config/ during the container build process.

AI-assisted: Claude Code