### PR TITLE
Generate minimal SONiC config.json for devices in sync_sonic task

### DIFF
--- a/osism/tasks/conductor.py
+++ b/osism/tasks/conductor.py
@@ -2,6 +2,9 @@
 
 from osism.tasks.conductor import (
     app,
+    get_device_hostname,
+    get_device_mac_address,
+    get_device_platform,
     get_ironic_parameters,
     get_port_config,
     sync_netbox,
@@ -11,6 +14,9 @@ from osism.tasks.conductor import (
 
 __all__ = [
     "app",
+    "get_device_hostname",
+    "get_device_mac_address",
+    "get_device_platform",
     "get_ironic_parameters",
     "get_port_config",
     "sync_netbox",


### PR DESCRIPTION
- Added generate_sonic_config() function to create minimal config.json
- Created helper functions for device metadata extraction:
  - get_device_platform(): Uses sonic_parameters.platform or generates from HWSKU
  - get_device_hostname(): Uses inventory_hostname custom field or device.name
  - get_device_mac_address(): Extracts MAC from management-only interface
- Platform generation follows pattern: x86_64-{hwsku_lower_with_underscores}-r0
- Configuration includes DEVICE_METADATA, PORT definitions, LOOPBACK, FEATURE settings
- Returns dictionary with device names as keys and their configs as values
- All port configurations are generated from HWSKU-specific port_config files

AI-assisted: Claude Code