### PR TITLE
Fix usage of netbox oob_ip

### DIFF
--- a/osism/tasks/conductor/ironic.py
+++ b/osism/tasks/conductor/ironic.py
@@ -139,8 +139,8 @@ def sync_ironic(request_id, get_ironic_parameters, force_update=False):
                 # NOTE: Render driver address field
                 address_key = driver_params[node_attributes["driver"]]["address"]
                 if address_key in node_attributes["driver_info"]:
-                    if device.oob_ip and "address" in device.oob_ip:
-                        node_mgmt_address = device.oob_ip["address"]
+                    if device.oob_ip:
+                        node_mgmt_address = device.oob_ip
                     else:
                         node_mgmt_addresses = [
                             interface["address"]


### PR DESCRIPTION
Pynetbox does not return a mapping with an `address` key when oob_ip is queried, but the IP directly in CIDR notation.