### PR TITLE
Add NetBox to SONiC interface name conversion with speed-based multip…

### DIFF
--- a/osism/tasks/conductor/netbox.py
+++ b/osism/tasks/conductor/netbox.py
@@ -151,6 +151,8 @@ def get_device_vlans(device):
                 # Add interface to VLAN members as untagged
                 if vid not in vlan_members:
                     vlan_members[vid] = {}
+
+                # Use original NetBox interface name - conversion will be done in sonic.py
                 vlan_members[vid][interface.name] = "untagged"
 
             # Process tagged VLANs
@@ -168,6 +170,8 @@ def get_device_vlans(device):
                     # Add interface to VLAN members as tagged
                     if vid not in vlan_members:
                         vlan_members[vid] = {}
+
+                    # Use original NetBox interface name - conversion will be done in sonic.py
                     vlan_members[vid][interface.name] = "tagged"
 
         # Get VLAN interfaces (SVIs) - virtual interfaces with VLAN assignments


### PR DESCRIPTION
…liers

Implement intelligent interface name conversion from NetBox notation (Eth1/1) to SONiC notation (Ethernet0) with speed-aware port multipliers. High-speed ports (100G+) use 4x lane multipliers while lower speeds use sequential numbering.

- Add convert_netbox_interface_to_sonic() function with speed-based logic
- Support 100G, 200G, 400G, 800G ports with 4x multiplier (Eth1/2 -> Ethernet4)
- Support 1G, 10G, 25G ports with 1x multiplier (Eth1/2 -> Ethernet1)
- Convert interface names in VLAN member assignments (tagged/untagged)
- Convert interface names in connected interface detection
- Move conversion logic to sonic.py for better separation of concerns
- Future-proof design for additional port speeds and multipliers

AI-assisted: Claude Code