### PR TITLE
Add static KDUMP configuration to SONiC config generation

### DIFF
--- a/osism/tasks/conductor/sonic.py
+++ b/osism/tasks/conductor/sonic.py
@@ -865,6 +865,15 @@ def generate_sonic_config(device, hwsku):
         "INGRESS_QOS_POLICY": "oob-qos-policy"
     }
 
+    # Add static KDUMP configuration
+    config["KDUMP"] = {
+        "config": {
+            "enabled": "true",
+            "memory": "0M-2G:256M,2G-4G:256M,4G-8G:384M,8G-:448M",
+            "num_dumps": "3",
+        }
+    }
+
     return config
 
 


### PR DESCRIPTION
This commit adds a static KDUMP (kernel crash dump) configuration to the SONiC configuration generator. The configuration enables KDUMP with memory allocation based on system RAM size (256MB for systems up to 4GB, 384MB for 4-8GB, and 448MB for systems with more than 8GB) and sets the maximum number of crash dumps to be retained to 3.

The KDUMP configuration is added as a static element in the generated SONiC configuration JSON, similar to the existing QoS policy configuration.

AI-assisted: Claude Code