### PR TITLE
Rename NETBOX_FILTER_CONDUCTOR to NETBOX_FILTER_CONDUCTOR_IRONIC

### DIFF
--- a/osism/settings.py
+++ b/osism/settings.py
@@ -35,8 +35,8 @@ INVENTORY_RECONCILER_SCHEDULE = float(
 
 OSISM_API_URL = os.getenv("OSISM_API_URL", None)
 
-NETBOX_FILTER_CONDUCTOR = os.getenv(
-    "NETBOX_FILTER_CONDUCTOR",
+NETBOX_FILTER_CONDUCTOR_IRONIC = os.getenv(
+    "NETBOX_FILTER_CONDUCTOR_IRONIC",
     "[{'state': 'active', 'tag': ['managed-by-ironic']}]",
 )
 

--- a/osism/tasks/conductor/netbox.py
+++ b/osism/tasks/conductor/netbox.py
@@ -18,7 +18,7 @@ def get_nb_device_query_list():
             "tag",
             "state",
         ]
-        nb_device_query_list = yaml.safe_load(settings.NETBOX_FILTER_CONDUCTOR)
+        nb_device_query_list = yaml.safe_load(settings.NETBOX_FILTER_CONDUCTOR_IRONIC)
         if type(nb_device_query_list) is not list:
             raise TypeError
         for nb_device_query in nb_device_query_list:
@@ -40,11 +40,11 @@ def get_nb_device_query_list():
                         raise ValueError(f"Invalid name {value_name} for {key}")
     except (yaml.YAMLError, TypeError):
         logger.error(
-            f"Setting NETBOX_FILTER_CONDUCTOR needs to be an array of mappings containing supported NetBox device filters: {supported_nb_device_filters}"
+            f"Setting NETBOX_FILTER_CONDUCTOR_IRONIC needs to be an array of mappings containing supported NetBox device filters: {supported_nb_device_filters}"
         )
         nb_device_query_list = []
     except ValueError as exc:
-        logger.error(f"Unknown value in NETBOX_FILTER_CONDUCTOR: {exc}")
+        logger.error(f"Unknown value in NETBOX_FILTER_CONDUCTOR_IRONIC: {exc}")
         nb_device_query_list = []
 
     return nb_device_query_list

--- a/osism/tasks/conductor/sonic.py
+++ b/osism/tasks/conductor/sonic.py
@@ -865,12 +865,12 @@ def sync_sonic():
 
     logger.debug(f"Supported HWSKUs: {', '.join(supported_hwskus)}")
 
-    # Get device query list from NETBOX_FILTER_CONDUCTOR
+    # Get device query list from NETBOX_FILTER_CONDUCTOR_IRONIC
     nb_device_query_list = get_nb_device_query_list()
 
     devices = []
     for nb_device_query in nb_device_query_list:
-        # Query devices with the NETBOX_FILTER_CONDUCTOR criteria
+        # Query devices with the NETBOX_FILTER_CONDUCTOR_IRONIC criteria
         for device in utils.nb.dcim.devices.filter(**nb_device_query):
             # Check if device role matches allowed roles
             if device.role and device.role.slug in DEFAULT_SONIC_ROLES:


### PR DESCRIPTION
This commit renames the environment variable NETBOX_FILTER_CONDUCTOR to NETBOX_FILTER_CONDUCTOR_IRONIC to better reflect its purpose for filtering Ironic-managed devices. The changes include:

- Updated environment variable name in settings.py
- Updated all references in the netbox.py module
- Updated error messages to use the new variable name
- Updated comments in sonic.py to reflect the new name

The default value remains unchanged, filtering for devices with state 'active' and tag 'managed-by-ironic'.