### PR TITLE
Add separate NETBOX_FILTER_CONDUCTOR_SONIC for SONiC device filtering

### DIFF
--- a/osism/settings.py
+++ b/osism/settings.py
@@ -40,6 +40,11 @@ NETBOX_FILTER_CONDUCTOR_IRONIC = os.getenv(
     "[{'state': 'active', 'tag': ['managed-by-ironic']}]",
 )
 
+NETBOX_FILTER_CONDUCTOR_SONIC = os.getenv(
+    "NETBOX_FILTER_CONDUCTOR_SONIC",
+    "[{'state': 'active', 'tag': ['managed-by-metalbox']}]",
+)
+
 NETBOX_SECONDARIES = (
     os.getenv("NETBOX_SECONDARIES", read_secret("NETBOX_SECONDARIES")) or "[]"
 )

--- a/osism/tasks/conductor/ironic.py
+++ b/osism/tasks/conductor/ironic.py
@@ -7,7 +7,10 @@ from pottery import Redlock
 
 from osism import utils as osism_utils
 from osism.tasks import netbox, openstack
-from osism.tasks.conductor.netbox import get_device_oob_ip, get_nb_device_query_list
+from osism.tasks.conductor.netbox import (
+    get_device_oob_ip,
+    get_nb_device_query_list_ironic,
+)
 from osism.tasks.conductor.utils import (
     deep_compare,
     deep_decrypt,
@@ -37,7 +40,7 @@ def sync_ironic(request_id, get_ironic_parameters, force_update=False):
         "Starting NetBox device synchronisation with ironic\n",
     )
     devices = set()
-    nb_device_query_list = get_nb_device_query_list()
+    nb_device_query_list = get_nb_device_query_list_ironic()
     for nb_device_query in nb_device_query_list:
         devices |= set(netbox.get_devices(**nb_device_query))
 

--- a/osism/tasks/conductor/netbox.py
+++ b/osism/tasks/conductor/netbox.py
@@ -7,7 +7,7 @@ from osism import settings, utils
 from osism.tasks import netbox
 
 
-def get_nb_device_query_list():
+def get_nb_device_query_list_ironic():
     try:
         supported_nb_device_filters = [
             "site",
@@ -45,6 +45,49 @@ def get_nb_device_query_list():
         nb_device_query_list = []
     except ValueError as exc:
         logger.error(f"Unknown value in NETBOX_FILTER_CONDUCTOR_IRONIC: {exc}")
+        nb_device_query_list = []
+
+    return nb_device_query_list
+
+
+def get_nb_device_query_list_sonic():
+    try:
+        supported_nb_device_filters = [
+            "site",
+            "region",
+            "site_group",
+            "location",
+            "rack",
+            "tag",
+            "state",
+        ]
+        nb_device_query_list = yaml.safe_load(settings.NETBOX_FILTER_CONDUCTOR_SONIC)
+        if type(nb_device_query_list) is not list:
+            raise TypeError
+        for nb_device_query in nb_device_query_list:
+            if type(nb_device_query) is not dict:
+                raise TypeError
+            for key in list(nb_device_query.keys()):
+                if key not in supported_nb_device_filters:
+                    raise ValueError
+                # NOTE: Only "location_id" and "rack_id" are supported by NetBox
+                if key in ["location", "rack"]:
+                    value_name = nb_device_query.pop(key, "")
+                    if key == "location":
+                        value_id = netbox.get_location_id(value_name)
+                    elif key == "rack":
+                        value_id = netbox.get_rack_id(value_name)
+                    if value_id:
+                        nb_device_query.update({key + "_id": value_id})
+                    else:
+                        raise ValueError(f"Invalid name {value_name} for {key}")
+    except (yaml.YAMLError, TypeError):
+        logger.error(
+            f"Setting NETBOX_FILTER_CONDUCTOR_SONIC needs to be an array of mappings containing supported NetBox device filters: {supported_nb_device_filters}"
+        )
+        nb_device_query_list = []
+    except ValueError as exc:
+        logger.error(f"Unknown value in NETBOX_FILTER_CONDUCTOR_SONIC: {exc}")
         nb_device_query_list = []
 
     return nb_device_query_list

--- a/osism/tasks/conductor/sonic.py
+++ b/osism/tasks/conductor/sonic.py
@@ -10,7 +10,7 @@ from osism.tasks.conductor.netbox import (
     get_device_loopbacks,
     get_device_oob_ip,
     get_device_vlans,
-    get_nb_device_query_list,
+    get_nb_device_query_list_sonic,
 )
 
 
@@ -865,27 +865,19 @@ def sync_sonic():
 
     logger.debug(f"Supported HWSKUs: {', '.join(supported_hwskus)}")
 
-    # Get device query list from NETBOX_FILTER_CONDUCTOR_IRONIC
-    nb_device_query_list = get_nb_device_query_list()
+    # Get device query list from NETBOX_FILTER_CONDUCTOR_SONIC
+    nb_device_query_list = get_nb_device_query_list_sonic()
 
     devices = []
     for nb_device_query in nb_device_query_list:
-        # Query devices with the NETBOX_FILTER_CONDUCTOR_IRONIC criteria
+        # Query devices with the NETBOX_FILTER_CONDUCTOR_SONIC criteria
         for device in utils.nb.dcim.devices.filter(**nb_device_query):
             # Check if device role matches allowed roles
             if device.role and device.role.slug in DEFAULT_SONIC_ROLES:
-                # Check if device has the required tag
-                if device.tags and any(
-                    tag.slug == "managed-by-osism" for tag in device.tags
-                ):
-                    devices.append(device)
-                    logger.debug(
-                        f"Found device: {device.name} with role: {device.role.slug}"
-                    )
-                else:
-                    logger.debug(
-                        f"Skipping device {device.name}: missing 'managed-by-osism' tag"
-                    )
+                devices.append(device)
+                logger.debug(
+                    f"Found device: {device.name} with role: {device.role.slug}"
+                )
 
     logger.info(f"Found {len(devices)} devices matching criteria")
 


### PR DESCRIPTION
This commit introduces a dedicated environment variable for filtering SONiC devices in NetBox, separate from the Ironic device filtering. The changes include:

- Added NETBOX_FILTER_CONDUCTOR_SONIC environment variable with default filter for 'managed-by-metalbox' tag
- Created get_nb_device_query_list_sonic() function for SONiC-specific device filtering
- Renamed get_nb_device_query_list() to get_nb_device_query_list_ironic() for consistency
- Updated sonic.py to use the new SONIC-specific filter
- Removed redundant tag checking in sync_sonic() as filtering is now handled by the environment variable
- Modified generate_sonic_config() to use /etc/sonic/config_db.json as base configuration when available

This separation allows independent configuration of device filters for SONiC and Ironic conductors, providing better flexibility in multi- conductor deployments.

AI-assisted: Claude Code