### PR TITLE
Add BGP_GLOBALS configuration with router_id from device primary IP

### DIFF
--- a/osism/tasks/conductor/sonic.py
+++ b/osism/tasks/conductor/sonic.py
@@ -580,6 +580,7 @@ def generate_sonic_config(device, hwsku):
         "LOOPBACK_INTERFACE": {},
         "BREAKOUT_CFG": {},
         "BREAKOUT_PORTS": {},
+        "BGP_GLOBALS": {},
         "BGP_NEIGHBOR_AF": {},
         "VERSIONS": {},
     }
@@ -605,6 +606,18 @@ def generate_sonic_config(device, hwsku):
     # Update VERSIONS if not present
     if "DATABASE" not in config["VERSIONS"]:
         config["VERSIONS"]["DATABASE"] = {"VERSION": version}
+
+    # Add BGP_GLOBALS configuration with router_id set to primary IP address
+    primary_ip = None
+    if device.primary_ip4:
+        primary_ip = str(device.primary_ip4.address).split("/")[0]
+    elif device.primary_ip6:
+        primary_ip = str(device.primary_ip6.address).split("/")[0]
+
+    if primary_ip:
+        if "default" not in config["BGP_GLOBALS"]:
+            config["BGP_GLOBALS"]["default"] = {}
+        config["BGP_GLOBALS"]["default"]["router_id"] = primary_ip
 
     # Add port configurations in sorted order
     # Sort ports naturally (Ethernet0, Ethernet4, Ethernet8, ...)


### PR DESCRIPTION
This commit adds BGP global configuration to SONiC with the router_id automatically set to the device's primary IP address from NetBox.

- Added BGP_GLOBALS section to the required SONiC configuration sections
- Added logic to extract the device's primary IP address from NetBox (preferring IPv4, falling back to IPv6)
- Set router_id in BGP_GLOBALS default section to the primary IP address without netmask

The router_id is extracted by accessing device.primary_ip4 or device.primary_ip6 from the NetBox device object and removing the network prefix to get just the IP address. This ensures each SONiC switch has a unique BGP router ID based on its primary network identity.

AI-assisted: Claude Code