### PR TITLE
Add virtual interface type support with 0 speed in port mapping

### DIFF
--- a/osism/tasks/conductor/sonic.py
+++ b/osism/tasks/conductor/sonic.py
@@ -53,6 +53,8 @@ PORT_TYPE_TO_SPEED_MAP = {
     # 400G Optical
     "400gbase-x-qsfpdd": 400000,  # 400G QSFP-DD
     "400gbase-x-osfp": 400000,  # 400G OSFP
+    # Virtual interface
+    "virtual": 0,  # Virtual interface (no physical speed)
 }
 
 


### PR DESCRIPTION
Add support for virtual interface type in the port type to speed mapping dictionary. Virtual interfaces return a speed of 0 Mbps since they have no physical speed limitations.

AI-assisted: Claude Code