### PR TITLE
Add default port parameters to SONiC PORT configuration

### DIFF
--- a/osism/tasks/conductor/sonic.py
+++ b/osism/tasks/conductor/sonic.py
@@ -877,6 +877,10 @@ def generate_sonic_config(device, hwsku):
             "lanes": port_lanes,
             "speed": port_speed,
             "mtu": "9100",
+            "adv_speeds": "all",
+            "autoneg": "off",
+            "link_training": "off",
+            "unreliable_los": "auto",
         }
 
     # Add breakout ports that might not be in the original port_config
@@ -954,6 +958,10 @@ def generate_sonic_config(device, hwsku):
                     "lanes": port_lanes,
                     "speed": port_speed,
                     "mtu": "9100",
+                    "adv_speeds": "all",
+                    "autoneg": "off",
+                    "link_training": "off",
+                    "unreliable_los": "auto",
                 }
 
     # Add tagged VLANs to PORT configuration


### PR DESCRIPTION
Extend PORT definitions with additional default parameters for proper interface configuration:

- adv_speeds: "all" - Advertise all available speeds
- autoneg: "off" - Disable auto-negotiation
- link_training: "off" - Disable link training
- unreliable_los: "auto" - Set unreliable loss of signal to auto

Applied to both regular ports and breakout ports to ensure consistent configuration across all interface types.

AI-assisted: Claude Code