### PR TITLE
Build and add bootstrap playbook to node config

### DIFF
--- a/Containerfile
+++ b/Containerfile
@@ -42,7 +42,8 @@ apk add --no-cache \
   less \
   openssh-client \
   procps \
-  tini
+  tini \
+  cdrkit
 
 # install python packages
 uv pip install --no-cache --system -r /src/requirements.txt


### PR DESCRIPTION
Add osism configuration as a bootstrap playbook to a baremetal node's config drive. The playbook may be executed on first boot of the node to configure.

Closes: https://github.com/osism/issues/issues/1263