### PR TITLE
Use serial number as default identifier for SONIC config export

### DIFF
--- a/osism/settings.py
+++ b/osism/settings.py
@@ -49,7 +49,7 @@ NETBOX_FILTER_CONDUCTOR_SONIC = os.getenv(
 SONIC_EXPORT_DIR = os.getenv("SONIC_EXPORT_DIR", "/etc/sonic/export")
 SONIC_EXPORT_PREFIX = os.getenv("SONIC_EXPORT_PREFIX", "osism_")
 SONIC_EXPORT_SUFFIX = os.getenv("SONIC_EXPORT_SUFFIX", "_config_db.json")
-SONIC_EXPORT_IDENTIFIER = os.getenv("SONIC_EXPORT_IDENTIFIER", "hostname")
+SONIC_EXPORT_IDENTIFIER = os.getenv("SONIC_EXPORT_IDENTIFIER", "serial-number")
 
 NETBOX_SECONDARIES = (
     os.getenv("NETBOX_SECONDARIES", read_secret("NETBOX_SECONDARIES")) or "[]"

--- a/osism/tasks/conductor/sonic.py
+++ b/osism/tasks/conductor/sonic.py
@@ -435,7 +435,7 @@ def export_config_to_file(device, config):
         os.makedirs(export_dir, exist_ok=True)
 
         # Get identifier based on configuration
-        if identifier_type == "serial":
+        if identifier_type == "serial-number":
             # Get serial number from device
             identifier = (
                 device.serial if hasattr(device, "serial") and device.serial else None


### PR DESCRIPTION
Changed the default SONIC_EXPORT_IDENTIFIER from "hostname" to "serial-number" to use device serial numbers for generated config_db.json filenames. Falls back to hostname when serial number is not available.