### PR TITLE
Exclude port channel members from BGP neighbor configuration in SONIC

### DIFF
--- a/osism/tasks/conductor/sonic.py
+++ b/osism/tasks/conductor/sonic.py
@@ -1429,10 +1429,11 @@ def generate_sonic_config(device, hwsku, device_as_mapping=None):
                     interface.name, interface_speed
                 )
 
-                # Only process if this interface is in our PORT configuration
+                # Only process if this interface is in our PORT configuration and not a port channel member
                 if (
                     sonic_interface_name in config["PORT"]
                     and sonic_interface_name in connected_interfaces
+                    and sonic_interface_name not in portchannel_info["member_mapping"]
                 ):
                     try:
                         # Get the cable and find the connected device


### PR DESCRIPTION
When an interface is a member of a port channel (LAG), it should not be configured as a BGP neighbor directly. BGP sessions should only be established over the port channel interface itself, not its individual member interfaces.

This change adds a check to exclude port channel member interfaces from the BGP_NEIGHBOR configuration when processing Loopback0-based neighbors, ensuring consistency with the existing logic for direct interface-based BGP neighbors.

AI-assisted: Claude Code