### PR TITLE
Refactor SONiC connection detection to use connected_endpoints API

### DIFF
--- a/osism/tasks/conductor/sonic/__init__.py
+++ b/osism/tasks/conductor/sonic/__init__.py
@@ -5,10 +5,22 @@
 from .config_generator import generate_sonic_config
 from .exporter import save_config_to_netbox, export_config_to_file
 from .sync import sync_sonic
+from .connections import (
+    get_connected_interfaces,
+    get_connected_device_for_sonic_interface,
+    get_connected_device_via_interface,
+    find_interconnected_devices,
+    get_device_bgp_neighbors_via_loopback,
+)
 
 __all__ = [
     "generate_sonic_config",
     "save_config_to_netbox",
     "export_config_to_file",
     "sync_sonic",
+    "get_connected_interfaces",
+    "get_connected_device_for_sonic_interface",
+    "get_connected_device_via_interface",
+    "find_interconnected_devices",
+    "get_device_bgp_neighbors_via_loopback",
 ]

--- a/osism/tasks/conductor/sonic/bgp.py
+++ b/osism/tasks/conductor/sonic/bgp.py
@@ -2,10 +2,8 @@
 
 """BGP and AS calculation functions for SONiC configuration."""
 
-from collections import defaultdict, deque
 from loguru import logger
 
-from osism import utils
 from .constants import DEFAULT_LOCAL_AS_PREFIX
 
 
@@ -46,6 +44,8 @@ def calculate_local_asn_from_ipv4(
         raise ValueError(f"Failed to calculate AS from {ipv4_address}: {str(e)}")
 
 
+# Deprecated: Use connections.find_interconnected_devices instead
+# This function is kept for backward compatibility but delegates to the new module
 def find_interconnected_spine_groups(devices, target_roles=["spine", "superspine"]):
     """Find groups of interconnected spine/superspine switches.
 
@@ -56,92 +56,10 @@ def find_interconnected_spine_groups(devices, target_roles=["spine", "superspine
     Returns:
         List of groups, where each group is a list of interconnected devices of the same role
     """
-    # Filter devices by target roles
-    spine_devices = {}
-    for device in devices:
-        if hasattr(device, "role") and device.role and device.role.slug in target_roles:
-            spine_devices[device.id] = device
+    # Import here to avoid circular imports
+    from .connections import find_interconnected_devices
 
-    if not spine_devices:
-        return []
-
-    # Build connection graph for each role separately
-    role_graphs = defaultdict(lambda: defaultdict(set))
-
-    for device in spine_devices.values():
-        device_role = device.role.slug
-
-        try:
-            # Get all interfaces for this device
-            interfaces = utils.nb.dcim.interfaces.filter(device_id=device.id)
-
-            for interface in interfaces:
-                # Check if interface has connected_endpoints
-                if (
-                    hasattr(interface, "connected_endpoints")
-                    and interface.connected_endpoints
-                ):
-                    # Ensure connected_endpoints_reachable is True
-                    if not getattr(interface, "connected_endpoints_reachable", False):
-                        continue
-
-                    try:
-                        # Process each connected endpoint
-                        for endpoint in interface.connected_endpoints:
-                            # Get the connected device from the endpoint
-                            if hasattr(endpoint, "device"):
-                                connected_device = endpoint.device
-
-                                # Check if connected device is also a spine/superspine device
-                                if (
-                                    connected_device.id in spine_devices
-                                    and connected_device.id != device.id
-                                    and connected_device.role.slug == device_role
-                                ):
-                                    # Add connection to the graph
-                                    role_graphs[device_role][device.id].add(
-                                        connected_device.id
-                                    )
-                                    role_graphs[device_role][connected_device.id].add(
-                                        device.id
-                                    )
-
-                    except Exception as e:
-                        logger.debug(
-                            f"Error processing connected_endpoints for interface {interface.name} on {device.name}: {e}"
-                        )
-
-        except Exception as e:
-            logger.warning(
-                f"Error processing device {device.name} for spine grouping: {e}"
-            )
-
-    # Find connected components for each role using BFS
-    all_groups = []
-
-    for role, graph in role_graphs.items():
-        visited = set()
-
-        for device_id in graph:
-            if device_id not in visited:
-                # BFS to find all connected devices
-                group = []
-                queue = deque([device_id])
-                visited.add(device_id)
-
-                while queue:
-                    current_id = queue.popleft()
-                    group.append(spine_devices[current_id])
-
-                    for neighbor_id in graph[current_id]:
-                        if neighbor_id not in visited:
-                            visited.add(neighbor_id)
-                            queue.append(neighbor_id)
-
-                if len(group) > 1:  # Only include groups with multiple devices
-                    all_groups.append(group)
-
-    return all_groups
+    return find_interconnected_devices(devices, target_roles)
 
 
 def calculate_minimum_as_for_group(device_group, prefix=DEFAULT_LOCAL_AS_PREFIX):

--- a/osism/tasks/conductor/sonic/connections.py
+++ b/osism/tasks/conductor/sonic/connections.py
@@ -1,0 +1,319 @@
+# SPDX-License-Identifier: Apache-2.0
+
+"""Centralized connection detection functions for SONiC configuration.
+
+This module provides unified helper functions for detecting connected devices
+using the NetBox connected_endpoints API, replacing legacy cable-based detection.
+"""
+
+from loguru import logger
+from typing import Optional, Set, Tuple, List, Any, DefaultDict
+from collections import defaultdict
+
+from osism import utils
+from .interface import (
+    convert_netbox_interface_to_sonic,
+)
+from .cache import get_cached_device_interfaces
+
+
+def get_connected_device_via_interface(
+    interface: Any, source_device_id: int
+) -> Optional[Any]:
+    """Get the connected device for a given interface using connected_endpoints API.
+
+    Args:
+        interface: NetBox interface object
+        source_device_id: ID of the source device to exclude from results
+
+    Returns:
+        Connected NetBox device object or None if not found/reachable
+    """
+    # Skip management-only interfaces
+    if hasattr(interface, "mgmt_only") and interface.mgmt_only:
+        return None
+
+    # Check if interface has connected_endpoints
+    if not (
+        hasattr(interface, "connected_endpoints") and interface.connected_endpoints
+    ):
+        return None
+
+    # Ensure connected_endpoints_reachable is True
+    if not getattr(interface, "connected_endpoints_reachable", False):
+        return None
+
+    try:
+        # Process each connected endpoint
+        for endpoint in interface.connected_endpoints:
+            # Get the connected device from the endpoint
+            if hasattr(endpoint, "device") and endpoint.device.id != source_device_id:
+                return endpoint.device
+    except Exception as e:
+        logger.debug(
+            f"Error processing connected_endpoints for interface {interface.name}: {e}"
+        )
+
+    return None
+
+
+def get_connected_interfaces(
+    device: Any, portchannel_info: Optional[dict] = None
+) -> Tuple[Set[str], Set[str]]:
+    """Get list of interface names that are connected to other devices.
+
+    Uses the modern connected_endpoints API as the primary method for detecting
+    connections, with reachability checks.
+
+    Args:
+        device: NetBox device object
+        portchannel_info: Optional port channel info dict from detect_port_channels
+
+    Returns:
+        tuple: (set of connected interfaces, set of connected port channels)
+    """
+    connected_interfaces = set()
+    connected_portchannels = set()
+
+    try:
+        # Get all interfaces for the device (using cache)
+        interfaces = get_cached_device_interfaces(device.id)
+
+        for interface in interfaces:
+            # Skip management-only interfaces
+            if hasattr(interface, "mgmt_only") and interface.mgmt_only:
+                continue
+
+            # Check if interface is connected using connected_endpoints API
+            connected_device = get_connected_device_via_interface(interface, device.id)
+
+            if connected_device:
+                # Convert NetBox interface name to SONiC format
+                sonic_interface_name = convert_netbox_interface_to_sonic(
+                    interface, device
+                )
+                connected_interfaces.add(sonic_interface_name)
+
+                # If this interface is part of a port channel, mark the port channel as connected
+                if (
+                    portchannel_info
+                    and sonic_interface_name in portchannel_info["member_mapping"]
+                ):
+                    pc_name = portchannel_info["member_mapping"][sonic_interface_name]
+                    connected_portchannels.add(pc_name)
+
+    except Exception as e:
+        logger.warning(
+            f"Could not get interface connections for device {device.name}: {e}"
+        )
+
+    return connected_interfaces, connected_portchannels
+
+
+def get_connected_device_for_sonic_interface(
+    device: Any, sonic_interface_name: str
+) -> Optional[Any]:
+    """Get the connected device for a given SONiC interface name.
+
+    Args:
+        device: NetBox device object
+        sonic_interface_name: SONiC interface name (e.g., "Ethernet0")
+
+    Returns:
+        NetBox device object or None if not found
+    """
+    try:
+        interfaces = get_cached_device_interfaces(device.id)
+
+        for interface in interfaces:
+            # Convert NetBox interface name to SONiC format
+            sonic_name = convert_netbox_interface_to_sonic(interface, device)
+
+            if sonic_name == sonic_interface_name:
+                return get_connected_device_via_interface(interface, device.id)
+
+    except Exception as e:
+        logger.debug(
+            f"Could not find connected device for interface {sonic_interface_name}: {e}"
+        )
+
+    return None
+
+
+def find_interconnected_devices(
+    devices: List[Any], target_roles: List[str] = ["spine", "superspine"]
+) -> List[List[Any]]:
+    """Find groups of interconnected devices with specific roles.
+
+    Uses connected_endpoints API to build a graph of device connections.
+
+    Args:
+        devices: List of NetBox device objects
+        target_roles: List of device roles to consider
+
+    Returns:
+        List of groups, where each group is a list of interconnected devices of the same role
+    """
+    from collections import deque
+
+    # Filter devices by target roles
+    target_devices = {}
+    for device in devices:
+        if hasattr(device, "role") and device.role and device.role.slug in target_roles:
+            target_devices[device.id] = device
+
+    if not target_devices:
+        return []
+
+    # Build connection graph for each role separately
+    role_graphs: DefaultDict[str, DefaultDict[int, Set[int]]] = defaultdict(
+        lambda: defaultdict(set)
+    )
+
+    for device in target_devices.values():
+        device_role = device.role.slug
+
+        try:
+            # Get all interfaces for this device
+            interfaces = get_cached_device_interfaces(device.id)
+
+            for interface in interfaces:
+                # Get connected device using our helper
+                connected_device = get_connected_device_via_interface(
+                    interface, device.id
+                )
+
+                if (
+                    connected_device
+                    and connected_device.id in target_devices
+                    and connected_device.role.slug == device_role
+                ):
+                    # Add bidirectional connection to the graph
+                    role_graphs[device_role][device.id].add(connected_device.id)
+                    role_graphs[device_role][connected_device.id].add(device.id)
+
+        except Exception as e:
+            logger.warning(f"Error processing device {device.name} for grouping: {e}")
+
+    # Find connected components for each role using BFS
+    all_groups = []
+
+    for role, graph in role_graphs.items():
+        visited = set()
+
+        for device_id in graph:
+            if device_id not in visited:
+                # BFS to find all connected devices
+                group = []
+                queue = deque([device_id])
+                visited.add(device_id)
+
+                while queue:
+                    current_id = queue.popleft()
+                    group.append(target_devices[current_id])
+
+                    for neighbor_id in graph[current_id]:
+                        if neighbor_id not in visited:
+                            visited.add(neighbor_id)
+                            queue.append(neighbor_id)
+
+                if len(group) > 1:  # Only include groups with multiple devices
+                    all_groups.append(group)
+
+    return all_groups
+
+
+def get_device_bgp_neighbors_via_loopback(
+    device: Any,
+    portchannel_info: dict,
+    connected_interfaces: Set[str],
+    port_config: dict,
+) -> List[dict]:
+    """Get BGP neighbors for a device based on Loopback0 addresses of connected devices.
+
+    Args:
+        device: NetBox device object
+        portchannel_info: Port channel information
+        connected_interfaces: Set of connected interface names
+        port_config: Port configuration dict
+
+    Returns:
+        List of BGP neighbor dictionaries with IP and device info
+    """
+    bgp_neighbors = []
+
+    try:
+        # Get all interfaces for the device
+        interfaces = get_cached_device_interfaces(device.id)
+
+        for interface in interfaces:
+            # Skip management-only interfaces
+            if hasattr(interface, "mgmt_only") and interface.mgmt_only:
+                continue
+
+            # Get connected device
+            connected_device = get_connected_device_via_interface(interface, device.id)
+            if not connected_device:
+                continue
+
+            # Convert to SONiC interface name to check if it's in our PORT config
+            sonic_interface_name = convert_netbox_interface_to_sonic(interface, device)
+
+            # Only process if this interface is in PORT configuration and connected
+            if (
+                sonic_interface_name in port_config
+                and sonic_interface_name in connected_interfaces
+                and sonic_interface_name not in portchannel_info["member_mapping"]
+            ):
+                # Check if connected device has the required tag
+                has_osism_tag = False
+                if connected_device.tags:
+                    has_osism_tag = any(
+                        tag.slug == "managed-by-osism" for tag in connected_device.tags
+                    )
+
+                if has_osism_tag:
+                    # Get Loopback0 IP addresses from the connected device
+                    try:
+                        # Get all interfaces for connected device (using cache)
+                        all_connected_interfaces = get_cached_device_interfaces(
+                            connected_device.id
+                        )
+                        loopback_interfaces: List[Any] = [
+                            iface
+                            for iface in all_connected_interfaces
+                            if iface.name == "Loopback0"
+                        ]
+
+                        for loopback_iface in loopback_interfaces:
+                            # Get IP addresses assigned to Loopback0
+                            ip_addresses = utils.nb.ipam.ip_addresses.filter(
+                                assigned_object_id=loopback_iface.id,
+                            )
+
+                            for ip_addr in ip_addresses:
+                                if ip_addr.address:
+                                    # Extract just the IP address without prefix
+                                    ip_only = ip_addr.address.split("/")[0]
+                                    bgp_neighbors.append(
+                                        {
+                                            "ip": ip_only,
+                                            "device": connected_device,
+                                            "interface": sonic_interface_name,
+                                        }
+                                    )
+
+                    except Exception as e:
+                        logger.debug(
+                            f"Could not get Loopback0 for device {connected_device.name}: {e}"
+                        )
+                else:
+                    logger.debug(
+                        f"Skipping BGP neighbor for device {connected_device.name}: "
+                        f"missing 'managed-by-osism' tag"
+                    )
+
+    except Exception as e:
+        logger.warning(f"Could not process BGP neighbors for device {device.name}: {e}")
+
+    return bgp_neighbors

--- a/osism/tasks/conductor/sonic/sync.py
+++ b/osism/tasks/conductor/sonic/sync.py
@@ -6,7 +6,8 @@ from loguru import logger
 
 from osism import utils
 from osism.tasks.conductor.netbox import get_nb_device_query_list_sonic
-from .bgp import find_interconnected_spine_groups, calculate_minimum_as_for_group
+from .bgp import calculate_minimum_as_for_group
+from .connections import find_interconnected_devices
 from .config_generator import generate_sonic_config, clear_all_caches
 from .constants import DEFAULT_SONIC_ROLES, SUPPORTED_HWSKUS
 from .exporter import save_config_to_netbox, export_config_to_file
@@ -48,7 +49,7 @@ def sync_sonic():
     logger.info(f"Found {len(devices)} devices matching criteria")
 
     # Find interconnected spine/superspine groups for special AS calculation
-    spine_groups = find_interconnected_spine_groups(devices)
+    spine_groups = find_interconnected_devices(devices, ["spine", "superspine"])
     logger.info(f"Found {len(spine_groups)} interconnected spine/superspine groups")
 
     # Create mapping from device ID to its assigned AS number


### PR DESCRIPTION
Modernized the SONiC conductor module to use NetBox's connected_endpoints API as the primary method for detecting device connections, replacing legacy cable-based detection throughout the codebase.

Key changes:
- Added new connections.py module with centralized connection detection helpers
- Replaced all cable-based detection with connected_endpoints API calls
- Simplified BGP neighbor detection using the new unified approach
- Consolidated duplicate connection detection code across modules
- Removed backward compatibility for legacy NetBox cable API
- Removed unused interface_speed variables from connection detection

This change requires NetBox versions that support the connected_endpoints API with reachability checks. The refactoring improves code maintainability and provides consistent connection detection behavior across all SONiC functions.

AI-assisted: Claude Code