### PR TITLE
Add result caching to SONiC interface conversion function

### DIFF
--- a/osism/tasks/conductor/sonic/config_generator.py
+++ b/osism/tasks/conductor/sonic/config_generator.py
@@ -25,6 +25,7 @@ from .interface import (
     detect_breakout_ports,
     detect_port_channels,
     clear_port_config_cache,
+    clear_interface_conversion_cache,
 )
 from .connections import (
     get_connected_interfaces,
@@ -785,6 +786,7 @@ def clear_all_caches():
     """Clear all caches in config_generator module."""
     clear_ntp_cache()
     clear_port_config_cache()
+    clear_interface_conversion_cache()
     logger.debug("Cleared all config_generator caches")
 
 


### PR DESCRIPTION
Enhances convert_netbox_interface_to_sonic with result caching to avoid repeated expensive conversions for the same interface/device/HWSKU combinations, improving performance during bulk operations.

Changes:
- Add _interface_conversion_cache global cache dictionary
- Implement _generate_conversion_cache_key() for unique cache keys
- Update convert_netbox_interface_to_sonic() to check cache before processing
- Add clear_interface_conversion_cache() and get_interface_conversion_cache_stats()
- Integrate with existing clear_all_caches() function

AI-assisted: Claude Code