### PR TITLE
Add device-specific sync support to SONiC sync command

### DIFF
--- a/osism/commands/sync.py
+++ b/osism/commands/sync.py
@@ -24,6 +24,11 @@ class Sonic(Command):
     def get_parser(self, prog_name):
         parser = super(Sonic, self).get_parser(prog_name)
         parser.add_argument(
+            "device",
+            nargs="?",
+            help="Optional device name to sync configuration for a specific device",
+        )
+        parser.add_argument(
             "--no-wait",
             default=False,
             help="Do not wait until the sync has been completed",
@@ -33,14 +38,25 @@ class Sonic(Command):
 
     def take_action(self, parsed_args):
         wait = not parsed_args.no_wait
+        device_name = parsed_args.device
 
-        task = conductor.sync_sonic.delay()
+        task = conductor.sync_sonic.delay(device_name)
         if wait:
-            logger.info(
-                f"Task {task.task_id} (sync sonic) is running. Wait. No more output."
-            )
+            if device_name:
+                logger.info(
+                    f"Task {task.task_id} (sync sonic for device {device_name}) is running. Wait. No more output."
+                )
+            else:
+                logger.info(
+                    f"Task {task.task_id} (sync sonic) is running. Wait. No more output."
+                )
             task.wait(timeout=None, interval=0.5)
         else:
-            logger.info(
-                f"Task {task.task_id} (sync sonic) is running in background. No more output."
-            )
+            if device_name:
+                logger.info(
+                    f"Task {task.task_id} (sync sonic for device {device_name}) is running in background. No more output."
+                )
+            else:
+                logger.info(
+                    f"Task {task.task_id} (sync sonic) is running in background. No more output."
+                )

--- a/osism/tasks/conductor/__init__.py
+++ b/osism/tasks/conductor/__init__.py
@@ -48,8 +48,8 @@ def sync_ironic(self, force_update=False):
 
 
 @app.task(bind=True, name="osism.tasks.conductor.sync_sonic")
-def sync_sonic(self):
-    return _sync_sonic()
+def sync_sonic(self, device_name=None):
+    return _sync_sonic(device_name)
 
 
 __all__ = [


### PR DESCRIPTION
Add an optional positional argument to the SONiC sync command that allows syncing configuration for a specific device instead of all eligible devices.

- Add optional 'device' positional argument to sync sonic CLI command
- Pass device_name parameter through conductor task to sync_sonic function
- Implement device-specific lookup in sync_sonic when device_name is provided
- Add appropriate logging to indicate single device vs full sync operation

Usage:
  osism sync sonic              # Sync all eligible SONiC devices
  osism sync sonic switch01     # Sync only device 'switch01'

AI-assisted: Claude Code