### PR TITLE
Add real-time device progress output to SONiC sync command

### DIFF
--- a/osism/commands/sync.py
+++ b/osism/commands/sync.py
@@ -41,22 +41,13 @@ class Sonic(Command):
         device_name = parsed_args.device
 
         task = conductor.sync_sonic.delay(device_name)
-        if wait:
-            if device_name:
-                logger.info(
-                    f"Task {task.task_id} (sync sonic for device {device_name}) is running. Wait. No more output."
-                )
-            else:
-                logger.info(
-                    f"Task {task.task_id} (sync sonic) is running. Wait. No more output."
-                )
-            task.wait(timeout=None, interval=0.5)
+
+        if device_name:
+            logger.info(
+                f"Task {task.task_id} (sync sonic for device {device_name}) started"
+            )
         else:
-            if device_name:
-                logger.info(
-                    f"Task {task.task_id} (sync sonic for device {device_name}) is running in background. No more output."
-                )
-            else:
-                logger.info(
-                    f"Task {task.task_id} (sync sonic) is running in background. No more output."
-                )
+            logger.info(f"Task {task.task_id} (sync sonic) started")
+
+        rc = handle_task(task, wait=wait)
+        return rc

--- a/osism/tasks/conductor/__init__.py
+++ b/osism/tasks/conductor/__init__.py
@@ -49,7 +49,7 @@ def sync_ironic(self, force_update=False):
 
 @app.task(bind=True, name="osism.tasks.conductor.sync_sonic")
 def sync_sonic(self, device_name=None):
-    return _sync_sonic(device_name)
+    return _sync_sonic(device_name, self.request.id)
 
 
 __all__ = [

--- a/osism/tasks/conductor/sonic/sync.py
+++ b/osism/tasks/conductor/sonic/sync.py
@@ -14,11 +14,12 @@ from .exporter import save_config_to_netbox, export_config_to_file
 from .cache import clear_interface_cache, get_interface_cache_stats
 
 
-def sync_sonic(device_name=None):
+def sync_sonic(device_name=None, task_id=None):
     """Sync SONiC configurations for eligible devices.
 
     Args:
         device_name (str, optional): Name of specific device to sync. If None, sync all eligible devices.
+        task_id (str, optional): Task ID for output logging.
 
     Returns:
         dict: Dictionary with device names as keys and their SONiC configs as values
@@ -115,6 +116,10 @@ def sync_sonic(device_name=None):
 
         logger.debug(f"Processing device: {device.name} with HWSKU: {hwsku}")
 
+        # Output current device being processed if task_id is available
+        if task_id:
+            utils.push_task_output(task_id, f"Processing device: {device.name}\n")
+
         # Validate that HWSKU is supported
         if hwsku not in SUPPORTED_HWSKUS:
             logger.warning(
@@ -155,6 +160,10 @@ def sync_sonic(device_name=None):
     clear_interface_cache()
     clear_all_caches()
     logger.debug("Cleared all caches after sync_sonic task completion")
+
+    # Finish task output if task_id is available
+    if task_id:
+        utils.finish_task_output(task_id, rc=0)
 
     # Return the dictionary with all device configurations
     return device_configs


### PR DESCRIPTION
Enhance the SONiC sync command to display which device is currently being processed during synchronization, providing better visibility into the sync progress.

- Add task_id parameter to sync_sonic function for output handling
- Use push_task_output to display currently processed device
- Replace manual wait logic with handle_task for consistent output handling
- Add finish_task_output to properly close the output stream

This change improves user experience by showing real-time progress when syncing multiple SONiC devices, making it clear which device is being processed at any given time.

AI-assisted: Claude Code