### PR TITLE
Add manage command aliases for ironic and sonic sync

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -80,6 +80,8 @@ osism.commands:
     manage baremetal list = osism.commands.baremetal:BaremetalList
     manage baremetal deploy = osism.commands.baremetal:BaremetalDeploy
     manage baremetal undeploy = osism.commands.baremetal:BaremetalUndeploy
+    manage ironic = osism.commands.netbox:Ironic
+    manage sonic = osism.commands.sync:Sonic
     netbox = osism.commands.netbox:Console
     get versions netbox = osism.commands.netbox:Versions
     noset bootstrap = osism.commands.noset:NoBootstrap


### PR DESCRIPTION
- Add 'manage ironic' as alias for 'sync ironic'
- Add 'manage sonic' as alias for 'sync sonic'

This provides consistency with other manage subcommands and offers an alternative way to invoke these sync operations.