### PR TITLE
Add manage dnsmasq command

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -73,6 +73,7 @@ osism.commands:
     manage compute start = osism.commands.compute:ComputeStart
     manage compute stop = osism.commands.compute:ComputeStop
     manage images = osism.commands.manage:Images
+    manage dnsmasq = osism.commands.manage:Dnsmasq
     manage netbox = osism.commands.netbox:Manage
     manage server list = osism.commands.server:ServerList
     manage server migrate = osism.commands.server:ServerMigrate
@@ -94,6 +95,7 @@ osism.commands:
     set maintenance = osism.commands.set:Maintenance
     set vault password = osism.commands.vault:SetPassword
     sync configuration = osism.commands.configuration:Sync
+    sync dnsmasq = osism.commands.manage:Dnsmasq
     sync facts = osism.commands.sync:Facts
     sync inventory = osism.commands.reconciler:Sync
     sync ironic = osism.commands.netbox:Ironic


### PR DESCRIPTION
Adds a new 'manage dnsmasq' command that provides the same functionality as 'apply dnsmasq'. The command executes the dnsmasq role in the infrastructure environment using the Ansible task runner.

AI-assisted: Claude Code