### PR TITLE
Fix SONiC peer type detection for single device configuration

### DIFF
--- a/osism/tasks/conductor/sonic/connections.py
+++ b/osism/tasks/conductor/sonic/connections.py
@@ -48,6 +48,16 @@ def get_connected_device_via_interface(
         for endpoint in interface.connected_endpoints:
             # Get the connected device from the endpoint
             if hasattr(endpoint, "device") and endpoint.device.id != source_device_id:
+                # Fetch the full device object to ensure all fields are populated
+                try:
+                    full_device = utils.nb.dcim.devices.get(id=endpoint.device.id)
+                    if full_device:
+                        return full_device
+                except Exception as fetch_error:
+                    logger.debug(
+                        f"Could not fetch full device for endpoint {endpoint}: {fetch_error}"
+                    )
+                # Fallback to partial device object if fetch fails
                 return endpoint.device
     except Exception as e:
         logger.debug(


### PR DESCRIPTION
When generating SONiC configuration for a single device, the connected device objects returned by the NetBox API may not have all fields populated, particularly the primary_ip4 attribute needed for AS number calculation.

This fix ensures that when a connected device lacks primary IP information, the full device object is fetched from NetBox to obtain the complete data required for proper BGP peer type determination (internal vs external).

AI-assisted: Claude Code