### PR TITLE
Fix SONiC interface to alias conversion using port config

### DIFF
--- a/osism/tasks/conductor/sonic/config_generator.py
+++ b/osism/tasks/conductor/sonic/config_generator.py
@@ -305,7 +305,7 @@ def _add_port_configurations(
         interface_speed = int(port_speed) if port_speed else None
         is_breakout_port = port_name in breakout_info["breakout_ports"]
         correct_alias = convert_sonic_interface_to_alias(
-            port_name, interface_speed, is_breakout_port
+            port_name, interface_speed, is_breakout_port, port_config
         )
 
         # Use master port index for breakout ports
@@ -457,7 +457,7 @@ def _add_missing_breakout_ports(
             # Generate correct alias (breakout port always gets subport notation)
             interface_speed = int(port_speed)
             correct_alias = convert_sonic_interface_to_alias(
-                port_name, interface_speed, is_breakout=True
+                port_name, interface_speed, is_breakout=True, port_config=port_config
             )
 
             # Use master port index for breakout ports


### PR DESCRIPTION
The convert_sonic_interface_to_alias function now correctly determines the sonic_port_number from the port config alias instead of directly from the interface name. This fixes breakout port alias generation where the base port must be found from the port config.

Key changes:
- Add port_config parameter to convert_sonic_interface_to_alias
- Implement _convert_using_port_config for alias-based conversion
- Add _find_base_port_for_breakout to find base port for breakout interfaces
- Add _extract_port_number_from_alias to extract port number from alias
- Maintain backward compatibility with legacy speed-based calculation as fallback
- Update function calls in config_generator.py to pass port_config

AI-assisted: Claude Code