### PR TITLE
Add --flush-cache parameter to osism sync inventory command

### DIFF
--- a/osism/commands/reconciler.py
+++ b/osism/commands/reconciler.py
@@ -38,13 +38,20 @@ class Sync(Command):
             type=int,
             help="Timeout for a scheduled task that has not been executed yet",
         )
+        parser.add_argument(
+            "--flush-cache",
+            default=False,
+            help="Flush cache before running sync",
+            action="store_true",
+        )
         return parser
 
     def take_action(self, parsed_args):
         wait = not parsed_args.no_wait
         task_timeout = parsed_args.task_timeout
+        flush_cache = parsed_args.flush_cache
 
-        t = reconciler.run.delay(publish=wait)
+        t = reconciler.run.delay(publish=wait, flush_cache=flush_cache)
         if wait:
             logger.info(
                 f"Task {t.task_id} (sync inventory) is running in background. Output coming soon."


### PR DESCRIPTION
- Add --flush-cache CLI parameter to sync inventory command
- Pass flush_cache parameter from command to reconciler task
- Set FLUSH_CACHE=true environment variable when parameter is used
- Allows forcing cache flush during inventory synchronization

AI-assisted: Claude Code