### PR TITLE
Fix TypeError in switches_ztp_complete by converting RecordSet to list

### DIFF
--- a/osism/api.py
+++ b/osism/api.py
@@ -114,19 +114,19 @@ async def switches_ztp_complete(identifier: str):
     # Search by device name
     devices = utils.nb.dcim.devices.filter(name=identifier)
     if devices:
-        device = devices[0]
+        device = list(devices)[0]
 
     # Search by inventory_hostname custom field
     if not device:
         devices = utils.nb.dcim.devices.filter(cf_inventory_hostname=identifier)
         if devices:
-            device = devices[0]
+            device = list(devices)[0]
 
     # Search by serial number
     if not device:
         devices = utils.nb.dcim.devices.filter(serial=identifier)
         if devices:
-            device = devices[0]
+            device = list(devices)[0]
 
     if device:
         logger.info(


### PR DESCRIPTION
NetBox API filter() returns RecordSet objects that don't support direct indexing. Convert to list before accessing first element to prevent "'RecordSet' object is not subscriptable" error.

AI-assisted: Claude Code