### PR TITLE
Add manage redfish list command to support Redfish API operations

### DIFF
--- a/osism/commands/redfish.py
+++ b/osism/commands/redfish.py
@@ -1,0 +1,87 @@
+# SPDX-License-Identifier: Apache-2.0
+
+from cliff.command import Command
+from loguru import logger
+from tabulate import tabulate
+
+from osism.tasks.conductor import get_redfish_resources
+
+
+class List(Command):
+    def get_parser(self, prog_name):
+        parser = super(List, self).get_parser(prog_name)
+        parser.add_argument(
+            "hostname",
+            type=str,
+            help="Hostname of the target system",
+        )
+        parser.add_argument(
+            "resourcetype",
+            type=str,
+            help="Resource type to process (e.g., EthernetInterfaces)",
+        )
+        return parser
+
+    def take_action(self, parsed_args):
+        hostname = parsed_args.hostname
+        resourcetype = parsed_args.resourcetype
+        logger.info(
+            f"Redfish list command called with hostname: {hostname}, resourcetype: {resourcetype}"
+        )
+
+        # Use Celery task to get Redfish resources
+        task_result = get_redfish_resources.delay(hostname, resourcetype)
+        result = task_result.get()
+
+        if resourcetype == "EthernetInterfaces" and result:
+            self._display_ethernet_interfaces(result)
+        elif result:
+            logger.info(f"Retrieved resources: {result}")
+        else:
+            print(f"No {resourcetype} resources found for {hostname}")
+
+    def _display_ethernet_interfaces(self, interfaces):
+        """Display EthernetInterfaces in a formatted table."""
+        if not interfaces:
+            print("No EthernetInterfaces found")
+            return
+
+        # Prepare table data with specified columns
+        table_data = []
+        headers = [
+            "ID",
+            "Name",
+            "Permanent MAC",
+            "Speed (Mbps)",
+            "Status",
+            "Link Status",
+        ]
+
+        for interface in interfaces:
+            # Extract values with fallbacks for missing data
+            row = [
+                interface.get("id", "N/A"),
+                interface.get("name", "N/A"),
+                interface.get("permanent_mac_address", "N/A"),
+                interface.get("speed_mbps", "N/A"),
+                self._format_status(interface.get("status")),
+                interface.get("link_status", "N/A"),
+            ]
+            table_data.append(row)
+
+        # Display the table
+        print(tabulate(table_data, headers=headers, tablefmt="grid"))
+        print(f"\nTotal EthernetInterfaces: {len(interfaces)}")
+
+    def _format_status(self, status):
+        """Format status object for display."""
+        if not status:
+            return "N/A"
+
+        if isinstance(status, dict):
+            # Extract relevant status information
+            state = status.get("state", "Unknown")
+            health = status.get("health", "Unknown")
+            return f"{state}/{health}"
+
+        return str(status)

--- a/osism/settings.py
+++ b/osism/settings.py
@@ -54,3 +54,6 @@ SONIC_EXPORT_IDENTIFIER = os.getenv("SONIC_EXPORT_IDENTIFIER", "serial-number")
 NETBOX_SECONDARIES = (
     os.getenv("NETBOX_SECONDARIES", read_secret("NETBOX_SECONDARIES")) or "[]"
 )
+
+# Redfish connection timeout in seconds
+REDFISH_TIMEOUT = int(os.getenv("REDFISH_TIMEOUT", "20"))

--- a/osism/tasks/conductor/__init__.py
+++ b/osism/tasks/conductor/__init__.py
@@ -8,6 +8,7 @@ from loguru import logger
 from osism.tasks import Config
 from osism.tasks.conductor.config import get_configuration
 from osism.tasks.conductor.ironic import sync_ironic as _sync_ironic
+from osism.tasks.conductor.redfish import get_resources as _get_redfish_resources
 from osism.tasks.conductor.sonic import sync_sonic as _sync_sonic
 
 
@@ -52,9 +53,15 @@ def sync_sonic(self, device_name=None, show_diff=True):
     return _sync_sonic(device_name, self.request.id, show_diff)
 
 
+@app.task(bind=True, name="osism.tasks.conductor.get_redfish_resources")
+def get_redfish_resources(self, hostname, resource_type):
+    return _get_redfish_resources(hostname, resource_type)
+
+
 __all__ = [
     "app",
     "get_ironic_parameters",
+    "get_redfish_resources",
     "sync_netbox",
     "sync_ironic",
     "sync_sonic",

--- a/osism/tasks/conductor/config.py
+++ b/osism/tasks/conductor/config.py
@@ -41,9 +41,12 @@ def get_configuration():
                 ]
                 if not is_uuid(image_source):
                     result = openstack.image_get(image_source)
-                    configuration["ironic_parameters"]["instance_info"][
-                        "image_source"
-                    ] = result.id
+                    if result:
+                        configuration["ironic_parameters"]["instance_info"][
+                            "image_source"
+                        ] = result.id
+                    else:
+                        logger.warning(f"Could not resolve image ID for {image_source}")
 
         if "driver_info" in configuration["ironic_parameters"]:
             if "deploy_kernel" in configuration["ironic_parameters"]["driver_info"]:
@@ -52,9 +55,14 @@ def get_configuration():
                 ]
                 if not is_uuid(deploy_kernel):
                     result = openstack.image_get(deploy_kernel)
-                    configuration["ironic_parameters"]["driver_info"][
-                        "deploy_kernel"
-                    ] = result.id
+                    if result:
+                        configuration["ironic_parameters"]["driver_info"][
+                            "deploy_kernel"
+                        ] = result.id
+                    else:
+                        logger.warning(
+                            f"Could not resolve image ID for {deploy_kernel}"
+                        )
 
             if "deploy_ramdisk" in configuration["ironic_parameters"]["driver_info"]:
                 deploy_ramdisk = configuration["ironic_parameters"]["driver_info"][
@@ -62,31 +70,44 @@ def get_configuration():
                 ]
                 if not is_uuid(deploy_ramdisk):
                     result = openstack.image_get(deploy_ramdisk)
-                    configuration["ironic_parameters"]["driver_info"][
-                        "deploy_ramdisk"
-                    ] = result.id
+                    if result:
+                        configuration["ironic_parameters"]["driver_info"][
+                            "deploy_ramdisk"
+                        ] = result.id
+                    else:
+                        logger.warning(
+                            f"Could not resolve image ID for {deploy_ramdisk}"
+                        )
 
             if "cleaning_network" in configuration["ironic_parameters"]["driver_info"]:
-                result = openstack.network_get(
+                cleaning_network = configuration["ironic_parameters"]["driver_info"][
+                    "cleaning_network"
+                ]
+                result = openstack.network_get(cleaning_network)
+                if result:
                     configuration["ironic_parameters"]["driver_info"][
                         "cleaning_network"
-                    ]
-                )
-                configuration["ironic_parameters"]["driver_info"][
-                    "cleaning_network"
-                ] = result.id
+                    ] = result.id
+                else:
+                    logger.warning(
+                        f"Could not resolve network ID for {cleaning_network}"
+                    )
 
             if (
                 "provisioning_network"
                 in configuration["ironic_parameters"]["driver_info"]
             ):
-                result = openstack.network_get(
+                provisioning_network = configuration["ironic_parameters"][
+                    "driver_info"
+                ]["provisioning_network"]
+                result = openstack.network_get(provisioning_network)
+                if result:
                     configuration["ironic_parameters"]["driver_info"][
                         "provisioning_network"
-                    ]
-                )
-                configuration["ironic_parameters"]["driver_info"][
-                    "provisioning_network"
-                ] = result.id
+                    ] = result.id
+                else:
+                    logger.warning(
+                        f"Could not resolve network ID for {provisioning_network}"
+                    )
 
         return configuration

--- a/osism/tasks/conductor/redfish.py
+++ b/osism/tasks/conductor/redfish.py
@@ -1,0 +1,103 @@
+# SPDX-License-Identifier: Apache-2.0
+
+from loguru import logger
+from osism.tasks.conductor.utils import get_redfish_connection
+
+
+def get_resources(hostname, resource_type):
+    """
+    Get Redfish resources for a specific hostname and resource type.
+
+    Args:
+        hostname (str): The hostname of the target system
+        resource_type (str): The type of resource to retrieve (e.g., EthernetInterfaces)
+
+    Returns:
+        list: Retrieved Redfish resources or empty list if failed
+    """
+    logger.info(
+        f"Getting Redfish resources for hostname: {hostname}, resource_type: {resource_type}"
+    )
+
+    if resource_type == "EthernetInterfaces":
+        return _get_ethernet_interfaces(hostname)
+
+    logger.warning(f"Resource type {resource_type} not supported yet")
+    return []
+
+
+def _get_ethernet_interfaces(hostname):
+    """
+    Get all EthernetInterfaces from a Redfish-enabled system.
+
+    Args:
+        hostname (str): The hostname of the target system
+
+    Returns:
+        list: List of EthernetInterface dictionaries
+    """
+    try:
+        # Get Redfish connection using the utility function
+        redfish_conn = get_redfish_connection(hostname, ignore_ssl_errors=True)
+
+        if not redfish_conn:
+            logger.error(f"Could not establish Redfish connection to {hostname}")
+            return []
+
+        ethernet_interfaces = []
+
+        # Navigate through the Redfish service to find EthernetInterfaces
+        # Structure: /redfish/v1/Systems/{system_id}/EthernetInterfaces
+        for system in redfish_conn.get_system_collection().get_members():
+            logger.debug(f"Processing system: {system.identity}")
+
+            # Check if the system has EthernetInterfaces
+            if hasattr(system, "ethernet_interfaces") and system.ethernet_interfaces:
+                for interface in system.ethernet_interfaces.get_members():
+                    try:
+                        # Extract relevant information from each EthernetInterface
+                        interface_data = {
+                            "id": interface.identity,
+                            "name": getattr(interface, "name", None),
+                            "description": getattr(interface, "description", None),
+                            "mac_address": getattr(interface, "mac_address", None),
+                            "permanent_mac_address": getattr(
+                                interface, "permanent_mac_address", None
+                            ),
+                            "speed_mbps": getattr(interface, "speed_mbps", None),
+                            "full_duplex": getattr(interface, "full_duplex", None),
+                            "mtu_size": getattr(interface, "mtu_size", None),
+                            "status": getattr(interface, "status", None),
+                            "link_status": getattr(interface, "link_status", None),
+                            "interface_enabled": getattr(
+                                interface, "interface_enabled", None
+                            ),
+                            "auto_neg": getattr(interface, "auto_neg", None),
+                            "vlan": getattr(interface, "vlan", None),
+                            "vlans": getattr(interface, "vlans", None),
+                        }
+
+                        # Clean up None values
+                        interface_data = {
+                            k: v for k, v in interface_data.items() if v is not None
+                        }
+
+                        ethernet_interfaces.append(interface_data)
+                        logger.debug(
+                            f"Found EthernetInterface: {interface_data.get('name', interface_data.get('id'))}"
+                        )
+
+                    except Exception as exc:
+                        logger.warning(
+                            f"Error processing EthernetInterface {interface.identity}: {exc}"
+                        )
+                        continue
+
+        logger.info(
+            f"Retrieved {len(ethernet_interfaces)} EthernetInterfaces from {hostname}"
+        )
+        return ethernet_interfaces
+
+    except Exception as exc:
+        logger.error(f"Error retrieving EthernetInterfaces from {hostname}: {exc}")
+        return []

--- a/osism/tasks/conductor/utils.py
+++ b/osism/tasks/conductor/utils.py
@@ -5,6 +5,8 @@ from ansible.parsing.vault import VaultLib, VaultSecret
 from loguru import logger
 
 from osism import utils
+import sushy
+import urllib3
 
 
 def deep_compare(a, b, updates):
@@ -77,3 +79,149 @@ def get_vault():
         logger.error("Unable to get vault secret. Dropping encrypted entries")
         vault = VaultLib()
     return vault
+
+
+def get_redfish_connection(
+    hostname, username=None, password=None, ignore_ssl_errors=True, timeout=None
+):
+    """Create a Redfish connection to the specified hostname."""
+    from osism import settings
+    from osism.tasks import openstack
+
+    if not hostname:
+        return None
+
+    # Use configurable timeout if not provided
+    if timeout is None:
+        timeout = settings.REDFISH_TIMEOUT
+
+    # Get Redfish address from Ironic driver_info
+    base_url = f"https://{hostname}"
+    device = None
+
+    # Try to find NetBox device first for conductor configuration fallback
+    if utils.nb:
+        try:
+            # First try to find device by name
+            device = utils.nb.dcim.devices.get(name=hostname)
+
+            # If not found by name, try by inventory_hostname custom field
+            if not device:
+                devices = utils.nb.dcim.devices.filter(cf_inventory_hostname=hostname)
+                if devices:
+                    device = devices[0]
+        except Exception as exc:
+            logger.warning(f"Could not resolve hostname {hostname} via NetBox: {exc}")
+
+    try:
+        ironic_node = openstack.baremetal_node_show(hostname, ignore_missing=True)
+        if ironic_node and "driver_info" in ironic_node:
+            driver_info = ironic_node["driver_info"]
+            # Use redfish_address from driver_info if available (contains full URL)
+            if "redfish_address" in driver_info:
+                base_url = driver_info["redfish_address"]
+                logger.info(f"Using Ironic redfish_address {base_url} for {hostname}")
+        else:
+            # Fallback to conductor configuration if Ironic driver_info not available
+            conductor_address = _get_conductor_redfish_address(device)
+            if conductor_address:
+                base_url = conductor_address
+                logger.info(
+                    f"Using conductor redfish_address {base_url} for {hostname}"
+                )
+    except Exception as exc:
+        logger.warning(f"Could not get Ironic node for {hostname}: {exc}")
+        # Fallback to conductor configuration on Ironic error
+        conductor_address = _get_conductor_redfish_address(device)
+        if conductor_address:
+            base_url = conductor_address
+            logger.info(f"Using conductor redfish_address {base_url} for {hostname}")
+
+    # Get credentials from conductor configuration if not provided
+    if not username or not password:
+        conductor_username, conductor_password = _get_conductor_redfish_credentials(
+            device
+        )
+        if not username:
+            username = conductor_username
+        if not password:
+            password = conductor_password
+
+    auth = sushy.auth.SessionOrBasicAuth(username=username, password=password)
+
+    try:
+        if ignore_ssl_errors:
+            urllib3.disable_warnings()
+            conn = sushy.Sushy(base_url, auth=auth, verify=False)
+        else:
+            conn = sushy.Sushy(base_url, auth=auth)
+
+        return conn
+    except Exception as exc:
+        logger.error(
+            f"Unable to connect to Redfish API at {base_url} with timeout {timeout}s: {exc}"
+        )
+        return None
+
+
+def _get_conductor_redfish_credentials(device):
+    """Get Redfish credentials from conductor configuration and device secrets."""
+    from osism.tasks.conductor.config import get_configuration
+    from osism.tasks.conductor.ironic import _prepare_node_attributes
+
+    try:
+        if not device:
+            return None, None
+
+        # Use _prepare_node_attributes to get processed node attributes
+        def get_ironic_parameters():
+            configuration = get_configuration()
+            return configuration.get("ironic_parameters", {})
+
+        node_attributes = _prepare_node_attributes(device, get_ironic_parameters)
+
+        # Extract Redfish credentials if available
+        if (
+            "driver_info" in node_attributes
+            and node_attributes.get("driver") == "redfish"
+        ):
+            driver_info = node_attributes["driver_info"]
+            username = driver_info.get("redfish_username")
+            password = driver_info.get("redfish_password")
+            return username, password
+
+    except Exception as exc:
+        logger.warning(f"Could not get conductor Redfish credentials: {exc}")
+
+    return None, None
+
+
+def _get_conductor_redfish_address(device):
+    """Get Redfish address from conductor configuration and device OOB IP."""
+    from osism.tasks.conductor.config import get_configuration
+    from osism.tasks.conductor.ironic import _prepare_node_attributes
+
+    try:
+        if not device:
+            return None
+
+        # Use _prepare_node_attributes to get processed node attributes
+        def get_ironic_parameters():
+            configuration = get_configuration()
+            return configuration.get("ironic_parameters", {})
+
+        node_attributes = _prepare_node_attributes(device, get_ironic_parameters)
+
+        # Extract Redfish address if available
+        if (
+            "driver_info" in node_attributes
+            and node_attributes.get("driver") == "redfish"
+        ):
+            driver_info = node_attributes["driver_info"]
+            address = driver_info.get("redfish_address")
+            return address
+
+    except Exception as exc:
+        logger.warning(f"Could not get conductor Redfish address: {exc}")
+
+    return None

--- a/setup.cfg
+++ b/setup.cfg
@@ -76,6 +76,7 @@ osism.commands:
     manage dnsmasq = osism.commands.manage:Dnsmasq
     manage netbox = osism.commands.netbox:Manage
     manage sonic = osism.commands.manage:Sonic
+    manage redfish list = osism.commands.redfish:List
     manage server list = osism.commands.server:ServerList
     manage server migrate = osism.commands.server:ServerMigrate
     manage volume list = osism.commands.volume:VolumeList


### PR DESCRIPTION
This adds a new command 'osism manage redfish list <resourcetype>' that accepts a resource type parameter (e.g., EthernetInterfaces) for future Redfish API integration. The command structure follows existing patterns and is registered in setup.cfg for CLI availability.

AI-assisted: Claude Code