### PR TITLE
Add NetworkAdapters support to osism manage redfish list command

### DIFF
--- a/osism/commands/redfish.py
+++ b/osism/commands/redfish.py
@@ -18,7 +18,7 @@ class List(Command):
         parser.add_argument(
             "resourcetype",
             type=str,
-            help="Resource type to process (e.g., EthernetInterfaces)",
+            help="Resource type to process (e.g., EthernetInterfaces, NetworkAdapters)",
         )
         return parser
 
@@ -35,6 +35,8 @@ class List(Command):
 
         if resourcetype == "EthernetInterfaces" and result:
             self._display_ethernet_interfaces(result)
+        elif resourcetype == "NetworkAdapters" and result:
+            self._display_network_adapters(result)
         elif result:
             logger.info(f"Retrieved resources: {result}")
         else:
@@ -72,3 +74,54 @@ class List(Command):
         # Display the table
         print(tabulate(table_data, headers=headers, tablefmt="grid"))
         print(f"\nTotal EthernetInterfaces: {len(interfaces)}")
+
+    def _display_network_adapters(self, adapters):
+        """Display NetworkAdapters in a formatted table."""
+        if not adapters:
+            print("No NetworkAdapters found")
+            return
+
+        # Prepare table data with specified columns
+        table_data = []
+        headers = [
+            "ID",
+            "Name",
+            "Manufacturer",
+            "Model",
+            "Part Number",
+            "Serial Number",
+            "Firmware Version",
+            "Status",
+        ]
+
+        for adapter in adapters:
+            # Extract values with fallbacks for missing data
+            status_str = "N/A"
+            if adapter.get("status"):
+                status_data = adapter.get("status")
+                if isinstance(status_data, str):
+                    try:
+                        import json
+
+                        status_dict = json.loads(status_data)
+                        status_str = status_dict.get("Health", "N/A")
+                    except (json.JSONDecodeError, AttributeError):
+                        status_str = status_data
+                elif isinstance(status_data, dict):
+                    status_str = status_data.get("Health", "N/A")
+
+            row = [
+                adapter.get("id", "N/A"),
+                adapter.get("name", "N/A"),
+                adapter.get("manufacturer", "N/A"),
+                adapter.get("model", "N/A"),
+                adapter.get("part_number", "N/A"),
+                adapter.get("serial_number", "N/A"),
+                adapter.get("firmware_version", "N/A"),
+                status_str,
+            ]
+            table_data.append(row)
+
+        # Display the table
+        print(tabulate(table_data, headers=headers, tablefmt="grid"))
+        print(f"\nTotal NetworkAdapters: {len(adapters)}")

--- a/osism/tasks/conductor/redfish.py
+++ b/osism/tasks/conductor/redfish.py
@@ -1,7 +1,38 @@
 # SPDX-License-Identifier: Apache-2.0
 
+import json
 from loguru import logger
 from osism.tasks.conductor.utils import get_redfish_connection
+
+
+def _normalize_redfish_data(data):
+    """
+    Convert Redfish data values to strings and clean up None values.
+
+    Args:
+        data (dict): Dictionary with Redfish resource data
+
+    Returns:
+        dict: Dictionary with normalized string values, None values removed
+    """
+    normalized_data = {}
+
+    for key, value in data.items():
+        if value is not None:
+            if isinstance(value, (dict, list)):
+                # Convert complex objects to JSON strings
+                normalized_data[key] = json.dumps(value)
+            elif isinstance(value, bool):
+                # Convert booleans to lowercase strings
+                normalized_data[key] = str(value).lower()
+            elif not isinstance(value, str):
+                # Convert numbers and other types to strings
+                normalized_data[key] = str(value)
+            else:
+                # Keep strings as-is
+                normalized_data[key] = value
+
+    return normalized_data
 
 
 def get_resources(hostname, resource_type):
@@ -21,6 +52,8 @@ def get_resources(hostname, resource_type):
 
     if resource_type == "EthernetInterfaces":
         return _get_ethernet_interfaces(hostname)
+    elif resource_type == "NetworkAdapters":
+        return _get_network_adapters(hostname)
 
     logger.warning(f"Resource type {resource_type} not supported yet")
     return []
@@ -73,25 +106,8 @@ def _get_ethernet_interfaces(hostname):
                             ),
                         }
 
-                        # Convert all values to strings
-                        for key, value in interface_data.items():
-                            if value is not None:
-                                if isinstance(value, (dict, list)):
-                                    # Convert complex objects to JSON strings
-                                    import json
-
-                                    interface_data[key] = json.dumps(value)
-                                elif isinstance(value, bool):
-                                    # Convert booleans to lowercase strings
-                                    interface_data[key] = str(value).lower()
-                                elif not isinstance(value, str):
-                                    # Convert numbers and other types to strings
-                                    interface_data[key] = str(value)
-
-                        # Clean up None values
-                        interface_data = {
-                            k: v for k, v in interface_data.items() if v is not None
-                        }
+                        # Normalize data values to strings and clean up None values
+                        interface_data = _normalize_redfish_data(interface_data)
 
                         ethernet_interfaces.append(interface_data)
                         logger.debug(
@@ -111,4 +127,72 @@ def _get_ethernet_interfaces(hostname):
 
     except Exception as exc:
         logger.error(f"Error retrieving EthernetInterfaces from {hostname}: {exc}")
+        return []
+
+
+def _get_network_adapters(hostname):
+    """
+    Get all NetworkAdapters from a Redfish-enabled system.
+
+    Args:
+        hostname (str): The hostname of the target system
+
+    Returns:
+        list: List of NetworkAdapter dictionaries
+    """
+    try:
+        # Get Redfish connection using the utility function
+        redfish_conn = get_redfish_connection(hostname, ignore_ssl_errors=True)
+
+        if not redfish_conn:
+            logger.error(f"Could not establish Redfish connection to {hostname}")
+            return []
+
+        network_adapters = []
+
+        # Navigate through the Redfish service to find NetworkAdapters
+        # Structure: /redfish/v1/Chassis/{chassis_id}/NetworkAdapters
+        for chassis in redfish_conn.get_chassis_collection().get_members():
+            logger.debug(f"Processing chassis: {chassis.identity}")
+
+            # Check if the chassis has NetworkAdapters
+            if hasattr(chassis, "network_adapters") and chassis.network_adapters:
+                for adapter in chassis.network_adapters.get_members():
+                    try:
+                        # Extract relevant information from each NetworkAdapter
+                        adapter_data = {
+                            "id": adapter.identity,
+                            "name": getattr(adapter, "name", None),
+                            "description": getattr(adapter, "description", None),
+                            "manufacturer": getattr(adapter, "manufacturer", None),
+                            "model": getattr(adapter, "model", None),
+                            "part_number": getattr(adapter, "part_number", None),
+                            "serial_number": getattr(adapter, "serial_number", None),
+                            "firmware_version": getattr(
+                                adapter, "firmware_version", None
+                            ),
+                            "status": getattr(adapter, "status", None),
+                        }
+
+                        # Normalize data values to strings and clean up None values
+                        adapter_data = _normalize_redfish_data(adapter_data)
+
+                        network_adapters.append(adapter_data)
+                        logger.debug(
+                            f"Found NetworkAdapter: {adapter_data.get('name', adapter_data.get('id'))}"
+                        )
+
+                    except Exception as exc:
+                        logger.warning(
+                            f"Error processing NetworkAdapter {adapter.identity}: {exc}"
+                        )
+                        continue
+
+        logger.info(
+            f"Retrieved {len(network_adapters)} NetworkAdapters from {hostname}"
+        )
+        return network_adapters
+
+    except Exception as exc:
+        logger.error(f"Error retrieving NetworkAdapters from {hostname}: {exc}")
         return []


### PR DESCRIPTION
Extends the redfish list functionality to support NetworkAdapters resource type alongside existing EthernetInterfaces support. Adds comprehensive adapter information display including manufacturer, model, part number, serial number, firmware version, and health status.

AI-assisted: Claude Code