### PR TITLE
Centralize Redlock creation with output suppression

### DIFF
--- a/osism/tasks/__init__.py
+++ b/osism/tasks/__init__.py
@@ -1,12 +1,10 @@
 # SPDX-License-Identifier: Apache-2.0
 
-import logging
 import os
 import re
 import subprocess
 
 from loguru import logger
-from pottery import Redlock
 
 from osism import utils
 
@@ -77,10 +75,8 @@ def run_ansible_in_environment(
 
     # NOTE: Consider arguments in the future
     if locking:
-        logging.getLogger("redlock").setLevel(logging.WARNING)
-        lock = Redlock(
+        lock = utils.create_redlock(
             key=f"lock-ansible-{environment}-{role}",
-            masters={utils.redis},
             auto_release_time=auto_release_time,
         )
 
@@ -195,9 +191,8 @@ def run_command(
         command_env.update(env)
 
     if locking:
-        lock = Redlock(
+        lock = utils.create_redlock(
             key=f"lock-{command}",
-            masters={utils.redis},
             auto_release_time=auto_release_time,
         )
 

--- a/osism/tasks/ansible.py
+++ b/osism/tasks/ansible.py
@@ -1,7 +1,6 @@
 # SPDX-License-Identifier: Apache-2.0
 
 from celery import Celery
-from pottery import Redlock
 
 from osism import settings, utils
 from osism.tasks import Config, run_ansible_in_environment
@@ -12,9 +11,8 @@ app.config_from_object(Config)
 
 @app.on_after_configure.connect
 def setup_periodic_tasks(sender, **kwargs):
-    lock = Redlock(
+    lock = utils.create_redlock(
         key="lock_osism_tasks_ansible_setup_periodic_tasks",
-        masters={utils.redis},
     )
     if settings.GATHER_FACTS_SCHEDULE > 0 and lock.acquire(timeout=10):
         sender.add_periodic_task(

--- a/osism/tasks/conductor/ironic.py
+++ b/osism/tasks/conductor/ironic.py
@@ -3,7 +3,6 @@
 import json
 
 import jinja2
-from pottery import Redlock
 
 from osism import utils as osism_utils
 from osism.tasks import netbox, openstack
@@ -180,9 +179,8 @@ def sync_ironic(request_id, get_ironic_parameters, force_update=False):
             if interface.enabled and not interface.mgmt_only and interface.mac_address
         ]
 
-        lock = Redlock(
+        lock = osism_utils.create_redlock(
             key=f"lock_osism_tasks_conductor_sync_ironic-{device.name}",
-            masters={osism_utils.redis},
             auto_release_time=600,
         )
         if lock.acquire(timeout=120):

--- a/osism/tasks/netbox.py
+++ b/osism/tasks/netbox.py
@@ -2,7 +2,6 @@
 
 from celery import Celery
 from loguru import logger
-from pottery import Redlock
 
 from osism import settings, utils
 from osism.tasks import Config, run_command
@@ -30,9 +29,8 @@ def run(self, action, arguments):
 def set_maintenance(self, device_name, state=True):
     """Set the maintenance state for a device in the NetBox."""
 
-    lock = Redlock(
+    lock = utils.create_redlock(
         key=f"lock_osism_tasks_netbox_set_maintenance_{device_name}",
-        masters={utils.redis},
         auto_release_time=60,
     )
     if lock.acquire(timeout=20):
@@ -59,9 +57,8 @@ def set_maintenance(self, device_name, state=True):
 def set_provision_state(self, device_name, state):
     """Set the provision state for a device in the NetBox."""
 
-    lock = Redlock(
+    lock = utils.create_redlock(
         key=f"lock_osism_tasks_netbox_set_provision_state_{device_name}",
-        masters={utils.redis},
         auto_release_time=60,
     )
     if lock.acquire(timeout=20):
@@ -89,9 +86,8 @@ def set_provision_state(self, device_name, state):
 def set_power_state(self, device_name, state):
     """Set the provision state for a device in the NetBox."""
 
-    lock = Redlock(
+    lock = utils.create_redlock(
         key=f"lock_osism_tasks_netbox_set_provision_state_{device_name}",
-        masters={utils.redis},
         auto_release_time=60,
     )
     if lock.acquire(timeout=20):


### PR DESCRIPTION
Move Redlock instantiation to a central utils.create_redlock() method that suppresses initialization output using redirect_stdout/stderr with os.devnull. This eliminates redundant code and ensures consistent output handling across all Redlock usage in the codebase.

Changes:
- Add create_redlock() utility function in osism/utils/__init__.py
- Update all Redlock instantiations to use the central method
- Remove direct pottery.Redlock imports from task modules
- Clean up unused logging configuration for redlock

AI-assisted: Claude Code