### PR TITLE
Refactor sonic commands into load and reload subcommands

### DIFF
--- a/osism/commands/sonic.py
+++ b/osism/commands/sonic.py
@@ -11,227 +11,384 @@ import paramiko
 from osism import utils
 
 
-class Manage(Command):
+class SonicCommandBase(Command):
+    """Base class for SONiC commands with common functionality"""
+
+    def _get_device_from_netbox(self, hostname):
+        """Get device from NetBox by name or inventory_hostname"""
+        device = utils.nb.dcim.devices.get(name=hostname)
+        if not device:
+            devices = utils.nb.dcim.devices.filter(cf_inventory_hostname=hostname)
+            if devices:
+                device = devices[0]
+                logger.info(f"Device found by inventory_hostname: {device.name}")
+            else:
+                logger.error(
+                    f"Device {hostname} not found in NetBox (searched by name and inventory_hostname)"
+                )
+                return None
+        return device
+
+    def _get_config_context(self, device, hostname):
+        """Get and validate device configuration context"""
+        if not hasattr(device, "local_context_data") or not device.local_context_data:
+            logger.error(f"Device {hostname} has no local_context_data in NetBox")
+            return None
+        return device.local_context_data
+
+    def _save_config_context(self, config_context, hostname, today):
+        """Save config context to local file"""
+        config_context_file = f"/tmp/config_db_{hostname}_{today}.json"
+        try:
+            with open(config_context_file, "w") as f:
+                json.dump(config_context, f, indent=2)
+            logger.info(f"Config context saved to {config_context_file}")
+            return config_context_file
+        except Exception as e:
+            logger.error(f"Failed to save config context: {e}")
+            return None
+
+    def _get_ssh_connection_details(self, config_context, device, hostname):
+        """Extract SSH connection details from config context and NetBox"""
+        ssh_host = None
+        ssh_username = None
+
+        # Try to get SSH details from config context
+        if "management" in config_context:
+            mgmt = config_context["management"]
+            if "ip" in mgmt:
+                ssh_host = mgmt["ip"]
+            if "username" in mgmt:
+                ssh_username = mgmt["username"]
+
+        # Fallback: try to get OOB IP from NetBox
+        if not ssh_host:
+            from osism.tasks.conductor.netbox import get_device_oob_ip
+
+            oob_result = get_device_oob_ip(device)
+            if oob_result:
+                ssh_host = oob_result[0]
+
+        if not ssh_host:
+            logger.error(f"No SSH host found for device {hostname}")
+            return None, None
+
+        if not ssh_username:
+            ssh_username = "admin"  # Default SONiC username
+
+        return ssh_host, ssh_username
+
+    def _create_ssh_connection(self, ssh_host, ssh_username):
+        """Create and return SSH connection"""
+        ssh_key_path = "/ansible/secrets/id_rsa.operator"
+
+        if not os.path.exists(ssh_key_path):
+            logger.error(f"SSH private key not found at {ssh_key_path}")
+            return None
+
+        ssh = paramiko.SSHClient()
+        ssh.set_missing_host_key_policy(paramiko.AutoAddPolicy())
+
+        try:
+            ssh.connect(
+                hostname=ssh_host,
+                username=ssh_username,
+                key_filename=ssh_key_path,
+                timeout=30,
+            )
+            return ssh
+        except Exception as e:
+            logger.error(f"Failed to create SSH connection: {e}")
+            return None
+
+    def _generate_backup_filename(self, ssh, hostname, today):
+        """Generate unique backup filename on switch"""
+        base_backup_path = f"/home/admin/config_db_{hostname}_{today}"
+        x = 1
+        while True:
+            backup_filename = f"{base_backup_path}_{x}.json"
+            check_cmd = f"ls {backup_filename} 2>/dev/null"
+            stdin, stdout, stderr = ssh.exec_command(check_cmd)
+            if stdout.read().decode().strip() == "":
+                return backup_filename
+            x += 1
+
+    def _backup_current_config(self, ssh, backup_filename):
+        """Backup current configuration on switch"""
+        logger.info(f"Backing up current configuration on switch to {backup_filename}")
+        backup_cmd = f"sudo cp /etc/sonic/config_db.json {backup_filename}"
+        stdin, stdout, stderr = ssh.exec_command(backup_cmd)
+        exit_status = stdout.channel.recv_exit_status()
+
+        if exit_status != 0:
+            error_msg = stderr.read().decode()
+            logger.error(f"Failed to backup configuration on switch: {error_msg}")
+            return False
+
+        logger.info("Configuration backed up successfully on switch")
+        return True
+
+    def _upload_config_context(self, ssh, config_context_file, hostname):
+        """Upload config context file to switch"""
+        switch_config_file = f"/tmp/config_db_{hostname}_current.json"
+        logger.info(f"Uploading config context to {switch_config_file} on switch")
+
+        sftp = ssh.open_sftp()
+        try:
+            sftp.put(config_context_file, switch_config_file)
+            logger.info(
+                f"Config context successfully uploaded to {switch_config_file} on switch"
+            )
+            return switch_config_file
+        except Exception as e:
+            logger.error(f"Failed to upload config context to switch: {e}")
+            return None
+        finally:
+            sftp.close()
+
+    def _load_configuration(self, ssh, switch_config_file):
+        """Load and apply configuration on switch"""
+        logger.info("Loading and applying new configuration on switch")
+        load_cmd = f"sudo config load -y {switch_config_file}"
+        stdin, stdout, stderr = ssh.exec_command(load_cmd)
+        exit_status = stdout.channel.recv_exit_status()
+
+        if exit_status != 0:
+            error_msg = stderr.read().decode()
+            logger.error(f"Failed to load configuration: {error_msg}")
+            return False
+
+        logger.info("Configuration loaded and applied successfully")
+        return True
+
+    def _reload_configuration(self, ssh):
+        """Reload configuration to restart services"""
+        logger.info("Reloading configuration to restart services")
+        reload_cmd = "sudo config reload -y"
+        stdin, stdout, stderr = ssh.exec_command(reload_cmd)
+        exit_status = stdout.channel.recv_exit_status()
+
+        if exit_status != 0:
+            error_msg = stderr.read().decode()
+            logger.error(f"Failed to reload configuration: {error_msg}")
+            return False
+
+        logger.info("Configuration reloaded successfully")
+        return True
+
+    def _save_configuration(self, ssh):
+        """Save configuration to persist changes"""
+        logger.info("Saving configuration to persist changes")
+        save_cmd = "sudo config save -y"
+        stdin, stdout, stderr = ssh.exec_command(save_cmd)
+        exit_status = stdout.channel.recv_exit_status()
+
+        if exit_status != 0:
+            error_msg = stderr.read().decode()
+            logger.error(f"Failed to save configuration: {error_msg}")
+            return False
+
+        logger.info("Configuration saved successfully")
+        return True
+
+    def _cleanup_temp_file(self, ssh, switch_config_file):
+        """Delete temporary configuration file"""
+        logger.info(f"Cleaning up temporary file {switch_config_file}")
+        delete_cmd = f"rm {switch_config_file}"
+        stdin, stdout, stderr = ssh.exec_command(delete_cmd)
+        exit_status = stdout.channel.recv_exit_status()
+
+        if exit_status != 0:
+            error_msg = stderr.read().decode()
+            logger.warning(f"Failed to delete temporary file: {error_msg}")
+        else:
+            logger.info("Temporary file deleted successfully")
+
+
+class Load(SonicCommandBase):
+    """Load SONiC switch configuration"""
+
     def get_parser(self, prog_name):
-        parser = super(Manage, self).get_parser(prog_name)
+        parser = super(Load, self).get_parser(prog_name)
         parser.add_argument(
-            "hostname", type=str, help="Hostname of the SONiC switch to manage"
-        )
-        parser.add_argument(
-            "--reload",
-            action="store_true",
-            help="Execute config reload after config load to restart services",
+            "hostname",
+            type=str,
+            help="Hostname of the SONiC switch to load configuration",
         )
         return parser
 
     def take_action(self, parsed_args):
         hostname = parsed_args.hostname
-        reload_config = parsed_args.reload
         today = datetime.now().strftime("%Y%m%d")
 
         try:
-            # Get device from NetBox - try by name first, then by inventory_hostname
-            device = utils.nb.dcim.devices.get(name=hostname)
+            # Get device from NetBox
+            device = self._get_device_from_netbox(hostname)
             if not device:
-                # Try to find by inventory_hostname custom field
-                devices = utils.nb.dcim.devices.filter(cf_inventory_hostname=hostname)
-                if devices:
-                    device = devices[0]  # Take the first match
-                    logger.info(f"Device found by inventory_hostname: {device.name}")
-                else:
-                    logger.error(
-                        f"Device {hostname} not found in NetBox (searched by name and inventory_hostname)"
-                    )
-                    return 1
-
-            # Get device configuration from local_context_data
-            if (
-                not hasattr(device, "local_context_data")
-                or not device.local_context_data
-            ):
-                logger.error(f"Device {hostname} has no local_context_data in NetBox")
                 return 1
 
-            config_context = device.local_context_data
-
-            # Save config context to local /tmp directory
-            config_context_file = f"/tmp/config_db_{hostname}_{today}.json"
-            try:
-                with open(config_context_file, "w") as f:
-                    json.dump(config_context, f, indent=2)
-                logger.info(f"Config context saved to {config_context_file}")
-            except Exception as e:
-                logger.error(f"Failed to save config context: {e}")
+            # Get device configuration context
+            config_context = self._get_config_context(device, hostname)
+            if not config_context:
                 return 1
 
-            # Extract SSH connection details
-            ssh_host = None
-            ssh_username = None
+            # Save config context locally
+            config_context_file = self._save_config_context(
+                config_context, hostname, today
+            )
+            if not config_context_file:
+                return 1
 
-            # Try to get SSH details from config context
-            if "management" in config_context:
-                mgmt = config_context["management"]
-                if "ip" in mgmt:
-                    ssh_host = mgmt["ip"]
-                if "username" in mgmt:
-                    ssh_username = mgmt["username"]
-
-            # Fallback: try to get OOB IP from NetBox
+            # Get SSH connection details
+            ssh_host, ssh_username = self._get_ssh_connection_details(
+                config_context, device, hostname
+            )
             if not ssh_host:
-                from osism.tasks.conductor.netbox import get_device_oob_ip
-
-                oob_result = get_device_oob_ip(device)
-                if oob_result:
-                    ssh_host = oob_result[0]
-
-            if not ssh_host:
-                logger.error(f"No SSH host found for device {hostname}")
-                return 1
-
-            if not ssh_username:
-                ssh_username = "admin"  # Default SONiC username
-
-            # SSH private key path
-            ssh_key_path = "/ansible/secrets/id_rsa.operator"
-
-            if not os.path.exists(ssh_key_path):
-                logger.error(f"SSH private key not found at {ssh_key_path}")
                 return 1
 
             logger.info(
-                f"Connecting to {hostname} ({ssh_host}) to backup SONiC configuration"
+                f"Connecting to {hostname} ({ssh_host}) to load SONiC configuration"
             )
 
             # Create SSH connection
-            ssh = paramiko.SSHClient()
-            ssh.set_missing_host_key_policy(paramiko.AutoAddPolicy())
+            ssh = self._create_ssh_connection(ssh_host, ssh_username)
+            if not ssh:
+                return 1
 
             try:
-                # Connect with private key
-                ssh.connect(
-                    hostname=ssh_host,
-                    username=ssh_username,
-                    key_filename=ssh_key_path,
-                    timeout=30,
-                )
+                # Generate backup filename
+                backup_filename = self._generate_backup_filename(ssh, hostname, today)
 
-                # Generate backup filename with date and increment on switch
-                base_backup_path = f"/home/admin/config_db_{hostname}_{today}"
-                backup_filename = f"{base_backup_path}_1.json"
-
-                # Find next available filename on switch
-                x = 1
-                while True:
-                    check_cmd = f"ls {base_backup_path}_{x}.json 2>/dev/null"
-                    stdin, stdout, stderr = ssh.exec_command(check_cmd)
-                    if stdout.read().decode().strip() == "":
-                        backup_filename = f"{base_backup_path}_{x}.json"
-                        break
-                    x += 1
-
-                logger.info(
-                    f"Backing up current configuration on switch to {backup_filename}"
-                )
-
-                # Backup current configuration on switch
-                backup_cmd = f"sudo cp /etc/sonic/config_db.json {backup_filename}"
-                stdin, stdout, stderr = ssh.exec_command(backup_cmd)
-                exit_status = stdout.channel.recv_exit_status()
-
-                if exit_status != 0:
-                    error_msg = stderr.read().decode()
-                    logger.error(
-                        f"Failed to backup configuration on switch: {error_msg}"
-                    )
+                # Backup current configuration
+                if not self._backup_current_config(ssh, backup_filename):
                     return 1
 
-                logger.info("Configuration backed up successfully on switch")
-
-                # Upload local config context to switch /tmp directory
-                switch_config_file = f"/tmp/config_db_{hostname}_current.json"
-                logger.info(
-                    f"Uploading config context to {switch_config_file} on switch"
+                # Upload config context
+                switch_config_file = self._upload_config_context(
+                    ssh, config_context_file, hostname
                 )
-
-                # Use SFTP to upload the config context file
-                sftp = ssh.open_sftp()
-                try:
-                    sftp.put(config_context_file, switch_config_file)
-                    logger.info(
-                        f"Config context successfully uploaded to {switch_config_file} on switch"
-                    )
-                except Exception as e:
-                    logger.error(f"Failed to upload config context to switch: {e}")
-                    return 1
-                finally:
-                    sftp.close()
-
-                # Load and apply the new configuration
-                logger.info("Loading and applying new configuration on switch")
-
-                load_cmd = f"sudo config load -y {switch_config_file}"
-                stdin, stdout, stderr = ssh.exec_command(load_cmd)
-                exit_status = stdout.channel.recv_exit_status()
-
-                if exit_status != 0:
-                    error_msg = stderr.read().decode()
-                    logger.error(f"Failed to load configuration: {error_msg}")
+                if not switch_config_file:
                     return 1
 
-                logger.info("Configuration loaded and applied successfully")
+                # Load configuration
+                if not self._load_configuration(ssh, switch_config_file):
+                    return 1
 
-                # Optionally reload configuration to restart services
-                config_operations_successful = True
-                if reload_config:
-                    logger.info("Reloading configuration to restart services")
+                # Save configuration
+                if not self._save_configuration(ssh):
+                    return 1
 
-                    reload_cmd = "sudo config reload -y"
-                    stdin, stdout, stderr = ssh.exec_command(reload_cmd)
-                    exit_status = stdout.channel.recv_exit_status()
+                # Cleanup
+                self._cleanup_temp_file(ssh, switch_config_file)
 
-                    if exit_status != 0:
-                        error_msg = stderr.read().decode()
-                        logger.error(f"Failed to reload configuration: {error_msg}")
-                        config_operations_successful = False
-                    else:
-                        logger.info("Configuration reloaded successfully")
+                logger.info("SONiC configuration load completed successfully")
+                logger.info(f"- Config context saved locally to: {config_context_file}")
+                logger.info("- Configuration loaded and saved on switch")
+                logger.info(f"- Backup created on switch: {backup_filename}")
 
-                # Save configuration only if load (and optionally reload) were successful
-                if config_operations_successful:
-                    logger.info("Saving configuration to persist changes")
+                return 0
 
-                    save_cmd = "sudo config save -y"
-                    stdin, stdout, stderr = ssh.exec_command(save_cmd)
-                    exit_status = stdout.channel.recv_exit_status()
+            except paramiko.AuthenticationException:
+                logger.error(f"Authentication failed for {ssh_host}")
+                return 1
+            except paramiko.SSHException as e:
+                logger.error(f"SSH connection failed: {e}")
+                return 1
+            except Exception as e:
+                logger.error(f"Unexpected error during SSH operations: {e}")
+                return 1
+            finally:
+                ssh.close()
 
-                    if exit_status != 0:
-                        error_msg = stderr.read().decode()
-                        logger.error(f"Failed to save configuration: {error_msg}")
+        except Exception as e:
+            logger.error(f"Error loading SONiC device {hostname}: {e}")
+            return 1
+
+
+class Reload(SonicCommandBase):
+    """Reload SONiC switch configuration"""
+
+    def get_parser(self, prog_name):
+        parser = super(Reload, self).get_parser(prog_name)
+        parser.add_argument(
+            "hostname", type=str, help="Hostname of the SONiC switch to reload"
+        )
+        return parser
+
+    def take_action(self, parsed_args):
+        hostname = parsed_args.hostname
+        today = datetime.now().strftime("%Y%m%d")
+
+        try:
+            # Get device from NetBox
+            device = self._get_device_from_netbox(hostname)
+            if not device:
+                return 1
+
+            # Get device configuration context
+            config_context = self._get_config_context(device, hostname)
+            if not config_context:
+                return 1
+
+            # Save config context locally
+            config_context_file = self._save_config_context(
+                config_context, hostname, today
+            )
+            if not config_context_file:
+                return 1
+
+            # Get SSH connection details
+            ssh_host, ssh_username = self._get_ssh_connection_details(
+                config_context, device, hostname
+            )
+            if not ssh_host:
+                return 1
+
+            logger.info(
+                f"Connecting to {hostname} ({ssh_host}) to reload SONiC configuration"
+            )
+
+            # Create SSH connection
+            ssh = self._create_ssh_connection(ssh_host, ssh_username)
+            if not ssh:
+                return 1
+
+            try:
+                # Generate backup filename
+                backup_filename = self._generate_backup_filename(ssh, hostname, today)
+
+                # Backup current configuration
+                if not self._backup_current_config(ssh, backup_filename):
+                    return 1
+
+                # Upload config context
+                switch_config_file = self._upload_config_context(
+                    ssh, config_context_file, hostname
+                )
+                if not switch_config_file:
+                    return 1
+
+                # Load configuration
+                if not self._load_configuration(ssh, switch_config_file):
+                    return 1
+
+                # Reload configuration
+                reload_successful = self._reload_configuration(ssh)
+
+                # Save configuration only if reload was successful
+                if reload_successful:
+                    if not self._save_configuration(ssh):
                         return 1
-
-                    logger.info("Configuration saved successfully")
                 else:
                     logger.warning("Skipping config save due to reload failure")
 
-                # Delete the temporary configuration file
-                logger.info(f"Cleaning up temporary file {switch_config_file}")
+                # Cleanup
+                self._cleanup_temp_file(ssh, switch_config_file)
 
-                delete_cmd = f"rm {switch_config_file}"
-                stdin, stdout, stderr = ssh.exec_command(delete_cmd)
-                exit_status = stdout.channel.recv_exit_status()
-
-                if exit_status != 0:
-                    error_msg = stderr.read().decode()
-                    logger.warning(f"Failed to delete temporary file: {error_msg}")
-                else:
-                    logger.info("Temporary file deleted successfully")
-
-                logger.info("SONiC configuration management completed successfully")
+                logger.info("SONiC configuration reload completed successfully")
                 logger.info(f"- Config context saved locally to: {config_context_file}")
-                if reload_config and config_operations_successful:
+                if reload_successful:
                     logger.info("- Configuration loaded, reloaded, and saved on switch")
-                elif config_operations_successful:
-                    logger.info("- Configuration loaded and saved on switch")
                 else:
                     logger.info(
                         "- Configuration loaded on switch (save skipped due to reload failure)"
@@ -253,5 +410,5 @@ class Manage(Command):
                 ssh.close()
 
         except Exception as e:
-            logger.error(f"Error managing SONiC device {hostname}: {e}")
+            logger.error(f"Error reloading SONiC device {hostname}: {e}")
             return 1

--- a/setup.cfg
+++ b/setup.cfg
@@ -75,7 +75,8 @@ osism.commands:
     manage images = osism.commands.manage:Images
     manage dnsmasq = osism.commands.manage:Dnsmasq
     manage netbox = osism.commands.netbox:Manage
-    manage sonic = osism.commands.sonic:Manage
+    manage sonic load = osism.commands.sonic:Load
+    manage sonic reload = osism.commands.sonic:Reload
     manage redfish list = osism.commands.redfish:List
     manage server list = osism.commands.server:ServerList
     manage server migrate = osism.commands.server:ServerMigrate


### PR DESCRIPTION
Split sonic command functionality into two distinct commands:
- osism manage sonic load: Load configuration without restart
- osism manage sonic reload: Load configuration with service restart

Extract common functionality into SonicCommandBase with helper methods for better code organization and maintainability.

AI-assisted: Claude Code