### PR TITLE
Add sonic backup command for configuration backup only

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -75,6 +75,7 @@ osism.commands:
     manage images = osism.commands.manage:Images
     manage dnsmasq = osism.commands.manage:Dnsmasq
     manage netbox = osism.commands.netbox:Manage
+    manage sonic backup = osism.commands.sonic:Backup
     manage sonic load = osism.commands.sonic:Load
     manage sonic reload = osism.commands.sonic:Reload
     manage redfish list = osism.commands.redfish:List


### PR DESCRIPTION
Introduce new osism manage sonic backup command that creates a configuration backup without any modifications. This provides a standalone backup functionality for maintenance and safety purposes.

Features:
- Creates timestamped backup files on the switch
- Minimal operation focused only on backup creation
- Reuses existing SSH connection and NetBox integration

AI-assisted: Claude Code