### PR TITLE
Add sonic ztp command for Zero Touch Provisioning management

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -78,6 +78,7 @@ osism.commands:
     manage sonic backup = osism.commands.sonic:Backup
     manage sonic load = osism.commands.sonic:Load
     manage sonic reload = osism.commands.sonic:Reload
+    manage sonic ztp = osism.commands.sonic:Ztp
     manage redfish list = osism.commands.redfish:List
     manage server list = osism.commands.server:ServerList
     manage server migrate = osism.commands.server:ServerMigrate


### PR DESCRIPTION
Introduce new osism manage sonic ztp command for managing ZTP (Zero Touch Provisioning) on SONiC switches. The command supports three modes:

- osism manage sonic ztp <hostname>: Check ZTP status
- osism manage sonic ztp <hostname> --enable: Enable ZTP
- osism manage sonic ztp <hostname> --disable: Disable ZTP

Features:
- Mutually exclusive enable/disable options
- Status reporting when no action specified
- Integration with existing SSH connection and NetBox functionality
- Comprehensive error handling and logging

AI-assisted: Claude Code