### PR TITLE
Add sonic reboot command for SONiC switch rebooting

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -77,6 +77,7 @@ osism.commands:
     manage netbox = osism.commands.netbox:Manage
     manage sonic backup = osism.commands.sonic:Backup
     manage sonic load = osism.commands.sonic:Load
+    manage sonic reboot = osism.commands.sonic:Reboot
     manage sonic reload = osism.commands.sonic:Reload
     manage sonic ztp = osism.commands.sonic:Ztp
     manage redfish list = osism.commands.redfish:List


### PR DESCRIPTION
This commit adds a new `osism manage sonic reboot` command that allows users to reboot SONiC switches remotely. The command follows the same pattern as other sonic commands, using NetBox for device information and SSH for remote execution.

AI-assisted: Claude Code