### PR TITLE
Add sonic show command for executing arbitrary show commands on SONiC…

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -98,6 +98,7 @@ osism.commands:
     sonic reboot = osism.commands.sonic:Reboot
     sonic reload = osism.commands.sonic:Reload
     sonic reset = osism.commands.sonic:Reset
+    sonic show = osism.commands.sonic:Show
     sonic sync= osism.commands.sync:Sonic
     sonic ztp = osism.commands.sonic:Ztp
     sync configuration = osism.commands.configuration:Sync


### PR DESCRIPTION
… switches

This command allows users to execute any show command with arbitrary parameters on SONiC switches via SSH connection. The command uses the existing SONiC infrastructure for device lookup and SSH connection management.

Usage: osism sonic show <hostname> <command parameters>
Examples:
- osism sonic show switch01 interfaces
- osism sonic show switch01 version
- osism sonic show switch01 ip route

AI-assisted: Claude Code