### PR TITLE
Suppress paramiko logging messages in sonic commands

### DIFF
--- a/osism/commands/sonic.py
+++ b/osism/commands/sonic.py
@@ -1,6 +1,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 import json
+import logging
 import os
 from datetime import datetime
 
@@ -11,6 +12,10 @@ from prompt_toolkit import prompt
 
 from osism import utils
 from osism.tasks import netbox
+
+# Suppress paramiko logging messages globally
+logging.getLogger("paramiko").setLevel(logging.ERROR)
+logging.getLogger("paramiko.transport").setLevel(logging.ERROR)
 
 
 class SonicCommandBase(Command):


### PR DESCRIPTION
Add paramiko.util.log_to_file('/dev/null') to suppress verbose connection messages like "Connected..", "Auth banner..", and "Authentication (publickey) successful\!" that were cluttering the output.