### PR TITLE
Add sonic console command for interactive SSH access to SONiC switches

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -94,6 +94,7 @@ osism.commands:
     set maintenance = osism.commands.set:Maintenance
     set vault password = osism.commands.vault:SetPassword
     sonic backup = osism.commands.sonic:Backup
+    sonic console = osism.commands.sonic:Console
     sonic load = osism.commands.sonic:Load
     sonic reboot = osism.commands.sonic:Reboot
     sonic reload = osism.commands.sonic:Reload


### PR DESCRIPTION
This new command allows users to open an interactive SSH console to SONiC switches using the existing NetBox device lookup and SSH connection infrastructure. The command uses the admin username and the operator SSH key from /ansible/secrets/id_rsa.operator.

Usage: osism sonic console <hostname>

AI-assisted: Claude Code