### PR TITLE
Fix BGP neighbor detection for switches with Eth(Port) alias format

### DIFF
--- a/osism/tasks/conductor/sonic/interface.py
+++ b/osism/tasks/conductor/sonic/interface.py
@@ -419,6 +419,16 @@ def _extract_port_number_from_alias(alias):
     if not alias:
         return None
 
+    # Try to extract number from Eth54(Port54) format first
+    paren_match = re.search(r"Eth(\d+)\(Port(\d+)\)", alias)
+    if paren_match:
+        port_number = int(paren_match.group(1))
+        logger.debug(
+            f"Extracted port number {port_number} from Eth(Port) alias '{alias}'"
+        )
+        return port_number
+
+    # Fallback to number at end of alias
     match = re.search(r"(\d+)$", alias)
     if match:
         port_number = int(match.group(1))


### PR DESCRIPTION
The _extract_port_number_from_alias function failed to parse port numbers from the "Eth54(Port54)" alias format used by AS4625-54T switches, causing BGP neighbors to not be detected. Added regex pattern to handle this format before falling back to the existing pattern.

AI-assisted: Claude Code