### PR TITLE
Add baremetal ping command for network connectivity testing

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -82,6 +82,7 @@ osism.commands:
     manage baremetal list = osism.commands.baremetal:BaremetalList
     manage baremetal deploy = osism.commands.baremetal:BaremetalDeploy
     manage baremetal undeploy = osism.commands.baremetal:BaremetalUndeploy
+    manage baremetal ping = osism.commands.baremetal:BaremetalPing
     netbox = osism.commands.netbox:Console
     get versions netbox = osism.commands.netbox:Versions
     noset bootstrap = osism.commands.noset:NoBootstrap


### PR DESCRIPTION
- Uses NETBOX_FILTER_CONDUCTOR_IRONIC setting for device filtering
- Filters by power_state='power on' and provision_state='active' custom fields
- Pings primary IPv4 addresses with 3 attempts per node
- Supports single node targeting or bulk operations
- Provides threaded execution for parallel ping operations
- Returns formatted table with status and timing information
- Includes success/failure summary statistics

AI-assisted: Claude Code