### PR TITLE
Add optional node parameter to osism sync ironic command

### DIFF
--- a/osism/tasks/conductor/__init__.py
+++ b/osism/tasks/conductor/__init__.py
@@ -44,8 +44,8 @@ def sync_netbox(self, force_update=False):
 
 
 @app.task(bind=True, name="osism.tasks.conductor.sync_ironic")
-def sync_ironic(self, force_update=False):
-    _sync_ironic(self.request.id, get_ironic_parameters, force_update)
+def sync_ironic(self, node_name=None, force_update=False):
+    _sync_ironic(self.request.id, get_ironic_parameters, node_name, force_update)
 
 
 @app.task(bind=True, name="osism.tasks.conductor.sync_sonic")


### PR DESCRIPTION
Enables synchronization of individual nodes instead of all nodes. Usage: 'osism sync ironic NODE' where NODE is optional.

- Add optional 'node' positional argument to Ironic command parser
- Filter NetBox devices and Ironic nodes by specified node name
- Update logging to indicate single node sync when specified
- Maintain backward compatibility with existing 'osism sync ironic' behavior

AI-assisted: Claude Code