### PR TITLE
Add validation checks to get_ansible_vault_password function

### DIFF
--- a/osism/tasks/conductor/utils.py
+++ b/osism/tasks/conductor/utils.py
@@ -75,8 +75,15 @@ def get_vault():
                 )
             ]
         )
-    except Exception:
-        logger.error("Unable to get vault secret. Dropping encrypted entries")
+    except ValueError as exc:
+        # Handle specific vault password configuration errors
+        logger.error(f"Vault password configuration error: {exc}")
+        logger.error("Please check your vault password setup in Redis")
+        vault = VaultLib()
+    except Exception as exc:
+        # Handle other errors (file access, decryption, etc.)
+        logger.error(f"Unable to get vault secret: {exc}")
+        logger.error("Dropping encrypted entries")
         vault = VaultLib()
     return vault
 

--- a/osism/utils/__init__.py
+++ b/osism/utils/__init__.py
@@ -109,8 +109,18 @@ def get_ansible_vault_password():
         f = Fernet(key)
 
         encrypted_ansible_vault_password = redis.get("ansible_vault_password")
+        if encrypted_ansible_vault_password is None:
+            raise ValueError("Ansible vault password is not set in Redis")
+
         ansible_vault_password = f.decrypt(encrypted_ansible_vault_password)
-        return ansible_vault_password.decode("utf-8")
+        password = ansible_vault_password.decode("utf-8")
+
+        if not password or password.strip() == "":
+            raise ValueError(
+                "Ansible vault password is empty or contains only whitespace"
+            )
+
+        return password
     except Exception as exc:
         logger.error("Unable to get ansible vault password")
         raise exc


### PR DESCRIPTION
Ensures that the ansible vault password is properly set and not empty.

- Check if encrypted_ansible_vault_password exists in Redis
- Validate that decrypted password is not empty or whitespace-only
- Raise ValueError with descriptive messages for missing or empty passwords
- Improve error handling for vault password configuration issues

AI-assisted: Claude Code