### PR TITLE
Add sonic list command to display SONiC switch information

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -96,6 +96,7 @@ osism.commands:
     set vault password = osism.commands.vault:SetPassword
     sonic backup = osism.commands.sonic:Backup
     sonic console = osism.commands.sonic:Console
+    sonic list = osism.commands.sonic:List
     sonic load = osism.commands.sonic:Load
     sonic reboot = osism.commands.sonic:Reboot
     sonic reload = osism.commands.sonic:Reload


### PR DESCRIPTION
Adds a new 'osism sonic list' command that displays SONiC switches with their key details in a formatted table. The command uses the same filtering mechanisms as 'sonic sync' for consistency.

- Lists all SONiC switches managed by sonic sync
- Shows Name, OOB IP, Primary IP, HWSKU, Version, and Provision State
- Uses NETBOX_FILTER_CONDUCTOR_SONIC filters like sonic sync
- Filters by DEFAULT_SONIC_ROLES for SONiC-compatible devices
- Supports optional device name parameter for filtering
- Extracts HWSKU and version from sonic_parameters custom field
- Determines provision state based on HWSKU configuration and device status
- Formatted table output with device count summary

AI-assisted: Claude Code