### PR TITLE
Centralize SSH known_hosts file management across all commands

### DIFF
--- a/osism/commands/compose.py
+++ b/osism/commands/compose.py
@@ -26,7 +26,7 @@ class Run(Command):
         ssh_command = (
             f"docker compose --project-directory=/opt/{environment} {arguments}"
         )
-        ssh_options = "-o StrictHostKeyChecking=no -o LogLevel=ERROR"
+        ssh_options = "-o StrictHostKeyChecking=no -o LogLevel=ERROR -o UserKnownHostsFile=/share/known_hosts"
 
         # FIXME: use paramiko or something else more Pythonic + make operator user + key configurable
         subprocess.call(

--- a/osism/commands/console.py
+++ b/osism/commands/console.py
@@ -129,7 +129,7 @@ class Run(Command):
             type_console = "clush"
             host = host[1:]
 
-        ssh_options = "-o StrictHostKeyChecking=no -o LogLevel=ERROR"
+        ssh_options = "-o StrictHostKeyChecking=no -o LogLevel=ERROR -o UserKnownHostsFile=/share/known_hosts"
 
         if type_console == "ansible":
             subprocess.call(f"/run-ansible-console.sh {host}", shell=True)
@@ -166,9 +166,7 @@ class Run(Command):
             target_command = "bash"
 
             ssh_command = f"docker exec -it {target_containername} {target_command}"
-            ssh_options = (
-                "-o RequestTTY=force -o StrictHostKeyChecking=no -o LogLevel=ERROR"
-            )
+            ssh_options = "-o RequestTTY=force -o StrictHostKeyChecking=no -o LogLevel=ERROR -o UserKnownHostsFile=/share/known_hosts"
 
             # Resolve hostname with Netbox fallback
             resolved_target_host = resolve_host_with_fallback(target_host)

--- a/osism/commands/container.py
+++ b/osism/commands/container.py
@@ -23,7 +23,7 @@ class Run(Command):
         host = parsed_args.host[0]
         command = " ".join(parsed_args.command)
 
-        ssh_options = "-o StrictHostKeyChecking=no -o LogLevel=ERROR"
+        ssh_options = "-o StrictHostKeyChecking=no -o LogLevel=ERROR -o UserKnownHostsFile=/share/known_hosts"
 
         if not command:
             while True:

--- a/osism/commands/log.py
+++ b/osism/commands/log.py
@@ -52,7 +52,7 @@ class Container(Command):
         parameters = " ".join(parsed_args.parameter)
 
         ssh_command = f"docker logs {parameters} {container_name}"
-        ssh_options = "-o StrictHostKeyChecking=no -o LogLevel=ERROR"
+        ssh_options = "-o StrictHostKeyChecking=no -o LogLevel=ERROR -o UserKnownHostsFile=/share/known_hosts"
 
         # FIXME: use paramiko or something else more Pythonic + make operator user + key configurable
         subprocess.call(

--- a/osism/commands/sonic.py
+++ b/osism/commands/sonic.py
@@ -109,6 +109,13 @@ class SonicCommandBase(Command):
             return None
 
         ssh = paramiko.SSHClient()
+        # Load system host keys from centralized known_hosts file
+        try:
+            ssh.load_host_keys("/share/known_hosts")
+        except FileNotFoundError:
+            logger.debug(
+                "Centralized known_hosts file not found, creating empty host key store"
+            )
         ssh.set_missing_host_key_policy(paramiko.AutoAddPolicy())
 
         try:
@@ -976,7 +983,7 @@ class Console(SonicCommandBase):
             logger.info(f"Connecting to {hostname} ({ssh_host}) via SSH console")
 
             # Execute SSH command using os.system to provide interactive terminal
-            ssh_command = f"ssh -i {ssh_key_path} -o StrictHostKeyChecking=no {ssh_username}@{ssh_host}"
+            ssh_command = f"ssh -i {ssh_key_path} -o StrictHostKeyChecking=no -o UserKnownHostsFile=/share/known_hosts {ssh_username}@{ssh_host}"
 
             logger.info("Starting SSH session...")
             logger.info("To exit the console, type 'exit' or press Ctrl+D")

--- a/osism/utils/ssh.py
+++ b/osism/utils/ssh.py
@@ -52,7 +52,7 @@ def get_host_identifiers(hostname: str) -> List[str]:
 
 
 def remove_known_hosts_entries(
-    hostname: str, known_hosts_path: str = "/root/.ssh/known_hosts"
+    hostname: str, known_hosts_path: str = "/share/known_hosts"
 ) -> bool:
     """
     Remove SSH known_hosts entries for a given hostname and its IP addresses.
@@ -62,7 +62,7 @@ def remove_known_hosts_entries(
 
     Args:
         hostname: The hostname to remove entries for
-        known_hosts_path: Path to the SSH known_hosts file (default: /root/.ssh/known_hosts)
+        known_hosts_path: Path to the SSH known_hosts file (default: /share/known_hosts)
 
     Returns:
         True if cleanup was successful, False otherwise
@@ -156,7 +156,7 @@ def remove_known_hosts_entries(
 
 
 def backup_known_hosts(
-    known_hosts_path: str = "/root/.ssh/known_hosts",
+    known_hosts_path: str = "/share/known_hosts",
 ) -> Optional[str]:
     """
     Create a backup of the SSH known_hosts file before making changes.
@@ -238,7 +238,7 @@ def cleanup_ssh_known_hosts_for_node(hostname: str, create_backup: bool = True) 
     Returns:
         True if cleanup was successful, False otherwise
     """
-    known_hosts_path = "/root/.ssh/known_hosts"
+    known_hosts_path = "/share/known_hosts"
 
     try:
         # Create backup if requested


### PR DESCRIPTION
Update all SSH operations to use a shared known_hosts file at /share/known_hosts instead of user-specific locations. This provides centralized management of SSH host key verification across compose, console, container, log, and sonic commands, improving security and consistency.

AI-assisted: Claude Code