### PR TITLE
Remove duplicate SSH known_hosts cleanup log messages

### DIFF
--- a/osism/utils/ssh.py
+++ b/osism/utils/ssh.py
@@ -243,15 +243,6 @@ def cleanup_ssh_known_hosts_for_node(hostname: str, create_backup: bool = True) 
         # Perform the cleanup
         success = remove_known_hosts_entries(hostname, known_hosts_path)
 
-        if success:
-            logger.info(
-                f"SSH known_hosts cleanup completed successfully for {hostname}"
-            )
-        else:
-            logger.warning(
-                f"SSH known_hosts cleanup completed with warnings for {hostname}"
-            )
-
         return success
 
     except Exception as e:


### PR DESCRIPTION
Remove redundant "SSH known_hosts cleanup completed successfully" log message that was duplicating the more informative detailed success message with entry counts from remove_known_hosts_entries().

AI-assisted: Claude Code