### PR TITLE
Improve SONiC IPv4 interface configuration parameters

### DIFF
--- a/osism/tasks/conductor/sonic/config_generator.py
+++ b/osism/tasks/conductor/sonic/config_generator.py
@@ -574,8 +574,10 @@ def _add_interface_configurations(
 
             if ipv4_address:
                 # If IPv4 address is available, configure the interface with it
-                config["INTERFACE"][port_name] = {"admin_status": "up"}
-                config["INTERFACE"][f"{port_name}|{ipv4_address}"] = {}
+                config["INTERFACE"][f"{port_name}|{ipv4_address}"] = {
+                    "scope": "global",
+                    "family": "IPv4",
+                }
                 logger.info(
                     f"Configured interface {port_name} with IPv4 address {ipv4_address}"
                 )


### PR DESCRIPTION
Remove redundant admin_status setting and add proper scope and family parameters for IPv4 interface addresses. This ensures IPv4 interfaces are configured with global scope and explicit IPv4 family designation.