### PR TITLE
Ensure NETBOX_TOKEN is always a string type

### DIFF
--- a/osism/commands/netbox.py
+++ b/osism/commands/netbox.py
@@ -228,9 +228,9 @@ class Console(Command):
         if not os.path.exists(nbcli_file):
             try:
                 with open("/run/secrets/NETBOX_TOKEN", "r") as fp:
-                    token = fp.read().strip()
+                    token = str(fp.read().strip())
             except FileNotFoundError:
-                token = None
+                token = ""
 
             url = os.environ.get("NETBOX_API", None)
 

--- a/osism/settings.py
+++ b/osism/settings.py
@@ -24,7 +24,7 @@ REDIS_DB: int = int(os.getenv("REDIS_DB", "0"))
 
 
 NETBOX_URL = os.getenv("NETBOX_API", os.getenv("NETBOX_URL"))
-NETBOX_TOKEN = os.getenv("NETBOX_TOKEN", read_secret("NETBOX_TOKEN"))
+NETBOX_TOKEN = str(os.getenv("NETBOX_TOKEN") or read_secret("NETBOX_TOKEN") or "")
 IGNORE_SSL_ERRORS = os.getenv("IGNORE_SSL_ERRORS", "True") == "True"
 
 # 43200 seconds = 12 hours

--- a/osism/utils/__init__.py
+++ b/osism/utils/__init__.py
@@ -73,7 +73,7 @@ try:
             )
         if (
             "NETBOX_TOKEN" not in secondary_nb_settings
-            or not secondary_nb_settings["NETBOX_TOKEN"]
+            or not str(secondary_nb_settings["NETBOX_TOKEN"]).strip()
         ):
             raise ValueError(
                 "All NETBOX_TOKEN values in the elements of setting NETBOX_SECONDARIES need to be valid NetBox tokens"
@@ -82,7 +82,7 @@ try:
         secondary_nb_list.append(
             get_netbox_connection(
                 secondary_nb_settings["NETBOX_URL"],
-                secondary_nb_settings["NETBOX_TOKEN"],
+                str(secondary_nb_settings["NETBOX_TOKEN"]),
                 secondary_nb_settings.get("IGNORE_SSL_ERRORS", True),
             )
         )


### PR DESCRIPTION
Convert NETBOX_TOKEN values to string type to prevent type errors when the token is None or read from environment/secrets. This ensures consistent string handling across netbox.py, settings.py, and utils.

Part of osism/issues#1282