### PR TITLE
Add BFD configuration support for SONiC BGP interfaces

### DIFF
--- a/files/sonic/config_db.json
+++ b/files/sonic/config_db.json
@@ -29,6 +29,8 @@
     "BGP_GLOBALS_AF_NETWORK": {},
     "BGP_NEIGHBOR": {},
     "BGP_NEIGHBOR_AF": {},
+    "BFD_PEER": {},
+    "BFD_PROFILE": {},
     "BREAKOUT_CFG": {},
     "BREAKOUT_PORTS": {},
     "CLASSIFIER_TABLE": {

--- a/osism/tasks/conductor/sonic/__init__.py
+++ b/osism/tasks/conductor/sonic/__init__.py
@@ -5,6 +5,7 @@
 from .config_generator import generate_sonic_config
 from .exporter import save_config_to_netbox, export_config_to_file
 from .sync import sync_sonic
+from .bfd import add_bfd_configurations, should_interface_have_bfd
 from .connections import (
     get_connected_interfaces,
     get_connected_device_for_sonic_interface,
@@ -18,6 +19,8 @@ __all__ = [
     "save_config_to_netbox",
     "export_config_to_file",
     "sync_sonic",
+    "add_bfd_configurations",
+    "should_interface_have_bfd",
     "get_connected_interfaces",
     "get_connected_device_for_sonic_interface",
     "get_connected_device_via_interface",

--- a/osism/tasks/conductor/sonic/bfd.py
+++ b/osism/tasks/conductor/sonic/bfd.py
@@ -1,0 +1,238 @@
+# SPDX-License-Identifier: Apache-2.0
+
+"""BFD configuration logic for SONiC."""
+
+from loguru import logger
+from .connections import get_connected_device_for_sonic_interface
+
+# Node device roles that should trigger BFD configuration
+NETBOX_NODE_ROLES = [
+    "compute",
+    "storage",
+    "resource",
+    "control",
+    "manager",
+    "network",
+    "metalbox",
+    "dpu",
+    "loadbalancer",
+    "router",
+    "firewall",
+]
+
+# Switch device roles that should trigger BFD configuration
+NETBOX_SWITCH_ROLES = [
+    "accessleaf",
+    "borderleaf",
+    "computeleaf",
+    "dataleaf",
+    "leaf",
+    "serviceleaf",
+    "spine",
+    "storageleaf",
+    "superspine",
+    "switch",
+    "transferleaf",
+]
+
+# Combined list of all BFD-enabled roles
+BFD_ENABLED_ROLES = NETBOX_NODE_ROLES + NETBOX_SWITCH_ROLES
+
+
+def should_interface_have_bfd(
+    port_name,
+    device,
+    bgp_neighbor_interfaces,
+    interface_ips=None,
+    netbox_interfaces=None,
+    transfer_ips=None,
+    portchannel_info=None,
+):
+    """Determine if an interface should have BFD configuration.
+
+    An interface qualifies for BFD configuration if ALL these criteria are met:
+    1. The interface already has BGP neighbor configuration
+    2. The connected device has a role from BFD_ENABLED_ROLES
+    3. The interface has either:
+       - IPv4 addresses from transfer role prefixes, OR
+       - No direct IPv4 addresses (IPv6-only mode)
+    4. Regular interfaces must not be port channel members (BFD is configured on the port channel itself)
+
+    Args:
+        port_name: SONiC interface name (e.g., "Ethernet0", "PortChannel1")
+        device: NetBox device object
+        bgp_neighbor_interfaces: Set of interface names that have BGP neighbors
+        interface_ips: Dict of direct IPv4 addresses on interfaces
+        netbox_interfaces: Dict mapping SONiC names to NetBox interface info
+        transfer_ips: Dict of IPv4 addresses from transfer role prefixes
+        portchannel_info: Port channel membership information
+
+    Returns:
+        bool: True if interface should have BFD configuration, False otherwise
+    """
+    # Check if interface already has BGP neighbor configuration
+    if port_name not in bgp_neighbor_interfaces:
+        logger.debug(
+            f"Interface {port_name} excluded from BFD: no BGP neighbor configuration"
+        )
+        return False
+
+    # Check if this is a port channel member (BFD should be on the port channel, not member)
+    if portchannel_info and port_name in portchannel_info.get("member_mapping", {}):
+        logger.debug(f"Interface {port_name} excluded from BFD: port channel member")
+        return False
+
+    # Get connected device
+    connected_device = get_connected_device_for_sonic_interface(device, port_name)
+    if not connected_device:
+        logger.debug(
+            f"Interface {port_name} excluded from BFD: no connected device found"
+        )
+        return False
+
+    # Check if connected device has a BFD-enabled role
+    if not connected_device.role or connected_device.role.slug not in BFD_ENABLED_ROLES:
+        logger.debug(
+            f"Interface {port_name} excluded from BFD: connected device {connected_device.name} "
+            f"has role '{connected_device.role.slug if connected_device.role else 'None'}' "
+            f"(not in BFD_ENABLED_ROLES)"
+        )
+        return False
+
+    # Check network type criteria (transfer role IPv4 OR IPv6-only mode)
+    has_direct_ipv4 = _has_direct_ipv4_address(
+        port_name, interface_ips, netbox_interfaces
+    )
+    has_transfer_ipv4 = _has_transfer_role_ipv4(
+        port_name, transfer_ips, netbox_interfaces
+    )
+
+    # Include interfaces with transfer role IPv4 or no direct IPv4 (IPv6-only)
+    if has_transfer_ipv4 or not has_direct_ipv4:
+        logger.debug(
+            f"Interface {port_name} qualifies for BFD: connected to {connected_device.name} "
+            f"({connected_device.role.slug}), transfer_ipv4={has_transfer_ipv4}, "
+            f"direct_ipv4={has_direct_ipv4}"
+        )
+        return True
+    else:
+        logger.debug(
+            f"Interface {port_name} excluded from BFD: has direct IPv4 but not transfer role"
+        )
+        return False
+
+
+def add_bfd_configurations(
+    config,
+    bgp_neighbor_interfaces,
+    device,
+    interface_ips=None,
+    netbox_interfaces=None,
+    transfer_ips=None,
+    portchannel_info=None,
+):
+    """Add BFD configuration sections to the SONiC configuration.
+
+    This function adds BFD_PROFILE and BFD_PEER configurations for interfaces
+    that qualify for BFD based on the specified criteria.
+
+    Args:
+        config: Configuration dictionary to update
+        bgp_neighbor_interfaces: Set of interface names that have BGP neighbors
+        device: NetBox device object
+        interface_ips: Dict of direct IPv4 addresses on interfaces
+        netbox_interfaces: Dict mapping SONiC names to NetBox interface info
+        transfer_ips: Dict of IPv4 addresses from transfer role prefixes
+        portchannel_info: Port channel membership information
+    """
+    # Initialize BFD configuration sections
+    if "BFD_PROFILE" not in config:
+        config["BFD_PROFILE"] = {}
+    if "BFD_PEER" not in config:
+        config["BFD_PEER"] = {}
+
+    # Add default BFD profile with SONiC best practices
+    config["BFD_PROFILE"]["default"] = {
+        "detect_multiplier": "3",  # Number of missed packets before declaring failure
+        "desired_min_tx": "300",  # Desired minimum TX interval (ms)
+        "required_min_rx": "300",  # Required minimum RX interval (ms)
+        "passive_mode": "false",  # Active BFD mode
+    }
+
+    bfd_interface_count = 0
+
+    # Check all interfaces for BFD eligibility
+    all_interfaces = set()
+
+    # Add regular interfaces
+    if "PORT" in config:
+        all_interfaces.update(config["PORT"].keys())
+
+    # Add port channels
+    if "PORTCHANNEL" in config:
+        all_interfaces.update(config["PORTCHANNEL"].keys())
+
+    for interface_name in all_interfaces:
+        if should_interface_have_bfd(
+            interface_name,
+            device,
+            bgp_neighbor_interfaces,
+            interface_ips,
+            netbox_interfaces,
+            transfer_ips,
+            portchannel_info,
+        ):
+            # Add BFD peer configuration
+            peer_key = f"default|{interface_name}"
+            config["BFD_PEER"][peer_key] = {
+                "profile": "default",  # Use default BFD profile
+                "multihop": "false",  # Single-hop BFD (directly connected)
+            }
+            bfd_interface_count += 1
+            logger.info(f"Added BFD configuration for interface {interface_name}")
+
+    logger.info(
+        f"Added BFD configuration for {bfd_interface_count} interfaces on device {device.name}"
+    )
+
+
+def _has_direct_ipv4_address(port_name, interface_ips, netbox_interfaces):
+    """Check if an interface has a direct IPv4 address assigned.
+
+    Args:
+        port_name: SONiC interface name (e.g., "Ethernet0")
+        interface_ips: Dict mapping NetBox interface names to IPv4 addresses
+        netbox_interfaces: Dict mapping SONiC names to NetBox interface info
+
+    Returns:
+        bool: True if interface has a direct IPv4 address, False otherwise
+    """
+    if not interface_ips or not netbox_interfaces:
+        return False
+
+    if port_name in netbox_interfaces:
+        netbox_interface_name = netbox_interfaces[port_name]["netbox_name"]
+        return netbox_interface_name in interface_ips
+
+    return False
+
+
+def _has_transfer_role_ipv4(port_name, transfer_ips, netbox_interfaces):
+    """Check if an interface has an IPv4 from a transfer role prefix.
+
+    Args:
+        port_name: SONiC interface name (e.g., "Ethernet0")
+        transfer_ips: Dict mapping NetBox interface names to transfer role IPv4 addresses
+        netbox_interfaces: Dict mapping SONiC names to NetBox interface info
+
+    Returns:
+        bool: True if interface has a transfer role IPv4 address, False otherwise
+    """
+    if not transfer_ips or not netbox_interfaces:
+        return False
+
+    if port_name in netbox_interfaces:
+        netbox_interface_name = netbox_interfaces[port_name]["netbox_name"]
+        return netbox_interface_name in transfer_ips
+
+    return False

--- a/osism/tasks/conductor/sonic/config_generator.py
+++ b/osism/tasks/conductor/sonic/config_generator.py
@@ -17,6 +17,7 @@ from osism.tasks.conductor.netbox import (
     get_device_vlans,
 )
 from .bgp import calculate_local_asn_from_ipv4
+from .bfd import add_bfd_configurations
 from .device import get_device_platform, get_device_hostname, get_device_mac_address
 from .interface import (
     get_port_config,
@@ -203,7 +204,7 @@ def generate_sonic_config(device, hwsku, device_as_mapping=None):
     )
 
     # Add BGP configurations
-    _add_bgp_configurations(
+    bgp_neighbor_interfaces = _add_bgp_configurations(
         config,
         connected_interfaces,
         connected_portchannels,
@@ -213,6 +214,17 @@ def generate_sonic_config(device, hwsku, device_as_mapping=None):
         interface_ips,
         netbox_interfaces,
         transfer_ips,
+    )
+
+    # Add BFD configurations for BGP interfaces
+    add_bfd_configurations(
+        config,
+        bgp_neighbor_interfaces,
+        device,
+        interface_ips,
+        netbox_interfaces,
+        transfer_ips,
+        portchannel_info,
     )
 
     # Add NTP server configuration (device-specific)
@@ -730,7 +742,13 @@ def _add_bgp_configurations(
         interface_ips: Dict of direct IPv4 addresses on interfaces
         netbox_interfaces: Dict mapping SONiC names to NetBox interface info
         transfer_ips: Dict of IPv4 addresses from transfer role prefixes
+
+    Returns:
+        set: Set of interface names that have BGP neighbor configuration
     """
+    # Track interfaces that get BGP neighbor configuration
+    bgp_neighbor_interfaces = set()
+
     # Add BGP_NEIGHBOR_AF configuration for connected interfaces
     for port_name in config["PORT"]:
         has_direct_ipv4 = _has_direct_ipv4_address(
@@ -748,6 +766,7 @@ def _add_bgp_configurations(
             if has_transfer_ipv4 or not has_direct_ipv4:
                 ipv4_key = f"default|{port_name}|ipv4_unicast"
                 config["BGP_NEIGHBOR_AF"][ipv4_key] = {"admin_status": "true"}
+                bgp_neighbor_interfaces.add(port_name)
 
                 # Only add ipv6_unicast if v6only would be true (no transfer role IPv4)
                 if not has_transfer_ipv4:
@@ -771,6 +790,7 @@ def _add_bgp_configurations(
         ipv6_key = f"default|{pc_name}|ipv6_unicast"
         config["BGP_NEIGHBOR_AF"][ipv4_key] = {"admin_status": "true"}
         config["BGP_NEIGHBOR_AF"][ipv6_key] = {"admin_status": "true"}
+        bgp_neighbor_interfaces.add(pc_name)
 
     # Add BGP_NEIGHBOR configuration for connected interfaces
     for port_name in config["PORT"]:
@@ -834,6 +854,8 @@ def _add_bgp_configurations(
             "peer_type": peer_type,
             "v6only": "true",
         }
+
+    return bgp_neighbor_interfaces
 
 
 def _get_connected_device_for_interface(device, interface_name):

--- a/osism/tasks/conductor/sonic/sync.py
+++ b/osism/tasks/conductor/sonic/sync.py
@@ -167,13 +167,13 @@ def sync_sonic(device_name=None, task_id=None, show_diff=True):
 
             # Output diff to task if available and there are changes
             if task_id and netbox_changed and diff_output:
-                utils.push_task_output(task_id, f"\n{'='*60}\n")
+                utils.push_task_output(task_id, f"\n{'='*60}\n")  # noqa E226
                 utils.push_task_output(
                     task_id, f"Configuration diff for {device.name}:\n"
                 )
-                utils.push_task_output(task_id, f"{'='*60}\n")
+                utils.push_task_output(task_id, f"{'='*60}\n")  # noqa E226
                 utils.push_task_output(task_id, f"{diff_output}\n")
-                utils.push_task_output(task_id, f"{'='*60}\n\n")
+                utils.push_task_output(task_id, f"{'='*60}\n\n")  # noqa E226
             elif task_id and netbox_changed and not diff_output:
                 # First-time configuration (no diff available)
                 utils.push_task_output(


### PR DESCRIPTION
Implements Bidirectional Forwarding Detection (BFD) for BGP neighbor interfaces to enable fast failure detection on network links. BFD peers are automatically configured for qualifying interfaces based on device roles and network type.

Key features:
- Adds BFD_PEER and BFD_PROFILE sections to SONiC config_db
- Configures BFD for interfaces with BGP neighbors connecting to specific device roles
- Supports both transfer role IPv4 and IPv6-only interfaces
- Uses SONiC best practice timers (300ms intervals, 3x multiplier)
- Excludes port channel members (BFD configured on port channel itself)

Qualifying criteria for BFD:
1. Interface must have BGP neighbor configuration
2. Connected device must have a BFD-enabled role (compute, storage, leaf, spine, etc.)
3. Interface must use transfer role IPv4 or be IPv6-only (no direct IPv4)

AI-assisted: Claude Code