### PR TITLE
Set netbox states unconditionally during ironic sync

### DIFF
--- a/osism/tasks/conductor/ironic.py
+++ b/osism/tasks/conductor/ironic.py
@@ -227,13 +227,9 @@ def sync_ironic(request_id, get_ironic_parameters, node_name=None, force_update=
                     node = openstack.baremetal_node_create(device.name, node_attributes)
                 else:
                     # NOTE: The listener service only reacts to changes in the baremetal node. Explicitly sync provision and power state in case updates were missed by the listener.
-                    if (
-                        device.custom_fields["provision_state"]
-                        != node["provision_state"]
-                    ):
-                        netbox.set_provision_state(device.name, node["provision_state"])
-                    if device.custom_fields["power_state"] != node["power_state"]:
-                        netbox.set_power_state(device.name, node["power_state"])
+                    # This sync is done unconditionally, because we do not know the state of secondary netboxes at this point
+                    netbox.set_provision_state(device.name, node["provision_state"])
+                    netbox.set_power_state(device.name, node["power_state"])
                     # NOTE: Check whether the baremetal node needs to be updated
                     node_updates = {}
                     deep_compare(node_attributes, node, node_updates)


### PR DESCRIPTION
Always sync the power and provision states with all netboxes during `osism sync ironic`.
We only have the states of the primary netbox. Instead of querying and comparing state with all secondary netboxes, we simply sync unconditionally.