### PR TITLE
Replace local_interface with local_addr in BGP neighbor configuration

### DIFF
--- a/osism/tasks/conductor/sonic/config_generator.py
+++ b/osism/tasks/conductor/sonic/config_generator.py
@@ -848,9 +848,25 @@ def _add_bgp_configurations(
                     "v6only": "false" if has_transfer_ipv4 else "true",
                 }
 
-                # If using IP address as key, also store the local interface
+                # If using IP address as key, also store the local address
                 if connected_ipv4:
-                    bgp_neighbor_config["local_interface"] = port_name
+                    # Get the local interface IPv4 address
+                    local_ipv4 = None
+                    if port_name in netbox_interfaces:
+                        netbox_interface_name = netbox_interfaces[port_name][
+                            "netbox_name"
+                        ]
+                        if netbox_interface_name in interface_ips:
+                            local_ipv4 = interface_ips[netbox_interface_name].split(
+                                "/"
+                            )[0]
+                        elif netbox_interface_name in transfer_ips:
+                            local_ipv4 = transfer_ips[netbox_interface_name].split("/")[
+                                0
+                            ]
+
+                    if local_ipv4:
+                        bgp_neighbor_config["local_addr"] = local_ipv4
 
                 config["BGP_NEIGHBOR"][neighbor_key] = bgp_neighbor_config
 
@@ -897,9 +913,15 @@ def _add_bgp_configurations(
             "v6only": "true",
         }
 
-        # If using IP address as key, also store the local interface
+        # If using IP address as key, also store the local address
         if connected_ipv4:
-            bgp_neighbor_config["local_interface"] = pc_name
+            # For port channels, get the local IPv4 address from interface IPs
+            # Note: Port channels don't have direct IP assignments in NetBox,
+            # so we use the connected interface IP logic
+            local_ipv4 = None
+            # Port channels don't have NetBox interface entries,
+            # so we skip local_addr for port channels for now
+            # TODO: Implement port channel local address lookup if needed
 
         config["BGP_NEIGHBOR"][neighbor_key] = bgp_neighbor_config
 


### PR DESCRIPTION
- Change BGP_NEIGHBOR configuration to use local_addr instead of local_interface
- Extract IP address from interface_ips or transfer_ips without CIDR notation
- Use actual IP address of the local interface for BGP neighbor relationships
- Add TODO for port channel local address implementation

AI-assisted: Claude Code