### PR TITLE
Support multiple IPv4 addresses per interface in NetBox integration

### DIFF
--- a/osism/tasks/conductor/netbox.py
+++ b/osism/tasks/conductor/netbox.py
@@ -319,9 +319,9 @@ def get_device_interface_ips(device):
         device: NetBox device object
 
     Returns:
-        dict: Dictionary mapping interface names to their IPv4 addresses
+        dict: Dictionary mapping interface names to list of their IPv4 addresses
               {
-                  'interface_name': 'ip_address/prefix_length',
+                  'interface_name': ['ip_address/prefix_length', 'ip_address2/prefix_length2', ...],
                   ...
               }
     """
@@ -345,20 +345,24 @@ def get_device_interface_ips(device):
                 assigned_object_id=interface.id,
             )
 
+            ipv4_addresses = []
             for ip_addr in ip_addresses:
                 if ip_addr.address:
                     # Check if it's an IPv4 address
                     try:
                         ip_obj = ipaddress.ip_interface(ip_addr.address)
                         if ip_obj.version == 4:
-                            interface_ips[interface.name] = ip_addr.address
+                            ipv4_addresses.append(ip_addr.address)
                             logger.debug(
                                 f"Found IPv4 address {ip_addr.address} on interface {interface.name} of device {device.name}"
                             )
-                            break  # Only use the first IPv4 address found
                     except (ValueError, ipaddress.AddressValueError):
                         # Skip invalid IP addresses
                         continue
+
+            # Store all IPv4 addresses for this interface
+            if ipv4_addresses:
+                interface_ips[interface.name] = ipv4_addresses
 
     except Exception as e:
         logger.warning(


### PR DESCRIPTION
Updates interface IP handling to collect and configure all IPv4 addresses assigned to an interface instead of just the first one. This allows for proper multi-homing scenarios where interfaces have multiple IP addresses.

Changes:
- Modified get_device_interface_ips() to return list of IPv4 addresses
- Updated SONiC config generator to handle multiple addresses per interface
- Enhanced BGP configuration to use first address as local_addr
- Updated documentation and logging to reflect multiple address support

AI-assisted: Claude Code