### PR TITLE
frontend: add maintenance filter and fix search errors

### DIFF
--- a/frontend/app/nodes/page.tsx
+++ b/frontend/app/nodes/page.tsx
@@ -10,6 +10,7 @@ export default function NodesPage() {
   const [searchTerm, setSearchTerm] = useState("");
   const [filterProvisionState, setFilterProvisionState] = useState("all");
   const [filterPowerState, setFilterPowerState] = useState("all");
+  const [filterMaintenance, setFilterMaintenance] = useState("all");
 
   const { data, isLoading, error, refetch, isRefetching } = useQuery({
     queryKey: ["baremetal-nodes"],
@@ -19,8 +20,8 @@ export default function NodesPage() {
 
   const filteredNodes = data?.nodes.filter((node: BaremetalNode) => {
     const matchesSearch = searchTerm === "" || 
-      node.name?.toLowerCase().includes(searchTerm.toLowerCase()) ||
-      node.uuid.toLowerCase().includes(searchTerm.toLowerCase());
+      (node.name && node.name.toLowerCase().includes(searchTerm.toLowerCase())) ||
+      (node.uuid && node.uuid.toLowerCase().includes(searchTerm.toLowerCase()));
     
     const matchesProvisionState = filterProvisionState === "all" || 
       node.provision_state === filterProvisionState;
@@ -28,7 +29,11 @@ export default function NodesPage() {
     const matchesPowerState = filterPowerState === "all" || 
       node.power_state === filterPowerState;
 
-    return matchesSearch && matchesProvisionState && matchesPowerState;
+    const matchesMaintenance = filterMaintenance === "all" ||
+      (filterMaintenance === "maintenance" && node.maintenance === true) ||
+      (filterMaintenance === "active" && node.maintenance === false);
+
+    return matchesSearch && matchesProvisionState && matchesPowerState && matchesMaintenance;
   });
 
   const uniqueProvisionStates = data ? 
@@ -58,7 +63,7 @@ export default function NodesPage() {
 
       <div className="bg-white shadow rounded-lg mb-6">
         <div className="px-4 py-5 sm:p-6">
-          <div className="grid grid-cols-1 gap-4 sm:grid-cols-3">
+          <div className="grid grid-cols-1 gap-4 sm:grid-cols-4">
             <div>
               <label htmlFor="search" className="block text-sm font-medium text-gray-700">
                 Search
@@ -112,6 +117,23 @@ export default function NodesPage() {
                 {uniquePowerStates.map(state => (
                   <option key={state} value={state}>{state}</option>
                 ))}
+              </select>
+            </div>
+
+            <div>
+              <label htmlFor="maintenance-state" className="block text-sm font-medium text-gray-700">
+                Maintenance
+              </label>
+              <select
+                id="maintenance-state"
+                name="maintenance-state"
+                className="mt-1 block w-full pl-3 pr-10 py-2 text-base border-gray-300 focus:outline-none focus:ring-blue-500 focus:border-blue-500 sm:text-sm rounded-md"
+                value={filterMaintenance}
+                onChange={(e) => setFilterMaintenance(e.target.value)}
+              >
+                <option value="all">All</option>
+                <option value="active">Active</option>
+                <option value="maintenance">Maintenance</option>
               </select>
             </div>
           </div>

--- a/frontend/app/page.tsx
+++ b/frontend/app/page.tsx
@@ -105,53 +105,6 @@ export default function Home() {
         })}
       </div>
 
-      {nodesData && nodesData.nodes.length > 0 && (
-        <div className="mt-8">
-          <h3 className="text-lg font-medium text-gray-900 mb-4">
-            Recent Nodes
-          </h3>
-          <div className="bg-white shadow overflow-hidden sm:rounded-md">
-            <ul className="divide-y divide-gray-200">
-              {nodesData.nodes.slice(0, 5).map((node) => (
-                <li key={node.uuid}>
-                  <div className="px-4 py-4 sm:px-6">
-                    <div className="flex items-center justify-between">
-                      <div className="flex items-center">
-                        <p className="text-sm font-medium text-gray-900">
-                          {node.name || node.uuid}
-                        </p>
-                        <div className="ml-4 flex items-center space-x-2">
-                          <span className={`px-2 inline-flex text-xs leading-5 font-semibold rounded-full ${
-                            node.power_state === "power on" 
-                              ? "bg-green-100 text-green-800"
-                              : "bg-gray-100 text-gray-800"
-                          }`}>
-                            {node.power_state || "unknown"}
-                          </span>
-                          <span className={`px-2 inline-flex text-xs leading-5 font-semibold rounded-full ${
-                            node.provision_state === "active"
-                              ? "bg-blue-100 text-blue-800"
-                              : node.provision_state === "available"
-                              ? "bg-green-100 text-green-800"
-                              : "bg-gray-100 text-gray-800"
-                          }`}>
-                            {node.provision_state || "unknown"}
-                          </span>
-                        </div>
-                      </div>
-                      {node.maintenance && (
-                        <span className="px-2 inline-flex text-xs leading-5 font-semibold rounded-full bg-yellow-100 text-yellow-800">
-                          Maintenance
-                        </span>
-                      )}
-                    </div>
-                  </div>
-                </li>
-              ))}
-            </ul>
-          </div>
-        </div>
-      )}
     </div>
   );
 }


### PR DESCRIPTION
- Add maintenance state filter to nodes page with All/Active/Maintenance options
- Fix client-side error in node search by improving null safety in filtering logic
- Remove Recent Nodes section from landing page to simplify dashboard

AI-assisted: Claude Code