### PR TITLE
frontend: implement runtime API URL configuration

### DIFF
--- a/frontend/app/api/config/route.ts
+++ b/frontend/app/api/config/route.ts
@@ -1,0 +1,7 @@
+import { NextResponse } from 'next/server';
+
+export async function GET() {
+  return NextResponse.json({
+    apiUrl: process.env.NEXT_PUBLIC_OSISM_API_URL || 'http://api:8000'
+  });
+}

--- a/frontend/app/api/health/route.ts
+++ b/frontend/app/api/health/route.ts
@@ -1,0 +1,9 @@
+import { NextResponse } from 'next/server';
+
+export async function GET() {
+  return NextResponse.json({
+    status: 'healthy',
+    timestamp: new Date().toISOString(),
+    service: 'OSISM Frontend'
+  });
+}


### PR DESCRIPTION
Enable NEXT_PUBLIC_OSISM_API_URL to be read at runtime instead of build time by:
- Adding /api/config endpoint to expose environment variables at runtime
- Refactoring API client to dynamically fetch configuration
- Supporting both client-side and server-side environment variable reading

AI-assisted: Claude Code