### PR TITLE
frontend: add real-time Events tab for Baremetal monitoring

### DIFF
--- a/frontend/app/components/ConnectionStatus.tsx
+++ b/frontend/app/components/ConnectionStatus.tsx
@@ -1,0 +1,51 @@
+"use client";
+
+import { Wifi, WifiOff, AlertCircle } from "lucide-react";
+import { ConnectionStatus as ConnectionStatusType } from "@/lib/types";
+import { formatDistanceToNow } from "date-fns";
+
+interface ConnectionStatusProps {
+  status: ConnectionStatusType;
+  className?: string;
+}
+
+export default function ConnectionStatus({ status, className = "" }: ConnectionStatusProps) {
+  const getStatusContent = () => {
+    if (status.connected) {
+      return {
+        icon: Wifi,
+        text: "Connected",
+        color: "text-green-600",
+        bgColor: "bg-green-100",
+      };
+    } else if (status.error) {
+      return {
+        icon: AlertCircle,
+        text: `Disconnected: ${status.error}`,
+        color: "text-red-600",
+        bgColor: "bg-red-100",
+      };
+    } else {
+      return {
+        icon: WifiOff,
+        text: "Disconnected",
+        color: "text-gray-600",
+        bgColor: "bg-gray-100",
+      };
+    }
+  };
+
+  const { icon: Icon, text, color, bgColor } = getStatusContent();
+
+  return (
+    <div className={`inline-flex items-center px-3 py-1 rounded-full text-sm font-medium ${bgColor} ${color} ${className}`}>
+      <Icon className="h-4 w-4 mr-2" />
+      <span>{text}</span>
+      {status.lastConnected && !status.connected && (
+        <span className="ml-2 text-xs opacity-75">
+          (Last: {formatDistanceToNow(status.lastConnected)} ago)
+        </span>
+      )}
+    </div>
+  );
+}

--- a/frontend/app/components/EventsFilters.tsx
+++ b/frontend/app/components/EventsFilters.tsx
@@ -1,0 +1,150 @@
+"use client";
+
+import { useState, useCallback } from "react";
+import { Filter, X } from "lucide-react";
+import { WebSocketFilter } from "@/lib/types";
+
+interface EventsFiltersProps {
+  onFiltersChange: (filters: WebSocketFilter) => void;
+  className?: string;
+}
+
+const BAREMETAL_EVENT_TYPES = [
+  "baremetal.node.power_set.end",
+  "baremetal.node.provision_set.start",
+  "baremetal.node.provision_set.end", 
+  "baremetal.node.provision_set.success",
+  "baremetal.node.power_state_corrected.success",
+  "baremetal.node.maintenance_set.end",
+  "baremetal.node.create.end",
+  "baremetal.node.delete.end",
+];
+
+export default function EventsFilters({ onFiltersChange, className = "" }: EventsFiltersProps) {
+  const [isOpen, setIsOpen] = useState(false);
+  const [selectedEventTypes, setSelectedEventTypes] = useState<string[]>([]);
+  const [nodeFilter, setNodeFilter] = useState("");
+
+  const applyFilters = useCallback(() => {
+    const filters: WebSocketFilter = {
+      service_filters: ["baremetal"], // Always filter for baremetal events
+    };
+
+    if (selectedEventTypes.length > 0) {
+      filters.event_filters = selectedEventTypes;
+    }
+
+    if (nodeFilter.trim()) {
+      filters.node_filters = nodeFilter.split(",").map(n => n.trim()).filter(n => n);
+    }
+
+    onFiltersChange(filters);
+    setIsOpen(false);
+  }, [selectedEventTypes, nodeFilter, onFiltersChange]);
+
+  const clearFilters = useCallback(() => {
+    setSelectedEventTypes([]);
+    setNodeFilter("");
+    onFiltersChange({ service_filters: ["baremetal"] });
+  }, [onFiltersChange]);
+
+  const toggleEventType = useCallback((eventType: string) => {
+    setSelectedEventTypes(prev => 
+      prev.includes(eventType)
+        ? prev.filter(t => t !== eventType)
+        : [...prev, eventType]
+    );
+  }, []);
+
+  const hasActiveFilters = selectedEventTypes.length > 0 || nodeFilter.trim().length > 0;
+
+  return (
+    <div className={`relative ${className}`}>
+      <button
+        onClick={() => setIsOpen(!isOpen)}
+        className={`inline-flex items-center px-4 py-2 border rounded-md text-sm font-medium transition-colors ${
+          hasActiveFilters
+            ? "border-blue-500 bg-blue-50 text-blue-700"
+            : "border-gray-300 bg-white text-gray-700 hover:bg-gray-50"
+        }`}
+      >
+        <Filter className="h-4 w-4 mr-2" />
+        Filters
+        {hasActiveFilters && (
+          <span className="ml-2 inline-flex items-center px-2 py-0.5 rounded-full text-xs font-medium bg-blue-100 text-blue-800">
+            {(selectedEventTypes.length > 0 ? 1 : 0) + (nodeFilter ? 1 : 0)}
+          </span>
+        )}
+      </button>
+
+      {isOpen && (
+        <div className="absolute top-full left-0 mt-2 w-96 bg-white border border-gray-200 rounded-lg shadow-lg z-10">
+          <div className="p-4 border-b border-gray-200">
+            <div className="flex items-center justify-between">
+              <h3 className="text-sm font-medium text-gray-900">Event Filters</h3>
+              <button
+                onClick={() => setIsOpen(false)}
+                className="text-gray-400 hover:text-gray-600"
+              >
+                <X className="h-4 w-4" />
+              </button>
+            </div>
+          </div>
+
+          <div className="p-4 space-y-4">
+            {/* Node Filter */}
+            <div>
+              <label className="block text-sm font-medium text-gray-700 mb-2">
+                Node Names (comma-separated)
+              </label>
+              <input
+                type="text"
+                value={nodeFilter}
+                onChange={(e) => setNodeFilter(e.target.value)}
+                placeholder="e.g., server-01, server-02"
+                className="w-full px-3 py-2 border border-gray-300 rounded-md text-sm focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-blue-500"
+              />
+            </div>
+
+            {/* Event Type Filter */}
+            <div>
+              <label className="block text-sm font-medium text-gray-700 mb-2">
+                Event Types
+              </label>
+              <div className="space-y-2 max-h-48 overflow-y-auto">
+                {BAREMETAL_EVENT_TYPES.map((eventType) => (
+                  <label key={eventType} className="flex items-center">
+                    <input
+                      type="checkbox"
+                      checked={selectedEventTypes.includes(eventType)}
+                      onChange={() => toggleEventType(eventType)}
+                      className="h-4 w-4 text-blue-600 focus:ring-blue-500 border-gray-300 rounded"
+                    />
+                    <span className="ml-2 text-sm text-gray-700 font-mono">
+                      {eventType}
+                    </span>
+                  </label>
+                ))}
+              </div>
+            </div>
+          </div>
+
+          <div className="p-4 border-t border-gray-200 flex justify-between">
+            <button
+              onClick={clearFilters}
+              className="px-4 py-2 text-sm font-medium text-gray-700 bg-white border border-gray-300 rounded-md hover:bg-gray-50"
+            >
+              Clear All
+            </button>
+            <button
+              onClick={applyFilters}
+              className="px-4 py-2 text-sm font-medium text-white bg-blue-600 border border-transparent rounded-md hover:bg-blue-700"
+            >
+              Apply Filters
+            </button>
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/frontend/app/components/EventsList.tsx
+++ b/frontend/app/components/EventsList.tsx
@@ -1,0 +1,189 @@
+"use client";
+
+import { useMemo, useState } from "react";
+import { format } from "date-fns";
+import { 
+  Server, 
+  Power, 
+  Settings, 
+  Trash2, 
+  Plus,
+  CheckCircle,
+  XCircle,
+  AlertTriangle,
+  Clock,
+  Pause,
+  Play
+} from "lucide-react";
+import { OpenStackEvent, BaremetalEvent } from "@/lib/types";
+
+interface EventsListProps {
+  events: OpenStackEvent[];
+  className?: string;
+}
+
+const getEventIcon = (eventType: string) => {
+  if (eventType.includes("power")) return Power;
+  if (eventType.includes("provision")) return Settings;
+  if (eventType.includes("maintenance")) return AlertTriangle;
+  if (eventType.includes("create")) return Plus;
+  if (eventType.includes("delete")) return Trash2;
+  return Server;
+};
+
+const getEventColor = (eventType: string) => {
+  if (eventType.includes("power_set.end")) return "text-blue-600 bg-blue-50";
+  if (eventType.includes("provision_set.success")) return "text-green-600 bg-green-50";
+  if (eventType.includes("provision_set.start")) return "text-yellow-600 bg-yellow-50";
+  if (eventType.includes("maintenance")) return "text-orange-600 bg-orange-50";
+  if (eventType.includes("create")) return "text-green-600 bg-green-50";
+  if (eventType.includes("delete")) return "text-red-600 bg-red-50";
+  return "text-gray-600 bg-gray-50";
+};
+
+const getStatusIcon = (eventType: string) => {
+  if (eventType.includes("success")) return CheckCircle;
+  if (eventType.includes("error") || eventType.includes("fail")) return XCircle;
+  if (eventType.includes("start")) return Clock;
+  return null;
+};
+
+const formatEventData = (event: OpenStackEvent) => {
+  if (event.data.service_type === "baremetal" && "ironic_object" in event.data) {
+    const baremetalEvent = event as BaremetalEvent;
+    const ironicData = baremetalEvent.data.ironic_object?.data;
+    
+    if (!ironicData) return null;
+
+    const details = [];
+    if (ironicData.power_state) details.push(`Power: ${ironicData.power_state}`);
+    if (ironicData.provision_state) details.push(`Provision: ${ironicData.provision_state}`);
+    if (ironicData.maintenance !== undefined) details.push(`Maintenance: ${ironicData.maintenance ? "Yes" : "No"}`);
+    
+    return details.join(" | ");
+  }
+  
+  return null;
+};
+
+export default function EventsList({ events, className = "" }: EventsListProps) {
+  const [isPaused, setIsPaused] = useState(false);
+  const [maxEvents, setMaxEvents] = useState(50);
+
+  const displayEvents = useMemo(() => {
+    return isPaused ? events : events.slice(0, maxEvents);
+  }, [events, isPaused, maxEvents]);
+
+  const togglePause = () => {
+    setIsPaused(!isPaused);
+  };
+
+  const loadMore = () => {
+    setMaxEvents(prev => prev + 50);
+  };
+
+  if (events.length === 0) {
+    return (
+      <div className={`text-center py-12 ${className}`}>
+        <Server className="mx-auto h-12 w-12 text-gray-400" />
+        <h3 className="mt-2 text-sm font-medium text-gray-900">No events yet</h3>
+        <p className="mt-1 text-sm text-gray-500">
+          Baremetal events will appear here in real-time.
+        </p>
+      </div>
+    );
+  }
+
+  return (
+    <div className={className}>
+      {/* Controls */}
+      <div className="flex items-center justify-between mb-4 text-sm text-gray-600">
+        <span>{events.length} events total</span>
+        <div className="flex items-center space-x-2">
+          <button
+            onClick={togglePause}
+            className="inline-flex items-center px-3 py-1 border border-gray-300 rounded-md hover:bg-gray-50"
+          >
+            {isPaused ? (
+              <>
+                <Play className="h-4 w-4 mr-1" />
+                Resume
+              </>
+            ) : (
+              <>
+                <Pause className="h-4 w-4 mr-1" />
+                Pause
+              </>
+            )}
+          </button>
+        </div>
+      </div>
+
+      {/* Events List */}
+      <div className="space-y-1">
+        {displayEvents.map((event) => {
+          const Icon = getEventIcon(event.event_type);
+          const StatusIcon = getStatusIcon(event.event_type);
+          const colorClass = getEventColor(event.event_type);
+          const eventDetails = formatEventData(event);
+
+          return (
+            <div
+              key={event.id}
+              className="flex items-start space-x-3 p-3 bg-white border border-gray-200 rounded-lg hover:border-gray-300 transition-colors"
+            >
+              {/* Icon */}
+              <div className={`flex-shrink-0 p-2 rounded-lg ${colorClass}`}>
+                <Icon className="h-4 w-4" />
+              </div>
+
+              {/* Content */}
+              <div className="flex-1 min-w-0">
+                <div className="flex items-center justify-between">
+                  <div className="flex items-center space-x-2">
+                    <span className="text-sm font-medium text-gray-900 font-mono">
+                      {event.event_type}
+                    </span>
+                    {StatusIcon && (
+                      <StatusIcon className="h-4 w-4 text-gray-400" />
+                    )}
+                  </div>
+                  <time className="text-xs text-gray-500 flex-shrink-0">
+                    {format(new Date(event.timestamp), "HH:mm:ss")}
+                  </time>
+                </div>
+
+                {event.node_name && (
+                  <div className="flex items-center mt-1">
+                    <Server className="h-3 w-3 text-gray-400 mr-1" />
+                    <span className="text-sm font-medium text-gray-700">
+                      {event.node_name}
+                    </span>
+                  </div>
+                )}
+
+                {eventDetails && (
+                  <p className="text-sm text-gray-600 mt-1">
+                    {eventDetails}
+                  </p>
+                )}
+              </div>
+            </div>
+          );
+        })}
+      </div>
+
+      {/* Load More */}
+      {!isPaused && events.length > maxEvents && (
+        <div className="mt-4 text-center">
+          <button
+            onClick={loadMore}
+            className="px-4 py-2 text-sm font-medium text-gray-700 bg-white border border-gray-300 rounded-md hover:bg-gray-50"
+          >
+            Load More Events ({events.length - maxEvents} remaining)
+          </button>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/frontend/app/events/page.tsx
+++ b/frontend/app/events/page.tsx
@@ -1,0 +1,197 @@
+"use client";
+
+import { useState, useEffect, useCallback } from "react";
+import { Activity, RefreshCw, Trash2 } from "lucide-react";
+import useWebSocket from "@/lib/hooks/useWebSocket";
+import EventsList from "../components/EventsList";
+import EventsFilters from "../components/EventsFilters";
+import ConnectionStatus from "../components/ConnectionStatus";
+import { WebSocketFilter } from "@/lib/types";
+
+async function getWebSocketUrl(): Promise<string> {
+  if (typeof window !== 'undefined') {
+    try {
+      const response = await fetch('/api/config');
+      if (!response.ok) {
+        throw new Error(`HTTP error! status: ${response.status}`);
+      }
+      const config = await response.json();
+      // Convert HTTP URL to WebSocket URL
+      const apiUrl = config.apiUrl.replace(/^http/, 'ws');
+      const wsUrl = `${apiUrl}/v1/events/openstack`;
+      console.log('Using WebSocket URL from config:', wsUrl);
+      return wsUrl;
+    } catch (error) {
+      console.warn('Failed to fetch API config for WebSocket:', error);
+      const fallbackUrl = 'ws://localhost:8000/v1/events/openstack';
+      console.log('Using fallback WebSocket URL:', fallbackUrl);
+      return fallbackUrl;
+    }
+  }
+  // Server-side fallback
+  const apiUrl = (process.env.NEXT_PUBLIC_OSISM_API_URL || 'http://api:8000').replace(/^http/, 'ws');
+  const wsUrl = `${apiUrl}/v1/events/openstack`;
+  console.log('Using server-side WebSocket URL:', wsUrl);
+  return wsUrl;
+}
+
+export default function EventsPage() {
+  const [wsUrl, setWsUrl] = useState<string>('');
+  const [eventCount, setEventCount] = useState(0);
+
+  // Initialize WebSocket URL
+  useEffect(() => {
+    getWebSocketUrl().then((url) => {
+      console.log('WebSocket URL resolved:', url);
+      setWsUrl(url);
+    });
+  }, []);
+
+  const {
+    events,
+    connectionStatus,
+    connect,
+    disconnect,
+    clearEvents,
+    setFilters
+  } = useWebSocket(wsUrl, {
+    autoConnect: false, // Don't auto-connect until URL is ready
+    onEvent: useCallback(() => {
+      setEventCount(prev => prev + 1);
+    }, [])
+  });
+
+  // Connect only after wsUrl is available
+  useEffect(() => {
+    if (wsUrl) {
+      connect();
+    }
+  }, [wsUrl, connect]);
+
+  const handleFiltersChange = useCallback((filters: WebSocketFilter) => {
+    setFilters(filters);
+  }, [setFilters]);
+
+  const handleReconnect = () => {
+    disconnect();
+    setTimeout(() => {
+      connect();
+    }, 100);
+  };
+
+  const handleClearEvents = () => {
+    clearEvents();
+    setEventCount(0);
+  };
+
+  if (!wsUrl) {
+    return (
+      <div className="px-4 sm:px-0">
+        <div className="animate-pulse">
+          <div className="h-8 bg-gray-200 rounded w-1/4 mb-4"></div>
+          <div className="h-4 bg-gray-200 rounded w-1/2"></div>
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <div className="px-4 sm:px-0">
+      {/* Header */}
+      <div className="mb-6">
+        <div className="flex items-center justify-between">
+          <div>
+            <h2 className="text-2xl font-bold text-gray-900 flex items-center">
+              <Activity className="h-7 w-7 mr-3" />
+              Events
+            </h2>
+            <p className="mt-1 text-sm text-gray-600">
+              Real-time Baremetal events from OpenStack Ironic
+            </p>
+          </div>
+          
+          {/* Connection Status */}
+          <ConnectionStatus status={connectionStatus} />
+        </div>
+      </div>
+
+      {/* Stats & Controls */}
+      <div className="mb-6 flex flex-col sm:flex-row sm:items-center sm:justify-between space-y-4 sm:space-y-0">
+        <div className="flex items-center space-x-4">
+          <div className="bg-white px-4 py-2 rounded-lg border border-gray-200">
+            <div className="flex items-center">
+              <Activity className="h-4 w-4 text-gray-400 mr-2" />
+              <span className="text-sm font-medium text-gray-700">
+                {events.length} events
+              </span>
+              {eventCount > 0 && (
+                <span className="ml-2 inline-flex items-center px-2 py-0.5 rounded-full text-xs font-medium bg-green-100 text-green-800">
+                  +{eventCount} new
+                </span>
+              )}
+            </div>
+          </div>
+          
+          <EventsFilters onFiltersChange={handleFiltersChange} />
+        </div>
+
+        <div className="flex items-center space-x-2">
+          <button
+            onClick={handleReconnect}
+            className="inline-flex items-center px-3 py-2 border border-gray-300 rounded-md text-sm font-medium text-gray-700 bg-white hover:bg-gray-50"
+            disabled={connectionStatus.connected}
+          >
+            <RefreshCw className="h-4 w-4 mr-2" />
+            Reconnect
+          </button>
+          
+          <button
+            onClick={handleClearEvents}
+            className="inline-flex items-center px-3 py-2 border border-gray-300 rounded-md text-sm font-medium text-gray-700 bg-white hover:bg-gray-50"
+            disabled={events.length === 0}
+          >
+            <Trash2 className="h-4 w-4 mr-2" />
+            Clear Events
+          </button>
+        </div>
+      </div>
+
+      {/* Connection Warning */}
+      {!connectionStatus.connected && (
+        <div className="mb-6 bg-yellow-50 border border-yellow-200 rounded-md p-4">
+          <div className="flex">
+            <div className="flex-shrink-0">
+              <Activity className="h-5 w-5 text-yellow-400" />
+            </div>
+            <div className="ml-3">
+              <h3 className="text-sm font-medium text-yellow-800">
+                Connection Issue
+              </h3>
+              <div className="mt-2 text-sm text-yellow-700">
+                <p>
+                  Unable to connect to the events stream. Events may not appear in real-time.
+                  {connectionStatus.error && ` Error: ${connectionStatus.error}`}
+                </p>
+              </div>
+              <div className="mt-4">
+                <div className="-mx-2 -my-1.5 flex">
+                  <button
+                    onClick={handleReconnect}
+                    className="bg-yellow-50 px-2 py-1.5 rounded-md text-sm font-medium text-yellow-800 hover:bg-yellow-100"
+                  >
+                    Try Reconnecting
+                  </button>
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+      )}
+
+      {/* Events List */}
+      <div className="bg-gray-50 rounded-lg p-6">
+        <EventsList events={events} />
+      </div>
+    </div>
+  );
+}

--- a/frontend/app/layout.tsx
+++ b/frontend/app/layout.tsx
@@ -21,6 +21,7 @@ export default function RootLayout({
     { id: "dashboard", name: "Dashboard", href: "/" },
     { id: "nodes", name: "Nodes", href: "/nodes" },
     { id: "services", name: "Services", href: "/services" },
+    { id: "events", name: "Events", href: "/events" },
   ];
 
   return (

--- a/frontend/app/page.tsx
+++ b/frontend/app/page.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { useQuery } from "@tanstack/react-query";
-import { Activity, Server, Settings } from "lucide-react";
+import { Activity, Server, Settings, Zap } from "lucide-react";
 import Link from "next/link";
 import api from "@/lib/api";
 
@@ -41,6 +41,14 @@ export default function Home() {
       value: "N/A",
       icon: Settings,
       href: "/services",
+      loading: false,
+    },
+    {
+      id: "events",
+      name: "Live Events",
+      value: "Stream",
+      icon: Zap,
+      href: "/events",
       loading: false,
     },
   ];

--- a/frontend/lib/hooks/useWebSocket.ts
+++ b/frontend/lib/hooks/useWebSocket.ts
@@ -1,0 +1,209 @@
+"use client";
+
+import { useState, useEffect, useRef, useCallback } from 'react';
+import { OpenStackEvent, WebSocketFilter, ConnectionStatus } from '../types';
+
+interface UseWebSocketOptions {
+  autoConnect?: boolean;
+  reconnectAttempts?: number;
+  reconnectInterval?: number;
+  onEvent?: (event: OpenStackEvent) => void;
+  onConnect?: () => void;
+  onDisconnect?: () => void;
+  onError?: (error: Event) => void;
+}
+
+interface UseWebSocketReturn {
+  events: OpenStackEvent[];
+  connectionStatus: ConnectionStatus;
+  connect: () => void;
+  disconnect: () => void;
+  clearEvents: () => void;
+  setFilters: (filters: WebSocketFilter) => void;
+  sendMessage: (message: Record<string, unknown>) => void;
+}
+
+export const useWebSocket = (
+  url: string,
+  options: UseWebSocketOptions = {}
+): UseWebSocketReturn => {
+  const {
+    autoConnect = true,
+    reconnectAttempts = 5,
+    reconnectInterval = 5000,
+    onEvent,
+    onConnect,
+    onDisconnect,
+    onError
+  } = options;
+
+  const [events, setEvents] = useState<OpenStackEvent[]>([]);
+  const [connectionStatus, setConnectionStatus] = useState<ConnectionStatus>({
+    connected: false
+  });
+
+  const wsRef = useRef<WebSocket | null>(null);
+  const reconnectTimeoutRef = useRef<NodeJS.Timeout | undefined>(undefined);
+  const reconnectAttemptsRef = useRef(0);
+  const isConnectingRef = useRef(false);
+
+  const addEvent = useCallback((event: OpenStackEvent) => {
+    setEvents(prev => [event, ...prev].slice(0, 1000)); // Keep last 1000 events
+    onEvent?.(event);
+  }, [onEvent]);
+
+  const connect = useCallback(() => {
+    if (!url || isConnectingRef.current || (wsRef.current?.readyState === WebSocket.OPEN)) {
+      return;
+    }
+
+    isConnectingRef.current = true;
+    
+    try {
+      // Convert http/https URL to ws/wss for WebSocket
+      const wsUrl = url.replace(/^http/, 'ws');
+      console.log('Attempting WebSocket connection to:', wsUrl);
+      const websocket = new WebSocket(wsUrl);
+
+      websocket.onopen = () => {
+        console.log('WebSocket connected:', wsUrl);
+        isConnectingRef.current = false;
+        reconnectAttemptsRef.current = 0;
+        
+        setConnectionStatus({
+          connected: true,
+          lastConnected: new Date()
+        });
+        
+        onConnect?.();
+      };
+
+      websocket.onmessage = (event) => {
+        try {
+          const data = JSON.parse(event.data);
+          
+          // Handle filter acknowledgment messages
+          if (data.type === 'filter_update') {
+            console.log('Filters updated:', data);
+            return;
+          }
+          
+          // Handle OpenStack events
+          if (data.event_type) {
+            addEvent(data as OpenStackEvent);
+          }
+        } catch (error) {
+          console.error('Error parsing WebSocket message:', error);
+        }
+      };
+
+      websocket.onclose = (event) => {
+        console.log('WebSocket disconnected:', event.code, event.reason);
+        isConnectingRef.current = false;
+        wsRef.current = null;
+        
+        setConnectionStatus({
+          connected: false,
+          error: event.reason || 'Connection closed'
+        });
+        
+        onDisconnect?.();
+        
+        // Attempt reconnection if not manually closed
+        if (event.code !== 1000 && reconnectAttemptsRef.current < reconnectAttempts) {
+          reconnectAttemptsRef.current++;
+          console.log(`Attempting reconnect ${reconnectAttemptsRef.current}/${reconnectAttempts}`);
+          
+          reconnectTimeoutRef.current = setTimeout(() => {
+            connect();
+          }, reconnectInterval);
+        }
+      };
+
+      websocket.onerror = (error) => {
+        console.error('WebSocket error:', error);
+        console.error('WebSocket URL was:', wsUrl);
+        isConnectingRef.current = false;
+        
+        setConnectionStatus({
+          connected: false,
+          error: 'Connection error - check console for details'
+        });
+        
+        onError?.(error);
+      };
+
+      wsRef.current = websocket;
+      
+    } catch (error) {
+      console.error('Failed to create WebSocket connection:', error);
+      isConnectingRef.current = false;
+      
+      setConnectionStatus({
+        connected: false,
+        error: 'Failed to connect'
+      });
+    }
+  }, [url, reconnectAttempts, reconnectInterval, onConnect, onDisconnect, onError, addEvent]);
+
+  const disconnect = useCallback(() => {
+    if (reconnectTimeoutRef.current) {
+      clearTimeout(reconnectTimeoutRef.current);
+    }
+    
+    if (wsRef.current) {
+      wsRef.current.close(1000, 'Manual disconnect');
+      wsRef.current = null;
+    }
+    
+    reconnectAttemptsRef.current = reconnectAttempts; // Prevent reconnection
+    isConnectingRef.current = false;
+    
+    setConnectionStatus({
+      connected: false
+    });
+  }, [reconnectAttempts]);
+
+  const clearEvents = useCallback(() => {
+    setEvents([]);
+  }, []);
+
+  const setFilters = useCallback((filters: WebSocketFilter) => {
+    if (wsRef.current?.readyState === WebSocket.OPEN) {
+      const message = {
+        action: 'set_filters',
+        ...filters
+      };
+      wsRef.current.send(JSON.stringify(message));
+    }
+  }, []);
+
+  const sendMessage = useCallback((message: Record<string, unknown>) => {
+    if (wsRef.current?.readyState === WebSocket.OPEN) {
+      wsRef.current.send(JSON.stringify(message));
+    }
+  }, []);
+
+  // Auto-connect on mount
+  useEffect(() => {
+    if (autoConnect) {
+      connect();
+    }
+
+    return () => {
+      disconnect();
+    };
+  }, [autoConnect, connect, disconnect]);
+
+  return {
+    events,
+    connectionStatus,
+    connect,
+    disconnect,
+    clearEvents,
+    setFilters,
+    sendMessage
+  };
+};
+
+export default useWebSocket;

--- a/frontend/lib/types.ts
+++ b/frontend/lib/types.ts
@@ -27,3 +27,46 @@ export interface DeviceSearchResult {
   result: string;
   device: string | null;
 }
+
+// Event-related types for WebSocket streaming
+export interface OpenStackEvent {
+  id: string;
+  timestamp: string;
+  event_type: string;
+  source: "openstack";
+  node_name: string | null;
+  data: {
+    service_type: string;
+    resource_id?: string;
+    [key: string]: unknown;
+  };
+}
+
+export interface BaremetalEvent extends OpenStackEvent {
+  data: {
+    service_type: "baremetal";
+    resource_id: string;
+    ironic_object: {
+      data: {
+        name: string;
+        uuid: string;
+        power_state?: string;
+        provision_state?: string;
+        maintenance?: boolean;
+        [key: string]: unknown;
+      };
+    };
+  };
+}
+
+export interface WebSocketFilter {
+  event_filters?: string[];
+  node_filters?: string[];
+  service_filters?: string[];
+}
+
+export interface ConnectionStatus {
+  connected: boolean;
+  lastConnected?: Date;
+  error?: string;
+}

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -12,6 +12,7 @@
         "@tanstack/react-query": "^5.84.2",
         "axios": "^1.11.0",
         "clsx": "^2.1.1",
+        "date-fns": "^4.1.0",
         "lucide-react": "^0.541.0",
         "next": "15.5.0",
         "react": "19.1.1",
@@ -2558,6 +2559,16 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/date-fns": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/date-fns/-/date-fns-4.1.0.tgz",
+      "integrity": "sha512-Ukq0owbQXxa/U3EGtsdVBkR1w7KOQ5gIBqdH2hkvknzZPYvBxb/aa6E8L7tmjFtkwZBu3UXBbjIgPo/Ez4xaNg==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/kossnocorp"
       }
     },
     "node_modules/debug": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -13,6 +13,7 @@
     "@tanstack/react-query": "^5.84.2",
     "axios": "^1.11.0",
     "clsx": "^2.1.1",
+    "date-fns": "^4.1.0",
     "lucide-react": "^0.541.0",
     "next": "15.5.0",
     "react": "19.1.1",

--- a/osism/services/event_bridge.py
+++ b/osism/services/event_bridge.py
@@ -1,0 +1,304 @@
+# SPDX-License-Identifier: Apache-2.0
+
+"""
+Event bridge for sharing events between RabbitMQ listener and WebSocket manager.
+This module provides a Redis-based way to forward events from the listener service
+to the WebSocket manager across different containers.
+"""
+
+import threading
+import queue
+import logging
+import json
+import os
+from typing import Dict, Any
+
+try:
+    import redis
+
+    REDIS_AVAILABLE = True
+except ImportError:
+    REDIS_AVAILABLE = False
+
+logger = logging.getLogger("osism.event_bridge")
+
+
+class EventBridge:
+    """Redis-based bridge for forwarding events between RabbitMQ listener and WebSocket manager across containers."""
+
+    def __init__(self):
+        self._event_queue = queue.Queue()
+        self._websocket_manager = None
+        self._processor_thread = None
+        self._subscriber_thread = None
+        self._shutdown_event = threading.Event()
+        self._redis_client = None
+        self._redis_subscriber = None
+
+        # Initialize Redis connection
+        self._init_redis()
+
+    def _init_redis(self):
+        """Initialize Redis connection."""
+        if not REDIS_AVAILABLE:
+            logger.warning(
+                "Redis not available - event bridge will use local queue only"
+            )
+            return
+
+        try:
+            redis_host = os.getenv("REDIS_HOST", "redis")
+            redis_port = int(os.getenv("REDIS_PORT", "6379"))
+            redis_db = int(os.getenv("REDIS_DB", "0"))
+
+            self._redis_client = redis.Redis(
+                host=redis_host,
+                port=redis_port,
+                db=redis_db,
+                decode_responses=True,
+                socket_connect_timeout=10,
+                socket_timeout=None,  # No timeout for blocking operations
+                health_check_interval=30,
+            )
+
+            # Test connection
+            self._redis_client.ping()
+            logger.info(f"Connected to Redis at {redis_host}:{redis_port}")
+
+            # Create subscriber for WebSocket manager (API container)
+            self._redis_subscriber = self._redis_client.pubsub()
+
+        except Exception as e:
+            logger.error(f"Failed to connect to Redis: {e}")
+            self._redis_client = None
+            self._redis_subscriber = None
+
+    def set_websocket_manager(self, websocket_manager):
+        """Set the WebSocket manager instance and start Redis subscriber."""
+        self._websocket_manager = websocket_manager
+        logger.info("WebSocket manager connected to event bridge")
+
+        # Start Redis subscriber thread if Redis is available
+        if self._redis_client and not self._subscriber_thread:
+            self._start_redis_subscriber()
+
+        # Start local processor thread if not already running
+        if not self._processor_thread or not self._processor_thread.is_alive():
+            self._start_processor_thread()
+
+    def add_event(self, event_type: str, payload: Dict[str, Any]) -> None:
+        """Add an event to be forwarded to WebSocket clients via Redis."""
+        try:
+            event_data = {"event_type": event_type, "payload": payload}
+
+            if self._redis_client:
+                # Publish to Redis for cross-container communication
+                try:
+                    message = json.dumps(event_data)
+                    subscribers = self._redis_client.publish("osism:events", message)
+                    logger.info(
+                        f"Published event to Redis: {event_type} (subscribers: {subscribers})"
+                    )
+
+                    if subscribers == 0:
+                        logger.warning(f"No Redis subscribers for event: {event_type}")
+
+                except Exception as redis_error:
+                    logger.error(f"Failed to publish event to Redis: {redis_error}")
+                    # Try to reconnect Redis
+                    try:
+                        self._init_redis()
+                        if self._redis_client:
+                            message = json.dumps(event_data)
+                            subscribers = self._redis_client.publish(
+                                "osism:events", message
+                            )
+                            logger.info(
+                                f"Published event to Redis after reconnect: {event_type} (subscribers: {subscribers})"
+                            )
+                        else:
+                            raise Exception("Redis reconnection failed")
+                    except Exception as reconnect_error:
+                        logger.error(f"Redis reconnection failed: {reconnect_error}")
+                        # Fallback to local queue
+                        self._event_queue.put_nowait(event_data)
+                        logger.debug(
+                            f"Added event to local fallback queue: {event_type}"
+                        )
+            else:
+                # Local queue fallback
+                self._event_queue.put_nowait(event_data)
+                logger.debug(f"Added event to local queue: {event_type}")
+
+        except queue.Full:
+            logger.warning("Event bridge queue is full, dropping event")
+        except Exception as e:
+            logger.error(f"Error adding event to bridge: {e}")
+
+    def _start_redis_subscriber(self):
+        """Start Redis subscriber thread for receiving events from other containers."""
+        self._subscriber_thread = threading.Thread(
+            target=self._redis_subscriber_loop, name="RedisEventSubscriber", daemon=True
+        )
+        self._subscriber_thread.start()
+        logger.info("Started Redis event subscriber thread")
+
+    def _start_processor_thread(self):
+        """Start the background thread that processes local events."""
+        self._processor_thread = threading.Thread(
+            target=self._process_events, name="EventBridgeProcessor", daemon=True
+        )
+        self._processor_thread.start()
+        logger.info("Started event bridge processor thread")
+
+    def _redis_subscriber_loop(self):
+        """Redis subscriber loop for receiving events from other containers with auto-reconnect."""
+        retry_count = 0
+        max_retries = 5
+        retry_delay = 5  # seconds
+
+        while not self._shutdown_event.is_set() and retry_count < max_retries:
+            try:
+                if not self._redis_subscriber:
+                    logger.error("Redis subscriber not available")
+                    return
+
+                logger.info(
+                    f"Starting Redis subscriber (attempt {retry_count + 1}/{max_retries})"
+                )
+                self._redis_subscriber.subscribe("osism:events")
+                logger.info("Subscribed to Redis events channel")
+                retry_count = 0  # Reset retry count on successful connection
+
+                # Use get_message with timeout instead of listen() to avoid hanging
+                while not self._shutdown_event.is_set():
+                    try:
+                        # Check for messages with timeout
+                        message = self._redis_subscriber.get_message(timeout=10.0)
+
+                        if message is None:
+                            continue  # Timeout, check shutdown and continue
+
+                        if message["type"] == "message":
+                            try:
+                                event_data = json.loads(message["data"])
+                                logger.info(
+                                    f"Received event from Redis: {event_data.get('event_type')}"
+                                )
+
+                                if self._websocket_manager:
+                                    # Process event directly
+                                    self._process_single_event(event_data)
+                                else:
+                                    # Add to local queue for later processing
+                                    self._event_queue.put_nowait(event_data)
+
+                            except json.JSONDecodeError as e:
+                                logger.error(
+                                    f"Failed to decode Redis event message: {e}"
+                                )
+                            except Exception as e:
+                                logger.error(f"Error processing Redis event: {e}")
+
+                    except Exception as get_msg_error:
+                        logger.error(f"Error getting Redis message: {get_msg_error}")
+                        break  # Break inner loop to trigger reconnect
+
+            except Exception as e:
+                retry_count += 1
+                logger.error(
+                    f"Redis subscriber error (attempt {retry_count}/{max_retries}): {e}"
+                )
+
+                if retry_count < max_retries:
+                    logger.info(
+                        f"Retrying Redis subscription in {retry_delay} seconds..."
+                    )
+                    self._shutdown_event.wait(retry_delay)
+
+                    # Recreate Redis connection
+                    try:
+                        self._init_redis()
+                    except Exception as init_error:
+                        logger.error(f"Failed to reinitialize Redis: {init_error}")
+
+            finally:
+                if self._redis_subscriber:
+                    try:
+                        self._redis_subscriber.close()
+                    except Exception:
+                        pass  # Ignore errors during cleanup
+
+        if retry_count >= max_retries:
+            logger.error("Max Redis reconnection attempts reached, giving up")
+        else:
+            logger.info("Redis subscriber stopped")
+
+    def _process_single_event(self, event_data: Dict[str, Any]):
+        """Process a single event with WebSocket manager."""
+        if not self._websocket_manager:
+            logger.warning("No WebSocket manager available, dropping event")
+            return
+
+        try:
+            import asyncio
+
+            # Create new event loop for this thread
+            loop = asyncio.new_event_loop()
+            asyncio.set_event_loop(loop)
+
+            # Process the event
+            loop.run_until_complete(
+                self._websocket_manager.broadcast_event_from_notification(
+                    event_data["event_type"], event_data["payload"]
+                )
+            )
+
+            loop.close()
+            logger.debug(f"Processed event via bridge: {event_data['event_type']}")
+
+        except Exception as e:
+            logger.error(f"Error processing event via bridge: {e}")
+
+    def _process_events(self):
+        """Background thread that processes events from the local queue."""
+        logger.info("Event bridge processor started")
+
+        while not self._shutdown_event.is_set():
+            try:
+                # Get event with timeout to check shutdown periodically
+                try:
+                    event_data = self._event_queue.get(timeout=1.0)
+                except queue.Empty:
+                    continue
+
+                self._process_single_event(event_data)
+                self._event_queue.task_done()
+
+            except Exception as e:
+                logger.error(f"Unexpected error in event bridge processor: {e}")
+
+        logger.info("Event bridge processor stopped")
+
+    def shutdown(self):
+        """Shutdown the event bridge."""
+        logger.info("Shutting down event bridge")
+        self._shutdown_event.set()
+
+        # Close Redis subscriber
+        if self._redis_subscriber:
+            try:
+                self._redis_subscriber.close()
+            except Exception as e:
+                logger.error(f"Error closing Redis subscriber: {e}")
+
+        # Wait for threads to finish
+        if self._processor_thread and self._processor_thread.is_alive():
+            self._processor_thread.join(timeout=5.0)
+
+        if self._subscriber_thread and self._subscriber_thread.is_alive():
+            self._subscriber_thread.join(timeout=5.0)
+
+
+# Global event bridge instance
+event_bridge = EventBridge()

--- a/osism/services/websocket_manager.py
+++ b/osism/services/websocket_manager.py
@@ -142,6 +142,9 @@ class WebSocketManager:
     ) -> None:
         """Create and broadcast an event from RabbitMQ notification."""
         try:
+            logger.info(f"Processing event for WebSocket broadcast: {event_type}")
+            logger.debug(f"Active WebSocket connections: {len(self.connections)}")
+
             # Extract relevant identifiers from different service types
             node_name = None
             resource_id = None
@@ -190,9 +193,10 @@ class WebSocketManager:
             )
 
             await self.add_event(event)
-            logger.debug(
-                f"Added {service_type} event to queue: {event_type} for resource {node_name or resource_id}"
+            logger.info(
+                f"Added {service_type} event to WebSocket queue: {event_type} for resource {node_name or resource_id}"
             )
+            logger.debug(f"Event queue size: {self.event_queue.qsize()}")
 
         except Exception as e:
             logger.error(f"Error creating event from notification: {e}")
@@ -240,7 +244,7 @@ class WebSocketManager:
                         f"Active connections: {len(self.connections)}"
                     )
 
-                logger.debug(
+                logger.info(
                     f"Broadcasted event {event.event_type} to {sent_count}/{len(self.connections)} connection(s)"
                 )
 


### PR DESCRIPTION
- Add new Events tab in navigation for real-time Baremetal event streaming
- Implement WebSocket connection with custom useWebSocket hook
- Create comprehensive event filtering by event types and node names
- Add connection status indicators and error handling
- Build responsive UI components: EventsList, EventsFilters, ConnectionStatus
- Integrate with backend WebSocket endpoint /v1/events/openstack
- Support event pause/resume, auto-reconnection, and live event counters
- Add TypeScript types for OpenStack and Baremetal events
- Enhance API with WebSocket CORS headers and info endpoint

AI-assisted: Claude Code