### PR TITLE
Add Garden Linux image management command

### DIFF
--- a/osism/data/__init__.py
+++ b/osism/data/__init__.py
@@ -65,3 +65,36 @@ images:
         build_date: {{ image_builddate }}
 
 """
+
+TEMPLATE_IMAGE_GARDENLINUX = """---
+images:
+  - name: garden-linux-image
+    enable: true
+    keep: true
+    separator: "-"
+    format: qcow2
+    login: garden
+    min_disk: 20
+    min_ram: 512
+    status: active
+    visibility: public
+    multi: false
+    meta:
+      architecture: x86_64
+      hw_disk_bus: scsi
+      hw_rng_model: virtio
+      hw_scsi_model: virtio-scsi
+      hw_watchdog_action: reset
+      hypervisor_type: qemu
+      os_distro: debian
+      replace_frequency: never
+      uuid_validity: none
+      provided_until: none
+    tags: []
+    versions:
+      - version: "{{ image_version }}"
+        url: "{{ image_url }}"
+        checksum: "{{ image_checksum }}"
+        build_date: {{ image_builddate }}
+
+"""

--- a/setup.cfg
+++ b/setup.cfg
@@ -68,6 +68,7 @@ osism.commands:
     log opensearch = osism.commands.log:Opensearch
     manage flavors = osism.commands.manage:Flavors
     manage image clusterapi = osism.commands.manage:ImageClusterapi
+    manage image gardenlinux = osism.commands.manage:ImageGardenlinux
     manage image octavia = osism.commands.manage:ImageOctavia
     manage compute disable = osism.commands.compute:ComputeDisable
     manage compute enable = osism.commands.compute:ComputeEnable


### PR DESCRIPTION
Implements 'osism manage image gardenlinux' command similar to ClusterAPI image command. Features hardcoded version 1877.2 with direct URL construction instead of dynamic last-file resolution. Uses debian OS distribution and retrieves checksums from .sha256 files.

AI-assisted: Claude Code