### PR TITLE
Add task lock/unlock functionality to prevent new task execution

### DIFF
--- a/osism/commands/lock.py
+++ b/osism/commands/lock.py
@@ -1,0 +1,92 @@
+# SPDX-License-Identifier: Apache-2.0
+
+import getpass
+from cliff.command import Command
+from loguru import logger
+
+from osism import utils
+
+
+class Lock(Command):
+    """Lock task execution to prevent new tasks from starting"""
+
+    def get_parser(self, prog_name):
+        parser = super(Lock, self).get_parser(prog_name)
+        parser.add_argument(
+            "--user",
+            help="User name to associate with the lock (defaults to current user)",
+        )
+        parser.add_argument("--reason", help="Reason for locking tasks")
+        return parser
+
+    def take_action(self, parsed_args):
+        user = parsed_args.user or getpass.getuser()
+        reason = parsed_args.reason
+
+        # Check if already locked
+        lock_info = utils.is_task_locked()
+        if lock_info and lock_info.get("locked"):
+            existing_user = lock_info.get("user", "unknown")
+            existing_timestamp = lock_info.get("timestamp", "unknown")
+            existing_reason = lock_info.get("reason")
+            logger.warning(
+                f"Tasks are already locked by {existing_user} at {existing_timestamp}"
+            )
+            if existing_reason:
+                logger.warning(f"Existing reason: {existing_reason}")
+            return
+
+        # Set the lock
+        if utils.set_task_lock(user, reason):
+            logger.info(f"Tasks locked by {user}")
+            if reason:
+                logger.info(f"Reason: {reason}")
+            logger.info("New tasks will be prevented from starting")
+            logger.info("Running tasks will continue normally")
+            logger.info("Use 'osism unlock' to remove the lock")
+        else:
+            logger.error("Failed to set task lock")
+            return 1
+
+
+class Unlock(Command):
+    """Unlock task execution to allow new tasks to start"""
+
+    def take_action(self, parsed_args):
+        # Check if currently locked
+        lock_info = utils.is_task_locked()
+        if not lock_info or not lock_info.get("locked"):
+            logger.info("Tasks are not currently locked")
+            return
+
+        existing_user = lock_info.get("user", "unknown")
+        existing_timestamp = lock_info.get("timestamp", "unknown")
+        existing_reason = lock_info.get("reason")
+
+        # Remove the lock
+        if utils.remove_task_lock():
+            logger.info(
+                f"Task lock removed (was set by {existing_user} at {existing_timestamp})"
+            )
+            if existing_reason:
+                logger.info(f"Previous reason: {existing_reason}")
+            logger.info("New tasks can now be started")
+        else:
+            logger.error("Failed to remove task lock")
+            return 1
+
+
+class LockStatus(Command):
+    """Show current task lock status"""
+
+    def take_action(self, parsed_args):
+        lock_info = utils.is_task_locked()
+        if lock_info and lock_info.get("locked"):
+            user = lock_info.get("user", "unknown")
+            timestamp = lock_info.get("timestamp", "unknown")
+            reason = lock_info.get("reason")
+            logger.info(f"Tasks are LOCKED by {user} at {timestamp}")
+            if reason:
+                logger.info(f"Reason: {reason}")
+        else:
+            logger.info("Tasks are UNLOCKED")

--- a/osism/commands/worker.py
+++ b/osism/commands/worker.py
@@ -4,6 +4,7 @@ import multiprocessing
 import subprocess
 
 from cliff.command import Command
+from osism import utils
 
 
 class Run(Command):
@@ -25,6 +26,9 @@ class Run(Command):
         return parser
 
     def take_action(self, parsed_args):
+        # Check if tasks are locked before starting workers
+        utils.check_task_lock_and_exit()
+
         queue = parsed_args.type[0]
         number_of_workers = parsed_args.number_of_workers
 

--- a/osism/tasks/ansible.py
+++ b/osism/tasks/ansible.py
@@ -37,6 +37,9 @@ def run(
     locking=False,
     auto_release_time=3600,
 ):
+    # Check if tasks are locked before execution
+    utils.check_task_lock_and_exit()
+
     return run_ansible_in_environment(
         self.request.id,
         "osism-ansible",

--- a/osism/tasks/ceph.py
+++ b/osism/tasks/ceph.py
@@ -2,6 +2,7 @@
 
 from celery import Celery
 
+from osism import utils
 from osism.tasks import Config, run_ansible_in_environment
 
 app = Celery("ceph")
@@ -15,6 +16,9 @@ def setup_periodic_tasks(sender, **kwargs):
 
 @app.task(bind=True, name="osism.tasks.ceph.run")
 def run(self, environment, playbook, arguments, publish=True, auto_release_time=3600):
+    # Check if tasks are locked before execution
+    utils.check_task_lock_and_exit()
+
     return run_ansible_in_environment(
         self.request.id,
         "ceph-ansible",

--- a/osism/tasks/conductor/__init__.py
+++ b/osism/tasks/conductor/__init__.py
@@ -5,6 +5,7 @@ from celery import Celery
 from celery.signals import worker_process_init
 from loguru import logger
 
+from osism import utils
 from osism.tasks import Config
 from osism.tasks.conductor.config import get_configuration
 from osism.tasks.conductor.ironic import sync_ironic as _sync_ironic
@@ -40,16 +41,25 @@ def get_ironic_parameters(self):
 
 @app.task(bind=True, name="osism.tasks.conductor.sync_netbox")
 def sync_netbox(self, force_update=False):
+    # Check if tasks are locked before execution
+    utils.check_task_lock_and_exit()
+
     logger.info("Not implemented")
 
 
 @app.task(bind=True, name="osism.tasks.conductor.sync_ironic")
 def sync_ironic(self, node_name=None, force_update=False):
+    # Check if tasks are locked before execution
+    utils.check_task_lock_and_exit()
+
     _sync_ironic(self.request.id, get_ironic_parameters, node_name, force_update)
 
 
 @app.task(bind=True, name="osism.tasks.conductor.sync_sonic")
 def sync_sonic(self, device_name=None, show_diff=True):
+    # Check if tasks are locked before execution
+    utils.check_task_lock_and_exit()
+
     return _sync_sonic(device_name, self.request.id, show_diff)
 
 

--- a/osism/tasks/kolla.py
+++ b/osism/tasks/kolla.py
@@ -2,6 +2,7 @@
 
 from celery import Celery
 
+from osism import utils
 from osism.tasks import Config, run_ansible_in_environment
 
 app = Celery("kolla")
@@ -15,6 +16,9 @@ def setup_periodic_tasks(sender, **kwargs):
 
 @app.task(bind=True, name="osism.tasks.kolla.run")
 def run(self, environment, playbook, arguments, publish=True, auto_release_time=3600):
+    # Check if tasks are locked before execution
+    utils.check_task_lock_and_exit()
+
     return run_ansible_in_environment(
         self.request.id,
         "kolla-ansible",

--- a/osism/tasks/kubernetes.py
+++ b/osism/tasks/kubernetes.py
@@ -2,6 +2,7 @@
 
 from celery import Celery
 
+from osism import utils
 from osism.tasks import Config, run_ansible_in_environment
 
 app = Celery("kubernetes")
@@ -15,6 +16,9 @@ def setup_periodic_tasks(sender, **kwargs):
 
 @app.task(bind=True, name="osism.tasks.kubernetes.run")
 def run(self, environment, playbook, arguments, publish=True, auto_release_time=3600):
+    # Check if tasks are locked before execution
+    utils.check_task_lock_and_exit()
+
     return run_ansible_in_environment(
         self.request.id,
         "kubernetes",

--- a/osism/tasks/netbox.py
+++ b/osism/tasks/netbox.py
@@ -17,6 +17,9 @@ def setup_periodic_tasks(sender, **kwargs):
 
 @app.task(bind=True, name="osism.tasks.netbox.run")
 def run(self, action, arguments):
+    # Check if tasks are locked before execution
+    utils.check_task_lock_and_exit()
+
     pass
 
 
@@ -28,6 +31,8 @@ def run(self, action, arguments):
 @app.task(bind=True, name="osism.tasks.netbox.set_maintenance")
 def set_maintenance(self, device_name, state=True):
     """Set the maintenance state for a device in the NetBox."""
+    # Check if tasks are locked before execution
+    utils.check_task_lock_and_exit()
 
     lock = utils.create_redlock(
         key=f"lock_osism_tasks_netbox_set_maintenance_{device_name}",
@@ -56,6 +61,8 @@ def set_maintenance(self, device_name, state=True):
 @app.task(bind=True, name="osism.tasks.netbox.set_provision_state")
 def set_provision_state(self, device_name, state):
     """Set the provision state for a device in the NetBox."""
+    # Check if tasks are locked before execution
+    utils.check_task_lock_and_exit()
 
     lock = utils.create_redlock(
         key=f"lock_osism_tasks_netbox_set_provision_state_{device_name}",
@@ -85,6 +92,8 @@ def set_provision_state(self, device_name, state):
 @app.task(bind=True, name="osism.tasks.netbox.set_power_state")
 def set_power_state(self, device_name, state):
     """Set the provision state for a device in the NetBox."""
+    # Check if tasks are locked before execution
+    utils.check_task_lock_and_exit()
 
     lock = utils.create_redlock(
         key=f"lock_osism_tasks_netbox_set_provision_state_{device_name}",
@@ -156,6 +165,9 @@ def get_addresses_by_device_and_interface(self, device_name, interface_name):
 
 @app.task(bind=True, name="osism.tasks.netbox.manage")
 def manage(self, *arguments, publish=True, locking=False, auto_release_time=3600):
+    # Check if tasks are locked before execution
+    utils.check_task_lock_and_exit()
+
     netbox_manager_env = {
         "NETBOX_MANAGER_URL": str(settings.NETBOX_URL),
         "NETBOX_MANAGER_TOKEN": str(settings.NETBOX_TOKEN),

--- a/osism/tasks/openstack.py
+++ b/osism/tasks/openstack.py
@@ -374,6 +374,9 @@ def image_manager(
     auto_release_time=3600,
     cloud=None,
 ):
+    # Check if tasks are locked before execution
+    utils.check_task_lock_and_exit()
+
     command = "/usr/local/bin/openstack-image-manager"
 
     if configs:
@@ -436,6 +439,9 @@ def flavor_manager(
     auto_release_time=3600,
     cloud=None,
 ):
+    # Check if tasks are locked before execution
+    utils.check_task_lock_and_exit()
+
     command = "/usr/local/bin/openstack-flavor-manager"
     return run_openstack_command_with_cloud(
         self.request.id,

--- a/osism/tasks/reconciler.py
+++ b/osism/tasks/reconciler.py
@@ -27,6 +27,9 @@ def setup_periodic_tasks(sender, **kwargs):
 
 @app.task(bind=True, name="osism.tasks.reconciler.run")
 def run(self, publish=True, flush_cache=False):
+    # Check if tasks are locked before execution
+    utils.check_task_lock_and_exit()
+
     lock = utils.create_redlock(
         key="lock_osism_tasks_reconciler_run",
         auto_release_time=60,

--- a/setup.cfg
+++ b/setup.cfg
@@ -122,6 +122,9 @@ osism.commands:
     sync sonic = osism.commands.sync:Sonic
     task list = osism.commands.get:Tasks
     task revoke = osism.commands.task:Revoke
+    lock = osism.commands.lock:Lock
+    unlock = osism.commands.lock:Unlock
+    lock status = osism.commands.lock:LockStatus
     validate = osism.commands.validate:Run
     vault password set = osism.commands.vault:SetPassword
     vault password unset = osism.commands.vault:UnsetPassword


### PR DESCRIPTION
- Add lock, unlock, and lock status commands with --user and --reason parameters
- Implement Redis-based task locking mechanism with metadata storage
- Add lock checks to all main Celery task entry points and worker startup
- Running tasks continue normally, only new task creation is blocked
- Lock information includes user, timestamp, and optional reason

AI-assisted: Claude Code