### PR TITLE
Improve task lock with command-level checks and dragon as default user

### DIFF
--- a/osism/commands/apply.py
+++ b/osism/commands/apply.py
@@ -9,6 +9,7 @@ from cliff.command import Command
 from loguru import logger
 from tabulate import tabulate
 
+from osism import utils
 from osism.data import enums
 from osism.data.playbooks import MAP_ROLE2ENVIRONMENT, MAP_ROLE2RUNTIME
 from osism.tasks import ansible, ceph, kolla, kubernetes, handle_task
@@ -451,6 +452,9 @@ class Run(Command):
         return rc
 
     def take_action(self, parsed_args):
+        # Check if tasks are locked before proceeding
+        utils.check_task_lock_and_exit()
+
         action = parsed_args.action
         arguments = parsed_args.arguments
         environment = parsed_args.environment

--- a/osism/commands/configuration.py
+++ b/osism/commands/configuration.py
@@ -5,6 +5,7 @@ import argparse
 from cliff.command import Command
 from loguru import logger
 
+from osism import utils
 from osism.tasks import ansible, handle_task
 
 
@@ -17,6 +18,9 @@ class Sync(Command):
         return parser
 
     def take_action(self, parsed_args):
+        # Check if tasks are locked before proceeding
+        utils.check_task_lock_and_exit()
+
         arguments = parsed_args.arguments
 
         t = ansible.run.delay(

--- a/osism/commands/lock.py
+++ b/osism/commands/lock.py
@@ -1,6 +1,5 @@
 # SPDX-License-Identifier: Apache-2.0
 
-import getpass
 from cliff.command import Command
 from loguru import logger
 
@@ -14,13 +13,13 @@ class Lock(Command):
         parser = super(Lock, self).get_parser(prog_name)
         parser.add_argument(
             "--user",
-            help="User name to associate with the lock (defaults to current user)",
+            help="User name to associate with the lock (defaults to dragon)",
         )
         parser.add_argument("--reason", help="Reason for locking tasks")
         return parser
 
     def take_action(self, parsed_args):
-        user = parsed_args.user or getpass.getuser()
+        user = parsed_args.user or "dragon"
         reason = parsed_args.reason
 
         # Check if already locked

--- a/osism/commands/manage.py
+++ b/osism/commands/manage.py
@@ -9,6 +9,7 @@ from jinja2 import Template
 from loguru import logger
 import requests
 
+from osism import utils
 from osism.data import (
     TEMPLATE_IMAGE_CLUSTERAPI,
     TEMPLATE_IMAGE_OCTAVIA,
@@ -62,6 +63,9 @@ class ImageClusterapi(Command):
         return parser
 
     def take_action(self, parsed_args):
+        # Check if tasks are locked before proceeding
+        utils.check_task_lock_and_exit()
+
         base_url = parsed_args.base_url
         cloud = parsed_args.cloud
         filter = parsed_args.filter
@@ -169,6 +173,9 @@ class ImageGardenlinux(Command):
         return parser
 
     def take_action(self, parsed_args):
+        # Check if tasks are locked before proceeding
+        utils.check_task_lock_and_exit()
+
         base_url = parsed_args.base_url
         cloud = parsed_args.cloud
         filter = parsed_args.filter
@@ -254,6 +261,9 @@ class ImageOctavia(Command):
         return parser
 
     def take_action(self, parsed_args):
+        # Check if tasks are locked before proceeding
+        utils.check_task_lock_and_exit()
+
         wait = not parsed_args.no_wait
         cloud = parsed_args.cloud
         base_url = parsed_args.base_url
@@ -365,6 +375,9 @@ class Images(Command):
         return parser
 
     def take_action(self, parsed_args):
+        # Check if tasks are locked before proceeding
+        utils.check_task_lock_and_exit()
+
         wait = not parsed_args.no_wait
 
         arguments = []
@@ -441,6 +454,9 @@ class Flavors(Command):
         return parser
 
     def take_action(self, parsed_args):
+        # Check if tasks are locked before proceeding
+        utils.check_task_lock_and_exit()
+
         wait = not parsed_args.no_wait
         cloud = parsed_args.cloud
         name = parsed_args.name
@@ -481,6 +497,9 @@ class Dnsmasq(Command):
         return parser
 
     def take_action(self, parsed_args):
+        # Check if tasks are locked before proceeding
+        utils.check_task_lock_and_exit()
+
         wait = not parsed_args.no_wait
 
         task_signature = ansible.run.si("infrastructure", "dnsmasq", [])

--- a/osism/commands/netbox.py
+++ b/osism/commands/netbox.py
@@ -38,6 +38,9 @@ class Ironic(Command):
         return parser
 
     def take_action(self, parsed_args):
+        # Check if tasks are locked before proceeding
+        utils.check_task_lock_and_exit()
+
         wait = not parsed_args.no_wait
         task_timeout = parsed_args.task_timeout
         node_name = parsed_args.node
@@ -87,6 +90,9 @@ class Sync(Command):
         return parser
 
     def take_action(self, parsed_args):
+        # Check if tasks are locked before proceeding
+        utils.check_task_lock_and_exit()
+
         wait = not parsed_args.no_wait
 
         task = conductor.sync_netbox.delay()
@@ -145,6 +151,9 @@ class Manage(Command):
         return parser
 
     def take_action(self, parsed_args):
+        # Check if tasks are locked before proceeding
+        utils.check_task_lock_and_exit()
+
         wait = not parsed_args.no_wait
         arguments = ["run"]
 
@@ -192,6 +201,9 @@ class Versions(Command):
         return parser
 
     def take_action(self, parsed_args):
+        # Check if tasks are locked before proceeding
+        utils.check_task_lock_and_exit()
+
         task = netbox.ping.delay()
         task.wait(timeout=None, interval=0.5)
         result = task.get()

--- a/osism/commands/noset.py
+++ b/osism/commands/noset.py
@@ -3,6 +3,7 @@
 from cliff.command import Command
 from loguru import logger
 
+from osism import utils
 from osism.tasks import ansible
 
 
@@ -18,6 +19,9 @@ class NoMaintenance(Command):
         return parser
 
     def take_action(self, parsed_args):
+        # Check if tasks are locked before proceeding
+        utils.check_task_lock_and_exit()
+
         host = parsed_args.host[0]
 
         logger.info(f"Set no maintenance state on host {host}")
@@ -46,6 +50,9 @@ class NoBootstrap(Command):
         return parser
 
     def take_action(self, parsed_args):
+        # Check if tasks are locked before proceeding
+        utils.check_task_lock_and_exit()
+
         host = parsed_args.host[0]
 
         logger.info(f"Set not bootstrapped state on host {host}")

--- a/osism/commands/reconciler.py
+++ b/osism/commands/reconciler.py
@@ -47,6 +47,9 @@ class Sync(Command):
         return parser
 
     def take_action(self, parsed_args):
+        # Check if tasks are locked before proceeding
+        utils.check_task_lock_and_exit()
+
         wait = not parsed_args.no_wait
         task_timeout = parsed_args.task_timeout
         flush_cache = parsed_args.flush_cache

--- a/osism/commands/redfish.py
+++ b/osism/commands/redfish.py
@@ -5,6 +5,7 @@ from cliff.command import Command
 from loguru import logger
 from tabulate import tabulate
 
+from osism import utils
 from osism.tasks.conductor import get_redfish_resources
 
 
@@ -145,6 +146,9 @@ class List(Command):
         return parser
 
     def take_action(self, parsed_args):
+        # Check if tasks are locked before proceeding
+        utils.check_task_lock_and_exit()
+
         hostname = parsed_args.hostname
         resourcetype = parsed_args.resourcetype
         output_format = parsed_args.format

--- a/osism/commands/service.py
+++ b/osism/commands/service.py
@@ -7,6 +7,7 @@ from cliff.command import Command
 from watchdog.observers.polling import PollingObserver
 from watchdog.events import FileSystemEventHandler
 
+from osism import utils
 from osism.tasks import reconciler
 
 
@@ -17,6 +18,9 @@ class Run(Command):
         return parser
 
     def take_action(self, parsed_args):
+        # Check if tasks are locked before proceeding
+        utils.check_task_lock_and_exit()
+
         service = parsed_args.type[0]
 
         if service == "api":

--- a/osism/commands/set.py
+++ b/osism/commands/set.py
@@ -3,6 +3,7 @@
 from cliff.command import Command
 from loguru import logger
 
+from osism import utils
 from osism.tasks import ansible
 
 
@@ -18,6 +19,9 @@ class Maintenance(Command):
         return parser
 
     def take_action(self, parsed_args):
+        # Check if tasks are locked before proceeding
+        utils.check_task_lock_and_exit()
+
         host = parsed_args.host[0]
 
         logger.info(f"Set maintenance state on host {host}")
@@ -46,6 +50,9 @@ class Bootstrap(Command):
         return parser
 
     def take_action(self, parsed_args):
+        # Check if tasks are locked before proceeding
+        utils.check_task_lock_and_exit()
+
         host = parsed_args.host[0]
 
         logger.info(f"Set bootstraped state on host {host}")

--- a/osism/commands/sonic.py
+++ b/osism/commands/sonic.py
@@ -738,6 +738,9 @@ class Reset(SonicCommandBase):
         return parser
 
     def take_action(self, parsed_args):
+        # Check if tasks are locked before proceeding
+        utils.check_task_lock_and_exit()
+
         hostname = parsed_args.hostname
         force = parsed_args.force
 

--- a/osism/commands/sync.py
+++ b/osism/commands/sync.py
@@ -3,6 +3,7 @@
 from cliff.command import Command
 from loguru import logger
 
+from osism import utils
 from osism.tasks import ansible, conductor, handle_task
 
 
@@ -12,6 +13,9 @@ class Facts(Command):
         return parser
 
     def take_action(self, parsed_args):
+        # Check if tasks are locked before proceeding
+        utils.check_task_lock_and_exit()
+
         arguments = []
         t = ansible.run.delay(
             "generic", "gather-facts", arguments, auto_release_time=3600
@@ -49,6 +53,9 @@ class Sonic(Command):
         return parser
 
     def take_action(self, parsed_args):
+        # Check if tasks are locked before proceeding
+        utils.check_task_lock_and_exit()
+
         wait = not parsed_args.no_wait
         device_name = parsed_args.device
         show_diff = parsed_args.diff

--- a/osism/commands/validate.py
+++ b/osism/commands/validate.py
@@ -70,6 +70,9 @@ class Run(Command):
             return 0
 
     def take_action(self, parsed_args):
+        # Check if tasks are locked before proceeding
+        utils.check_task_lock_and_exit()
+
         arguments = parsed_args.arguments
         environment = parsed_args.environment
         validator = parsed_args.validator[0]

--- a/osism/utils/__init__.py
+++ b/osism/utils/__init__.py
@@ -262,7 +262,7 @@ def set_task_lock(user=None, reason=None):
         lock_data = {
             "locked": True,
             "timestamp": datetime.now().isoformat(),
-            "user": user or "unknown",
+            "user": user or "dragon",
             "reason": reason,
         }
 


### PR DESCRIPTION
- Add lock checks to all command take_action methods before task submission
- Users now get immediate feedback when tasks are locked instead of waiting for worker logs
- Change default lock user from current user to "dragon"
- Maintain dual-layer protection: command-level + task-level lock checks
- Update help text and lock status display to reflect new default user

AI-assisted: Claude Code