### PR TITLE
Fix Ubuntu version in CAPI image management

### DIFF
--- a/osism/commands/manage.py
+++ b/osism/commands/manage.py
@@ -87,7 +87,9 @@ class ImageClusterapi(Command):
             logger.info(f"date: {splitted[0]}")
             logger.info(f"image: {splitted[1]}")
 
-            r = findall(r".*ubuntu-2204-kube-v(.*\..*\..*).qcow2", splitted[1])
+            r = findall(
+                r".*ubuntu-[0-9][02468]04-kube-v(.*\..*\..*).qcow2", splitted[1]
+            )
             logger.info(f"version: {r[0].strip()}")
 
             url = urljoin(base_url, splitted[1])


### PR DESCRIPTION
Support current, past and future Ubuntu LTS versions in Ubuntu CAPI image template.
CAPI Image version 1.33 is based on Ubuntu 24.04 instead of 22.04.