### PR TITLE
Add ansible play execution tracking to central log file

### DIFF
--- a/osism/tasks/kubernetes.py
+++ b/osism/tasks/kubernetes.py
@@ -21,7 +21,7 @@ def run(self, environment, playbook, arguments, publish=True, auto_release_time=
 
     return run_ansible_in_environment(
         self.request.id,
-        "kubernetes",
+        "osism-kubernetes",
         environment,
         playbook,
         arguments,


### PR DESCRIPTION
Track all Ansible play executions (osism-ansible, kolla-ansible, ceph-ansible, osism-kubernetes) in /share/ansible-execution-history.json with timestamp, runtime version, hosts, and result status.

- Add get_container_version() to read versions from /interface/versions/{worker}.yml
- Add log_play_execution() to append execution records with file locking
- Log play start and completion in run_ansible_in_environment()
- Use "latest" as default when version parameter is empty
- Use JSON Lines format for safe concurrent appends

AI-assisted: Claude Code