### PR TITLE
Make celery worker concurrency configurable

### DIFF
--- a/osism/commands/reconciler.py
+++ b/osism/commands/reconciler.py
@@ -1,5 +1,6 @@
 # SPDX-License-Identifier: Apache-2.0
 
+import multiprocessing
 import os
 import subprocess
 
@@ -16,8 +17,12 @@ class Run(Command):
             "The osism reconciler command is deprecated and will be removed. Use osism service reconciler."
         )
         # NOTE: use python interface in the future, works for the moment
+        default_concurrency = min(multiprocessing.cpu_count(), 4)
+        concurrency = int(
+            os.environ.get("OSISM_CELERY_CONCURRENCY", default_concurrency)
+        )
         p = subprocess.Popen(
-            "celery -A osism.tasks.reconciler worker -n reconciler --loglevel=INFO -Q reconciler",
+            f"celery -A osism.tasks.reconciler worker -n reconciler --loglevel=INFO -Q reconciler -c {concurrency}",
             shell=True,
         )
         p.wait()

--- a/osism/commands/service.py
+++ b/osism/commands/service.py
@@ -1,5 +1,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
+import multiprocessing
+import os
 import subprocess
 import time
 
@@ -65,8 +67,12 @@ class Run(Command):
             p.wait()
 
         elif service == "reconciler":
+            default_concurrency = min(multiprocessing.cpu_count(), 4)
+            concurrency = int(
+                os.environ.get("OSISM_CELERY_CONCURRENCY", default_concurrency)
+            )
             p = subprocess.Popen(
-                "celery -A osism.tasks.reconciler worker -n reconciler --loglevel=INFO -Q reconciler",
+                f"celery -A osism.tasks.reconciler worker -n reconciler --loglevel=INFO -Q reconciler -c {concurrency}",
                 shell=True,
             )
             p.wait()

--- a/osism/commands/worker.py
+++ b/osism/commands/worker.py
@@ -1,6 +1,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 import multiprocessing
+import os
 import subprocess
 
 from cliff.command import Command
@@ -9,10 +10,11 @@ from osism import utils
 
 class Run(Command):
     def get_parser(self, prog_name):
-        if multiprocessing.cpu_count() <= 8:
-            number_of_workers_default = multiprocessing.cpu_count()
-        else:
-            number_of_workers_default = 8
+        number_of_workers_default = int(
+            os.environ.get(
+                "OSISM_CELERY_CONCURRENCY", min(multiprocessing.cpu_count(), 4)
+            )
+        )
 
         parser = super(Run, self).get_parser(prog_name)
         parser.add_argument(


### PR DESCRIPTION
Make celery worker concurrency configurable via OSISM_CELERY_CONCURRENCY environment variable with intelligent default based on CPU count.

Changes:

- Add OSISM_CELERY_CONCURRENCY environment variable support
- Default to min(cpu_count, 4) when environment variable not set
- Apply to all celery worker invocations (service, reconciler, worker commands)
- Maintains backward compatibility with command-line --number-of-workers flag

The default ensures efficient resource usage while preventing oversubscription on systems with many CPUs, and adapts to systems with fewer CPUs.

AI-assisted: Claude Code

Closes osism/issues#1311