### PR TITLE
Fix AS4625-54T port detection by using correct alias extraction

### DIFF
--- a/osism/tasks/conductor/sonic/interface.py
+++ b/osism/tasks/conductor/sonic/interface.py
@@ -287,15 +287,13 @@ def _find_sonic_name_by_alias_mapping(interface_name, port_config):
             logger.debug(f"Skipping {sonic_port}: no alias")
             continue
 
-        # Extract number from alias (e.g., tenGigE1 -> 1, hundredGigE49 -> 49)
-        alias_match = re.search(r"(\d+)$", alias)
-        if not alias_match:
+        # Extract number from alias (e.g., tenGigE1 -> 1, Eth1(Port1) -> 1)
+        alias_num = _extract_port_number_from_alias(alias)
+        if alias_num is None:
             logger.debug(
-                f"Skipping {sonic_port}: alias '{alias}' has no trailing number"
+                f"Skipping {sonic_port}: could not extract number from alias '{alias}'"
             )
             continue
-
-        alias_num = int(alias_match.group(1))
 
         # Generate expected NetBox interface names for this alias
         expected_names = [


### PR DESCRIPTION
The Accton-AS4625-54T uses alias format Eth1(Port1) instead of the standard tenGigE1 format. The inline regex r"(\d+)$" failed to extract port numbers from this format because the string ends with ")" not a digit, causing NetBox interface mapping to fail and ports to appear disconnected.

Solution: Replace inline regex with existing _extract_port_number_from_alias() helper function which correctly handles both formats:
- Standard format: tenGigE1 -> extracts 1
- AS4625-54T format: Eth1(Port1) -> extracts 1

This allows proper NetBox to SONiC interface mapping:
  Eth1(Port1) -> generates expected_names ['Eth1/1', 'Eth1/1/1']
  -> matches NetBox interface Eth1/1 -> returns Ethernet0

Result: AS4625-54T ports are now correctly detected as connected, receive admin_status='up', and have BGP configurations generated.

AI-assisted: Claude Code