### PR TITLE
netbox: Add show command for device information display

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -97,6 +97,7 @@ osism.commands:
     manage baremetal maintenance set = osism.commands.baremetal:BaremetalMaintenanceSet
     manage baremetal maintenance unset = osism.commands.baremetal:BaremetalMaintenanceUnset
     netbox = osism.commands.netbox:Console
+    netbox show = osism.commands.netbox:Show
     get versions netbox = osism.commands.netbox:Versions
     noset bootstrap = osism.commands.noset:NoBootstrap
     noset maintenance = osism.commands.noset:NoMaintenance


### PR DESCRIPTION
Implements new 'osism netbox show' command to retrieve and display NetBox device information with the following features:

- Device search by name or custom fields (alternative_name, inventory_hostname, external_hostname)
- Display device details (name, type, role, site, status)
- Show network information (out-of-band IP, primary IPv4/IPv6)
- Display custom field parameters with proper YAML formatting:
  * dnsmasq_parameters
  * netplan_parameters
  * sonic_parameters
  * frr_parameters
- Optional field filter argument for focused output
- Case-insensitive partial field name matching

Implementation:
- Added Show class to osism/commands/netbox.py
- Registered command entry point in setup.cfg
- Uses existing NetBox connection (utils.nb)
- Follows established command patterns
- YAML formatting with proper indentation for readability

Usage:
  osism netbox show <hostname> [field_filter]

Examples:
  osism netbox show server01 osism netbox show server01 ip osism netbox show server01 parameters

AI-assisted: Claude Code