### PR TITLE
Add baremetal power commands to control node power state via Ironic

### DIFF
--- a/osism/commands/baremetal.py
+++ b/osism/commands/baremetal.py
@@ -703,6 +703,70 @@ class BaremetalMaintenanceUnset(Command):
             )
 
 
+class BaremetalPowerOn(Command):
+    def get_parser(self, prog_name):
+        parser = super(BaremetalPowerOn, self).get_parser(prog_name)
+
+        parser.add_argument(
+            "name",
+            nargs="?",
+            type=str,
+            help="Power on given baremetal node",
+        )
+        return parser
+
+    def take_action(self, parsed_args):
+        name = parsed_args.name
+
+        if not name:
+            logger.error("Please specify a node name")
+            return
+
+        conn = get_cloud_connection()
+        node = conn.baremetal.find_node(name, ignore_missing=True, details=True)
+        if not node:
+            logger.warning(f"Could not find node {name}")
+            return
+
+        try:
+            conn.baremetal.set_node_power_state(node.id, "power on")
+            logger.info(f"Successfully powered on node {node.name} ({node.id})")
+        except Exception as exc:
+            logger.error(f"Failed to power on node {node.name} ({node.id}): {exc}")
+
+
+class BaremetalPowerOff(Command):
+    def get_parser(self, prog_name):
+        parser = super(BaremetalPowerOff, self).get_parser(prog_name)
+
+        parser.add_argument(
+            "name",
+            nargs="?",
+            type=str,
+            help="Power off given baremetal node",
+        )
+        return parser
+
+    def take_action(self, parsed_args):
+        name = parsed_args.name
+
+        if not name:
+            logger.error("Please specify a node name")
+            return
+
+        conn = get_cloud_connection()
+        node = conn.baremetal.find_node(name, ignore_missing=True, details=True)
+        if not node:
+            logger.warning(f"Could not find node {name}")
+            return
+
+        try:
+            conn.baremetal.set_node_power_state(node.id, "power off")
+            logger.info(f"Successfully powered off node {node.name} ({node.id})")
+        except Exception as exc:
+            logger.error(f"Failed to power off node {node.name} ({node.id}): {exc}")
+
+
 class BaremetalDelete(Command):
     def get_parser(self, prog_name):
         parser = super(BaremetalDelete, self).get_parser(prog_name)

--- a/setup.cfg
+++ b/setup.cfg
@@ -44,6 +44,8 @@ osism.commands:
     baremetal deploy = osism.commands.baremetal:BaremetalDeploy
     baremetal list = osism.commands.baremetal:BaremetalList
     baremetal ping = osism.commands.baremetal:BaremetalPing
+    baremetal power off = osism.commands.baremetal:BaremetalPowerOff
+    baremetal power on = osism.commands.baremetal:BaremetalPowerOn
     baremetal undeploy = osism.commands.baremetal:BaremetalUndeploy
     compose = osism.commands.compose:Run
     configuration sync = osism.commands.configuration:Sync
@@ -97,6 +99,8 @@ osism.commands:
     manage baremetal maintenance set = osism.commands.baremetal:BaremetalMaintenanceSet
     manage baremetal maintenance unset = osism.commands.baremetal:BaremetalMaintenanceUnset
     manage baremetal ping = osism.commands.baremetal:BaremetalPing
+    manage baremetal power off = osism.commands.baremetal:BaremetalPowerOff
+    manage baremetal power on = osism.commands.baremetal:BaremetalPowerOn
     manage baremetal undeploy = osism.commands.baremetal:BaremetalUndeploy
     netbox = osism.commands.netbox:Console
     netbox show = osism.commands.netbox:Show


### PR DESCRIPTION
Implements power on/off commands for baremetal nodes, enabling direct power state control through the Ironic API. This provides operators with simple commands to manage node power without requiring maintenance mode.

AI-assisted: Claude Code