### PR TITLE
Add baremetal maintenance commands to CLI

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -43,6 +43,8 @@ osism.commands:
     baremetal delete = osism.commands.baremetal:BaremetalDelete
     baremetal deploy = osism.commands.baremetal:BaremetalDeploy
     baremetal list = osism.commands.baremetal:BaremetalList
+    baremetal maintenance set = osism.commands.baremetal:BaremetalMaintenanceSet
+    baremetal maintenance unset = osism.commands.baremetal:BaremetalMaintenanceUnset
     baremetal ping = osism.commands.baremetal:BaremetalPing
     baremetal power off = osism.commands.baremetal:BaremetalPowerOff
     baremetal power on = osism.commands.baremetal:BaremetalPowerOn


### PR DESCRIPTION
Make maintenance set/unset commands available under both 'baremetal' and 'manage baremetal' prefixes for consistency with other baremetal commands.

AI-assisted: Claude Code