### PR TITLE
Add baremetal dump command to output deployment playbook

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -42,6 +42,7 @@ osism.commands:
     baremetal burnin = osism.commands.baremetal:BaremetalBurnIn
     baremetal delete = osism.commands.baremetal:BaremetalDelete
     baremetal deploy = osism.commands.baremetal:BaremetalDeploy
+    baremetal dump = osism.commands.baremetal:BaremetalDump
     baremetal list = osism.commands.baremetal:BaremetalList
     baremetal maintenance set = osism.commands.baremetal:BaremetalMaintenanceSet
     baremetal maintenance unset = osism.commands.baremetal:BaremetalMaintenanceUnset
@@ -97,6 +98,7 @@ osism.commands:
     manage baremetal burnin = osism.commands.baremetal:BaremetalBurnIn
     manage baremetal delete = osism.commands.baremetal:BaremetalDelete
     manage baremetal deploy = osism.commands.baremetal:BaremetalDeploy
+    manage baremetal dump = osism.commands.baremetal:BaremetalDump
     manage baremetal list = osism.commands.baremetal:BaremetalList
     manage baremetal maintenance set = osism.commands.baremetal:BaremetalMaintenanceSet
     manage baremetal maintenance unset = osism.commands.baremetal:BaremetalMaintenanceUnset


### PR DESCRIPTION
This adds a new 'baremetal dump <hostname>' command that outputs the deployment playbook for a given baremetal node to the console. The command reuses the playbook generation logic from BaremetalDeploy including NetBox integration for local_context_data, netplan_parameters, and frr_parameters.

Usage:
  osism baremetal dump <hostname>
  osism manage baremetal dump <hostname>

AI-assisted: Claude Code