### PR TITLE
Add baremetal clean command to erase node devices

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -40,6 +40,7 @@ console_scripts =
 osism.commands:
     apply = osism.commands.apply:Run
     baremetal burnin = osism.commands.baremetal:BaremetalBurnIn
+    baremetal clean = osism.commands.baremetal:BaremetalClean
     baremetal delete = osism.commands.baremetal:BaremetalDelete
     baremetal deploy = osism.commands.baremetal:BaremetalDeploy
     baremetal dump = osism.commands.baremetal:BaremetalDump
@@ -96,6 +97,7 @@ osism.commands:
     manage server migrate = osism.commands.server:ServerMigrate
     manage volume list = osism.commands.volume:VolumeList
     manage baremetal burnin = osism.commands.baremetal:BaremetalBurnIn
+    manage baremetal clean = osism.commands.baremetal:BaremetalClean
     manage baremetal delete = osism.commands.baremetal:BaremetalDelete
     manage baremetal deploy = osism.commands.baremetal:BaremetalDeploy
     manage baremetal dump = osism.commands.baremetal:BaremetalDump


### PR DESCRIPTION
Adds a new command to clean baremetal nodes by erasing their storage devices. The node must be in "available" state, which is then transitioned to "manageable" before executing the erase_devices clean step.

AI-assisted: Claude Code