### PR TITLE
Strip whitespace from NETBOX_TOKEN to prevent authentication issues

### DIFF
--- a/osism/settings.py
+++ b/osism/settings.py
@@ -24,7 +24,9 @@ REDIS_DB: int = int(os.getenv("REDIS_DB", "0"))
 
 
 NETBOX_URL = os.getenv("NETBOX_API", os.getenv("NETBOX_URL"))
-NETBOX_TOKEN = str(os.getenv("NETBOX_TOKEN") or read_secret("NETBOX_TOKEN") or "")
+NETBOX_TOKEN = str(
+    os.getenv("NETBOX_TOKEN") or read_secret("NETBOX_TOKEN") or ""
+).strip()
 IGNORE_SSL_ERRORS = os.getenv("IGNORE_SSL_ERRORS", "True") == "True"
 
 # 43200 seconds = 12 hours

--- a/osism/utils/__init__.py
+++ b/osism/utils/__init__.py
@@ -82,7 +82,7 @@ try:
         secondary_nb_list.append(
             get_netbox_connection(
                 secondary_nb_settings["NETBOX_URL"],
-                str(secondary_nb_settings["NETBOX_TOKEN"]),
+                str(secondary_nb_settings["NETBOX_TOKEN"]).strip(),
                 secondary_nb_settings.get("IGNORE_SSL_ERRORS", True),
             )
         )


### PR DESCRIPTION
Ensure NETBOX_TOKEN from environment variables and NETBOX_SECONDARIES configuration have leading/trailing whitespace (including newlines) removed using .strip() method to prevent API authentication failures.

AI-assisted: Claude Code