### PR TITLE
Fix missing /share/known_hosts initialization in SSH commands

### DIFF
--- a/osism/commands/container.py
+++ b/osism/commands/container.py
@@ -4,7 +4,10 @@ import argparse
 import subprocess
 
 from cliff.command import Command
+from loguru import logger
 from prompt_toolkit import prompt
+
+from osism.utils.ssh import ensure_known_hosts_file, KNOWN_HOSTS_PATH
 
 
 class Run(Command):
@@ -23,7 +26,13 @@ class Run(Command):
         host = parsed_args.host[0]
         command = " ".join(parsed_args.command)
 
-        ssh_options = "-o StrictHostKeyChecking=no -o LogLevel=ERROR -o UserKnownHostsFile=/share/known_hosts"
+        # Ensure known_hosts file exists
+        if not ensure_known_hosts_file():
+            logger.warning(
+                f"Could not initialize {KNOWN_HOSTS_PATH}, SSH may show warnings"
+            )
+
+        ssh_options = f"-o StrictHostKeyChecking=no -o LogLevel=ERROR -o UserKnownHostsFile={KNOWN_HOSTS_PATH}"
 
         if not command:
             while True:


### PR DESCRIPTION
Fixes an issue where SSH-based commands fail in new installations because /share/known_hosts file doesn't exist.

Changes:
- Added ensure_known_hosts_file() utility function to osism/utils/ssh.py to create /share directory and known_hosts file if they don't exist
- Updated all SSH-based commands to call this initialization:
  * sonic.py: Console and SSH connection methods
  * console.py: All console types (ssh, container, container_prompt)
  * compose.py: Docker compose remote execution
  * log.py: Container log retrieval
  * container.py: Docker container commands
- Added proper error handling for permission issues
- Centralized implementation avoids code duplication

The initialization creates:
- /share directory with 0755 permissions if missing
- /share/known_hosts file with 0644 permissions if missing

This ensures all SSH operations work correctly in new installations.