### PR TITLE
Split sync ironic and implement sync netbox with URL filtering

### DIFF
--- a/osism/tasks/conductor/__init__.py
+++ b/osism/tasks/conductor/__init__.py
@@ -3,7 +3,6 @@
 import copy
 from celery import Celery
 from celery.signals import worker_process_init
-from loguru import logger
 
 from osism import utils
 from osism.tasks import Config
@@ -40,11 +39,13 @@ def get_ironic_parameters(self):
 
 
 @app.task(bind=True, name="osism.tasks.conductor.sync_netbox")
-def sync_netbox(self, force_update=False):
+def sync_netbox(self, node_name=None, netbox_filter=None):
     # Check if tasks are locked before execution
     utils.check_task_lock_and_exit()
 
-    logger.info("Not implemented")
+    from osism.tasks.conductor.ironic import sync_netbox_from_ironic
+
+    sync_netbox_from_ironic(self.request.id, node_name, netbox_filter)
 
 
 @app.task(bind=True, name="osism.tasks.conductor.sync_ironic")

--- a/osism/tasks/netbox.py
+++ b/osism/tasks/netbox.py
@@ -29,8 +29,15 @@ def run(self, action, arguments):
 
 
 @app.task(bind=True, name="osism.tasks.netbox.set_maintenance")
-def set_maintenance(self, device_name, state=True):
-    """Set the maintenance state for a device in the NetBox."""
+def set_maintenance(self, device_name, state=True, netbox_filter=None):
+    """Set the maintenance state for a device in the NetBox.
+
+    Args:
+        device_name: Name of the device
+        state: Maintenance state (True/False)
+        netbox_filter: Optional URL filter (substring match, case-insensitive).
+                      Only NetBox instances whose base_url contains this substring will be updated.
+    """
     # Check if tasks are locked before execution
     utils.check_task_lock_and_exit()
 
@@ -41,6 +48,13 @@ def set_maintenance(self, device_name, state=True):
     if lock.acquire(timeout=20):
         try:
             for nb in [utils.nb] + utils.secondary_nb_list:
+                # Apply filter if specified
+                if netbox_filter and netbox_filter.lower() not in nb.base_url.lower():
+                    logger.debug(
+                        f"Skipping {nb.base_url} (does not match filter: {netbox_filter})"
+                    )
+                    continue
+
                 logger.info(
                     f"Set maintenance state of device {device_name} = {state} on {nb.base_url}"
                 )
@@ -59,8 +73,15 @@ def set_maintenance(self, device_name, state=True):
 
 
 @app.task(bind=True, name="osism.tasks.netbox.set_provision_state")
-def set_provision_state(self, device_name, state):
-    """Set the provision state for a device in the NetBox."""
+def set_provision_state(self, device_name, state, netbox_filter=None):
+    """Set the provision state for a device in the NetBox.
+
+    Args:
+        device_name: Name of the device
+        state: Provision state value
+        netbox_filter: Optional URL filter (substring match, case-insensitive).
+                      Only NetBox instances whose base_url contains this substring will be updated.
+    """
     # Check if tasks are locked before execution
     utils.check_task_lock_and_exit()
 
@@ -70,8 +91,14 @@ def set_provision_state(self, device_name, state):
     )
     if lock.acquire(timeout=20):
         try:
-
             for nb in [utils.nb] + utils.secondary_nb_list:
+                # Apply filter if specified
+                if netbox_filter and netbox_filter.lower() not in nb.base_url.lower():
+                    logger.debug(
+                        f"Skipping {nb.base_url} (does not match filter: {netbox_filter})"
+                    )
+                    continue
+
                 logger.info(
                     f"Set provision state of device {device_name} = {state} on {nb.base_url}"
                 )
@@ -90,8 +117,15 @@ def set_provision_state(self, device_name, state):
 
 
 @app.task(bind=True, name="osism.tasks.netbox.set_power_state")
-def set_power_state(self, device_name, state):
-    """Set the provision state for a device in the NetBox."""
+def set_power_state(self, device_name, state, netbox_filter=None):
+    """Set the power state for a device in the NetBox.
+
+    Args:
+        device_name: Name of the device
+        state: Power state value
+        netbox_filter: Optional URL filter (substring match, case-insensitive).
+                      Only NetBox instances whose base_url contains this substring will be updated.
+    """
     # Check if tasks are locked before execution
     utils.check_task_lock_and_exit()
 
@@ -102,6 +136,13 @@ def set_power_state(self, device_name, state):
     if lock.acquire(timeout=20):
         try:
             for nb in [utils.nb] + utils.secondary_nb_list:
+                # Apply filter if specified
+                if netbox_filter and netbox_filter.lower() not in nb.base_url.lower():
+                    logger.debug(
+                        f"Skipping {nb.base_url} (does not match filter: {netbox_filter})"
+                    )
+                    continue
+
                 logger.info(
                     f"Set power state of device {device_name} = {state} on {nb.base_url}"
                 )


### PR DESCRIPTION
Split the bidirectional sync ironic command into two separate commands:
- sync ironic: NetBox → Ironic synchronization (unchanged direction)
- sync netbox: Ironic → NetBox synchronization (new command)

The sync ironic command now only synchronizes from NetBox to Ironic, creating/updating/deleting Ironic nodes based on NetBox devices. The previously embedded Ironic → NetBox state updates have been removed and moved to the new sync netbox command.

Implement sync netbox command to synchronize Ironic node states to NetBox:
- Updates provision_state, power_state, and maintenance custom fields
- Syncs to primary NetBox and all configured secondary instances
- Supports optional node_name parameter to sync specific nodes
- Add --netbox-filter parameter for selective NetBox instance updates
- Filter uses case-insensitive substring matching on base_url

The URL filter enables targeted synchronization scenarios:
- Sync only to primary NetBox: --netbox-filter primary
- Sync only to specific secondary: --netbox-filter secondary-1
- Sync to environment-specific instances: --netbox-filter prod

This separation allows independent execution of each sync direction and provides fine-grained control over which NetBox instances to update.

AI-assisted: Claude Code