### PR TITLE
Remove --flush-cache parameter from inventory reconciler

### DIFF
--- a/osism/commands/reconciler.py
+++ b/osism/commands/reconciler.py
@@ -43,12 +43,6 @@ class Sync(Command):
             type=int,
             help="Timeout for a scheduled task that has not been executed yet",
         )
-        parser.add_argument(
-            "--flush-cache",
-            default=False,
-            help="Flush cache before running sync",
-            action="store_true",
-        )
         return parser
 
     def take_action(self, parsed_args):
@@ -57,9 +51,8 @@ class Sync(Command):
 
         wait = not parsed_args.no_wait
         task_timeout = parsed_args.task_timeout
-        flush_cache = parsed_args.flush_cache
 
-        t = reconciler.run.delay(publish=wait, flush_cache=flush_cache)
+        t = reconciler.run.delay(publish=wait)
         if wait:
             logger.info(
                 f"Task {t.task_id} (sync inventory) is running in background. Output coming soon."

--- a/osism/tasks/reconciler.py
+++ b/osism/tasks/reconciler.py
@@ -26,7 +26,7 @@ def setup_periodic_tasks(sender, **kwargs):
 
 
 @app.task(bind=True, name="osism.tasks.reconciler.run")
-def run(self, publish=True, flush_cache=False):
+def run(self, publish=True):
     # Check if tasks are locked before execution
     utils.check_task_lock_and_exit()
 
@@ -39,8 +39,6 @@ def run(self, publish=True, flush_cache=False):
         logger.info("RUN /run.sh")
 
         env = os.environ.copy()
-        if flush_cache:
-            env["FLUSH_CACHE"] = "true"
 
         p = subprocess.Popen(
             "/run.sh",


### PR DESCRIPTION
This parameter is no longer needed for the reconciler sync command. Removed all related functionality including:

- CLI parameter definition in Sync.get_parser()
- flush_cache variable assignment in Sync.take_action()
- flush_cache parameter from reconciler.run() function
- FLUSH_CACHE environment variable logic

AI-assisted: Claude Code