### PR TITLE
Add API connectivity checks to sync ironic command

### DIFF
--- a/osism/tasks/conductor/ironic.py
+++ b/osism/tasks/conductor/ironic.py
@@ -434,6 +434,36 @@ def sync_netbox_from_ironic(request_id, node_name=None, netbox_filter=None):
             f"Starting Ironic to NetBox synchronisation{filter_msg}\n",
         )
 
+    # Check NetBox API connectivity
+    try:
+        osism_utils.push_task_output(
+            request_id, "Checking NetBox API connectivity...\n"
+        )
+        osism_utils.nb.status()
+        osism_utils.push_task_output(request_id, "NetBox API is reachable\n")
+    except Exception as e:
+        osism_utils.push_task_output(
+            request_id, f"ERROR: NetBox API is not reachable: {e}\n"
+        )
+        osism_utils.finish_task_output(request_id, rc=1)
+        return
+
+    # Check Ironic API connectivity
+    try:
+        osism_utils.push_task_output(
+            request_id, "Checking Ironic API connectivity...\n"
+        )
+        conn = osism_utils.get_openstack_connection()
+        # Try a simple API call to verify connectivity
+        list(conn.baremetal.nodes(limit=1))
+        osism_utils.push_task_output(request_id, "Ironic API is reachable\n")
+    except Exception as e:
+        osism_utils.push_task_output(
+            request_id, f"ERROR: Ironic API is not reachable: {e}\n"
+        )
+        osism_utils.finish_task_output(request_id, rc=1)
+        return
+
     # Get all Ironic nodes
     nodes = openstack.baremetal_node_list()
 


### PR DESCRIPTION
Add NetBox and Ironic API connectivity checks at the start of the sync_ironic function to enable quick abort if APIs are not reachable. This prevents long timeouts and provides clear error messages when APIs are unavailable.

Changes:
- Check NetBox API connectivity using osism_utils.nb.status()
- Check Ironic API connectivity using OpenStack connection
- Exit early with error code 1 if either API is unreachable
- Provide clear error messages indicating which API failed

AI-assisted: Claude Code