### PR TITLE
Convert Ironic power state None to n/a for clearer feedback

### DIFF
--- a/osism/commands/baremetal.py
+++ b/osism/commands/baremetal.py
@@ -80,7 +80,7 @@ class BaremetalList(Command):
                 [
                     b["name"],
                     device_role,
-                    b["power_state"],
+                    b["power_state"] if b["power_state"] is not None else "n/a",
                     b["provision_state"],
                     b["maintenance"],
                 ]

--- a/osism/tasks/netbox.py
+++ b/osism/tasks/netbox.py
@@ -197,11 +197,15 @@ def set_power_state(self, device_name, state, netbox_filter=None):
 
     Args:
         device_name: Name of the device
-        state: Power state value
+        state: Power state value (None is converted to "n/a")
         netbox_filter: Optional filter (substring match, case-insensitive).
                       Matches against NetBox name, site, or URL.
                       Use 'primary' to match the primary NetBox instance.
     """
+    # Convert None to "n/a" for clearer user feedback
+    if state is None:
+        state = "n/a"
+
     # Check if tasks are locked before execution
     utils.check_task_lock_and_exit()
 


### PR DESCRIPTION
When Ironic reports an unknown power state (None), display and store it as "n/a" instead for better user readability. This change affects both the baremetal list output and NetBox synchronization.

AI-assisted: Claude Code