### PR TITLE
Fix NetBox state change race conditions with unified locking and conn…

### DIFF
--- a/osism/settings.py
+++ b/osism/settings.py
@@ -59,3 +59,6 @@ NETBOX_SECONDARIES = (
 
 # Redfish connection timeout in seconds
 REDFISH_TIMEOUT = int(os.getenv("REDFISH_TIMEOUT", "20"))
+
+# NetBox connection limiting
+NETBOX_MAX_CONNECTIONS = int(os.getenv("NETBOX_MAX_CONNECTIONS", "5"))


### PR DESCRIPTION
…ection limiting

Implemented two critical fixes to prevent race conditions when multiple state changes occur simultaneously for NetBox nodes:

1. Unified Lock Keys:
   - All three state-setting functions now use the same lock key per device
   - Previously each function used different locks allowing parallel execution
   - Prevents race conditions when multiple states change in quick succession
   - Fixed incorrect lock key in set_power_state (was using provision_state key)

2. NetBox Connection Limiting:
   - Implemented Redis-based semaphore system to limit concurrent connections
   - Default: maximum 5 concurrent operations per NetBox instance
   - Configurable via NETBOX_MAX_CONNECTIONS environment variable
   - Prevents overloading NetBox services during parallel operations
   - Works for both primary and secondary NetBox instances

3. Increased Timeouts:
   - Lock acquisition timeout: 20s -> 120s (2 minutes)
   - Auto-release time: 60s -> 300s (5 minutes)
   - Handles high-concurrency scenarios during node provisioning and sync

AI-assisted: Claude Code