### PR TITLE
Rename --force-update parameter to --force for sync ironic command

### DIFF
--- a/osism/commands/netbox.py
+++ b/osism/commands/netbox.py
@@ -33,7 +33,7 @@ class Ironic(Command):
             help="Timeout for a scheduled task that has not been executed yet",
         )
         parser.add_argument(
-            "--force-update",
+            "--force",
             help="Force update of baremetal nodes (Used to update non-comparable items like passwords)",
             action="store_true",
         )
@@ -47,9 +47,7 @@ class Ironic(Command):
         task_timeout = parsed_args.task_timeout
         node_name = parsed_args.node
 
-        task = conductor.sync_ironic.delay(
-            node_name=node_name, force_update=parsed_args.force_update
-        )
+        task = conductor.sync_ironic.delay(node_name=node_name, force=parsed_args.force)
         if wait:
             if node_name:
                 logger.info(

--- a/osism/tasks/conductor/__init__.py
+++ b/osism/tasks/conductor/__init__.py
@@ -49,11 +49,11 @@ def sync_netbox(self, node_name=None, netbox_filter=None):
 
 
 @app.task(bind=True, name="osism.tasks.conductor.sync_ironic")
-def sync_ironic(self, node_name=None, force_update=False):
+def sync_ironic(self, node_name=None, force=False):
     # Check if tasks are locked before execution
     utils.check_task_lock_and_exit()
 
-    _sync_ironic(self.request.id, get_ironic_parameters, node_name, force_update)
+    _sync_ironic(self.request.id, get_ironic_parameters, node_name, force)
 
 
 @app.task(bind=True, name="osism.tasks.conductor.sync_sonic")

--- a/osism/tasks/conductor/ironic.py
+++ b/osism/tasks/conductor/ironic.py
@@ -133,7 +133,7 @@ def _prepare_node_attributes(device, get_ironic_parameters):
     return node_attributes
 
 
-def sync_ironic(request_id, get_ironic_parameters, node_name=None, force_update=False):
+def sync_ironic(request_id, get_ironic_parameters, node_name=None, force=False):
     if node_name:
         osism_utils.push_task_output(
             request_id,
@@ -275,7 +275,7 @@ def sync_ironic(request_id, get_ironic_parameters, node_name=None, force_update=
                             node_updates["driver_info"].pop(password_key, None)
                             if not node_updates["driver_info"]:
                                 node_updates.pop("driver_info", None)
-                    if node_updates or force_update:
+                    if node_updates or force:
                         osism_utils.push_task_output(
                             request_id,
                             f"Updating baremetal node for {device.name} with {node_updates}\n",


### PR DESCRIPTION
Simplifies the CLI interface by shortening the parameter name from --force-update to --force. This change affects:
- CLI argument definition in osism/commands/netbox.py
- Task parameter in osism/tasks/conductor/__init__.py
- Function parameter in osism/tasks/conductor/ironic.py

The functionality remains unchanged - the parameter still forces updates of baremetal nodes for non-comparable items like passwords.

AI-assisted: Claude Code