### PR TITLE
Improve Redis/Celery reliability to prevent task loss

### DIFF
--- a/osism/settings.py
+++ b/osism/settings.py
@@ -21,6 +21,9 @@ OPENSEARCH_PORT = os.getenv("OPENSEARCH_PORT")
 REDIS_HOST: str = os.getenv("REDIS_HOST", "redis")
 REDIS_PORT: int = int(os.getenv("REDIS_PORT", "6379"))
 REDIS_DB: int = int(os.getenv("REDIS_DB", "0"))
+REDIS_SOCKET_TIMEOUT: int = int(os.getenv("REDIS_SOCKET_TIMEOUT", "30"))
+REDIS_SOCKET_CONNECT_TIMEOUT: int = int(os.getenv("REDIS_SOCKET_CONNECT_TIMEOUT", "30"))
+REDIS_HEALTH_CHECK_INTERVAL: int = int(os.getenv("REDIS_HEALTH_CHECK_INTERVAL", "10"))
 
 
 NETBOX_URL = os.getenv("NETBOX_API", os.getenv("NETBOX_URL"))


### PR DESCRIPTION
- Add visibility_timeout (12h) to prevent tasks from being redelivered while still running
- Enable task_acks_late and task_reject_on_worker_lost to ensure tasks are requeued if a worker crashes
- Set worker_prefetch_multiplier=1 to prevent task hoarding
- Add broker_heartbeat for faster connection problem detection
- Configure socket timeouts and retry_on_timeout for Redis connections
- Add exponential backoff retry (3 retries) for Redis client
- Add health_check_interval for periodic connection validation
- Add configurable task time limits (24h hard, 23h soft)
- Fix task_track_started from tuple (True,) to boolean True

New environment variables for configuration:
- CELERY_VISIBILITY_TIMEOUT, CELERY_BROKER_HEARTBEAT
- CELERY_TASK_TIME_LIMIT, CELERY_TASK_SOFT_TIME_LIMIT
- CELERY_BROKER_POOL_LIMIT, CELERY_REDIS_MAX_CONNECTIONS
- REDIS_SOCKET_TIMEOUT, REDIS_SOCKET_CONNECT_TIMEOUT
- REDIS_HEALTH_CHECK_INTERVAL

AI-assisted: Claude Code