### PR TITLE
Fix sync versions to use openstack_version from SBOM

### DIFF
--- a/osism/commands/sync.py
+++ b/osism/commands/sync.py
@@ -344,12 +344,6 @@ class Versions(Command):
                 else:
                     sbom_image = f"registry.osism.cloud/kolla/sbom:{version_tag}"
 
-        if release is not None:
-            logger.info(f"OSISM release: {release}")
-        logger.info(f"OpenStack version: {openstack_version}")
-        logger.info(f"Configuration path: {config_path}")
-        logger.info(f"SBOM image: {sbom_image}")
-
         # Check configuration path exists
         if not dry_run and not config_path.exists():
             logger.error(f"Configuration path does not exist: {config_path}")
@@ -366,6 +360,15 @@ class Versions(Command):
             return 1
 
         versions = sbom.get("versions", {})
+
+        # Always use openstack_version from SBOM
+        openstack_version = sbom.get("openstack_version", openstack_version)
+
+        if release is not None:
+            logger.info(f"OSISM release: {release}")
+        logger.info(f"OpenStack version: {openstack_version}")
+        logger.info(f"Configuration path: {config_path}")
+        logger.info(f"SBOM image: {sbom_image}")
         logger.info(f"Found {len(versions)} version entries in SBOM")
 
         # Render template


### PR DESCRIPTION
The openstack_version was incorrectly using the CLI argument default value instead of the version from the SBOM. Now the SBOM is extracted first and openstack_version is read from it before logging and template rendering.

AI-assisted: Claude Code