### PR TITLE
Rename generic queue pattern to notifications in migrate command

### DIFF
--- a/osism/commands/migrate.py
+++ b/osism/commands/migrate.py
@@ -57,7 +57,7 @@ SERVICE_QUEUE_PATTERNS = {
         r"^worker_fanout_.*$",
         r"^reply_[a-f0-9]+$",
     ],
-    "generic": [
+    "notifications": [
         r"^notifications\..*$",
         r"^versioned_notifications\..*$",
     ],


### PR DESCRIPTION
The queue pattern key "generic" was misleading since it only contains notification-related queue patterns. Renaming to "notifications" makes the purpose clearer.