### PR TITLE
Use RabbitMQ default queue type for listener queues

### DIFF
--- a/osism/services/listener.py
+++ b/osism/services/listener.py
@@ -350,13 +350,13 @@ class NotificationsDump(ConsumerMixin):
                     passive=True,
                 )
                 # Create our own queue bound to the existing exchange
-                # Our queue can have its own properties (non-durable, auto-delete)
+                # Don't set durable explicitly to use RabbitMQ's configured default
+                # queue type (e.g., quorum queues in RabbitMQ 4)
                 queue = Queue(
                     config["queue"],
                     exchange,
                     routing_key=config["routing_key"],
-                    durable=False,
-                    auto_delete=True,
+                    auto_delete=False,
                     no_ack=True,
                 )
                 consumers.append(consumer(queue, callbacks=[self.on_message]))


### PR DESCRIPTION
Remove explicit durable=False and set auto_delete=False to make listener queues compatible with RabbitMQ's configured default queue type. Previously, the queues were always created as classic queues because durable=False and auto_delete=True are not supported by quorum queues.

With these changes, the osism-listener-* queues will use the vhost's default queue type (e.g., quorum queues in RabbitMQ 4 with the openstack vhost created by migrate rabbitmq3to4 prepare).

AI-assisted: Claude Code