### PR TITLE
Add changelog generation script and initial CHANGELOG

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@
 __pycache__
 build
 dist
+changelog-input*.md

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,215 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [v0.20251202.0] - 2025-12-02
+
+### Added
+- New `osism migrate rabbitmq3to4` command to assist with RabbitMQ 3 to 4 migration, including subcommands for listing, deleting classic queues, checking migration status, and preparing the openstack vhost with quorum queue defaults
+- New `osism status database` command to check MariaDB Galera Cluster status with extended metrics including flow control, transaction statistics, cluster member info, and general MariaDB metrics
+- New `osism status messaging` command to check RabbitMQ Cluster status across all nodes with optional hostname filtering
+- Support for `event.sample` queue pattern in ceilometer for the migrate command
+
+### Changed
+- Moved `validate database` and `validate messaging` commands to `status database` and `status messaging` respectively
+- Extended `status messaging` command to check all RabbitMQ nodes instead of only the first one
+- Listener queues now use RabbitMQ's configured default queue type instead of forcing classic queues, enabling compatibility with quorum queues in RabbitMQ 4
+- Renamed generic queue pattern key to "notifications" in migrate command for clarity
+- Refactored RabbitMQ connection code into shared `osism/utils/rabbitmq.py` module
+
+### Fixed
+- Improved migration detection in `migrate rabbitmq3to4 check` with vhost-specific queue counting for more accurate status reporting
+
+## [v0.20251130.1] - 2025-11-30
+
+### Fixed
+- Sync versions command now correctly uses openstack_version from SBOM instead of CLI argument default value
+
+## [v0.20251130.0] - 2025-11-30
+
+### Added
+- New `osism sync versions [kolla]` command for synchronizing Kolla version information from SBOM container images to the configuration repository
+- Support for `--release` parameter to sync Kolla versions from a specific OSISM release by fetching version data from the release repository
+- Configurable URLs for the release repository (`--release-repository-url`) and SBOM image base path (`--sbom-image-base`)
+- Dry-run mode (`--dry-run`) for previewing version synchronization without writing files
+- Skopeo dependency added to container image for extracting SBOM data without requiring Docker
+
+### Changed
+- Improved SBOM image path detection to properly handle release versions by stripping 'v' prefix from version tags and detecting date patterns (YYYYMMDD) in version strings
+
+## [v0.20251128.0] - 2025-11-28
+
+### Dependencies
+- fastapi 0.121.3 → 0.122.0
+- ghcr.io/astral-sh/uv 0.9.11 → 0.9.13
+- openstack-flavor-manager 0.20251101.0 → 0.20251128.0
+- openstack-image-manager 0.20251109.0 → 0.20251128.0
+- openstacksdk 4.7.1 → 4.8.0
+- sushy 5.8.0 → 5.9.0
+
+## [v0.20251126.2] - 2025-11-26
+
+### Added
+- Periodic exchange discovery to connect to new exchanges dynamically in the listener service
+  - Background thread checks for new exchanges every 60 seconds
+  - Consumer restarts automatically when new exchanges are found
+  - Discovery stops automatically once all configured exchanges are available
+
+### Fixed
+- RabbitMQ 4 compatibility by using passive exchange declarations
+  - Listener now waits for OpenStack services to create exchanges instead of creating them itself
+  - Prevents PRECONDITION_FAILED errors when listener starts before other services
+  - Removed legacy fallback that could create exchanges with wrong properties
+
+## [v0.20251126.1] - 2025-11-25
+
+### Changed
+- Reverted Redis/Celery reliability improvements that were introduced to prevent task loss, restoring previous simpler configuration
+
+## [v0.20251126.0] - 2025-11-25
+
+### Added
+- Shared session management for NetBox connections to prevent file descriptor exhaustion
+- Robust exception handling for NetBox tasks with timeout resilience (handles ConnectTimeout, Timeout, ConnectionError, RequestException)
+- Redis/Celery reliability improvements with configurable options:
+  - Visibility timeout (12h) to prevent task redelivery while running
+  - Task acknowledgement after completion with requeue on worker crash
+  - Broker heartbeat for faster connection problem detection
+  - Exponential backoff retry for Redis client
+  - Configurable task time limits (24h hard, 23h soft)
+- New environment variables: CELERY_VISIBILITY_TIMEOUT, CELERY_BROKER_HEARTBEAT, CELERY_TASK_TIME_LIMIT, CELERY_TASK_SOFT_TIME_LIMIT, CELERY_BROKER_POOL_LIMIT, CELERY_REDIS_MAX_CONNECTIONS, REDIS_SOCKET_TIMEOUT, REDIS_SOCKET_CONNECT_TIMEOUT, REDIS_HEALTH_CHECK_INTERVAL
+
+### Changed
+- NetBox sync lock error handling now returns success/failure status and reports failed devices at sync completion
+- Worker prefetch multiplier set to 1 to prevent task hoarding
+
+### Fixed
+- File descriptor exhaustion in NetBox connections by implementing NetBoxSessionManager with connection pooling
+- TypeError in sync_ironic caused by missing request_id parameter in push_task_output calls
+- Format strings missing f-prefix in lock acquisition error messages
+- task_track_started configuration from tuple (True,) to boolean True
+
+### Dependencies
+- cliff 4.11.0 → 4.12.0
+- fastapi 0.121.1 → 0.121.3
+- netbox-manager 0.20251029.0 → 0.20251120.0
+- sushy 5.7.1 → 5.8.0
+
+## [v0.20251123.0] - 2025-11-23
+
+### Added
+- `--check` parameter for `sync netbox` command to test connectivity to all configured NetBox instances
+- `--list` parameter for `sync netbox` command to display all configured NetBox instances
+- API connectivity checks for `sync netbox` and `sync ironic` commands with early exit on failure
+- Two-stage connectivity check for NetBox (reachability then authentication)
+- Progress logging during NetBox connectivity checks
+- Optional `NETBOX_NAME` and `NETBOX_SITE` metadata fields for secondary NetBox instances
+- Redis-based semaphore for limiting concurrent NetBox connections (configurable via `NETBOX_MAX_CONNECTIONS`)
+- Timeout support for NetBox API connections
+
+### Changed
+- Renamed `--netbox-filter` parameter to `--filter` with support for filtering by name, site, or URL
+- Renamed `--force-update` parameter to `--force` for `sync ironic` command
+- NetBox filter now applies to both primary and secondary instances before connectivity checks
+- Improved error handling for NetBox state changes with unified locking and increased timeouts
+- Convert Ironic power state `None` to `n/a` for clearer user feedback
+
+### Fixed
+- Race conditions in NetBox state changes with unified lock keys per device
+- Missing imports and `TimeoutHTTPAdapter` class definition for NetBox connections
+
+### Dependencies
+- community.docker 4.8.2 → 5.0.2
+
+## [v0.20251122.0] - 2025-11-22
+
+### Added
+- New `sync netbox` command to synchronize Ironic node states to NetBox with optional URL filtering via `--netbox-filter` parameter
+- `ensure_known_hosts_file()` utility function in `osism/utils/ssh.py` to automatically create `/share/known_hosts` file if missing
+
+### Changed
+- Split `sync ironic` command into two separate commands: `sync ironic` (NetBox → Ironic) and `sync netbox` (Ironic → NetBox)
+- Renamed `netbox show` command to `netbox dump`
+- Limit Ansible Vault decryption to Custom Fields only in sync ironic instead of all node attributes
+
+### Fixed
+- Missing `/share/known_hosts` initialization in SSH commands causing failures in new installations
+- Strip whitespace from NETBOX_TOKEN to prevent authentication issues
+
+### Removed
+- `--flush-cache` parameter from inventory reconciler sync command
+
+### Dependencies
+- ghcr.io/astral-sh/uv 0.9.7 → 0.9.11
+
+## [v0.20251120.0] - 2025-11-19
+
+### Added
+- New `baremetal clean` command to erase storage devices on baremetal nodes
+- New `baremetal provide` command to move nodes from manageable to available state
+- `--all` parameter for `baremetal clean` command with `--yes-i-really-really-mean-it` safety confirmation
+- `--all` parameter for `baremetal provide` command to process all manageable nodes
+- Device Role column to `baremetal list` command output, fetched from NetBox
+
+## [v0.20251115.0] - 2025-11-15
+
+### Added
+- `--ironic` parameter to `baremetal dump` command to show actual deployment state from Ironic instead of NetBox, enabling comparison between planned and deployed configurations
+
+### Changed
+- Updated gardenlinux from 1877.6 to 1877.7
+- Moved redfish dependency from Containerfile to project requirements
+
+### Dependencies
+- openstack-image-manager v0.20251020.0 → v0.20251109.0
+- redfish 3.3.3 → 3.3.4 (now in project requirements)
+- cachetools 6.2.1 → 6.2.2
+- certifi 2025.10.5 → 2025.11.12
+- prettytable 3.16.0 → 3.17.0
+- pynacl 1.6.0 → 1.6.1
+- pytest 9.0.0 → 9.0.1
+
+## [v0.20251110.0] - 2025-11-10
+
+### Added
+- New `osism netbox show` command for displaying device information from NetBox with support for custom field parameters and field filtering
+- Device Role column to `sonic list` command output for better visibility into switch roles
+- VRF support to SONiC configuration generator including VRF table extraction and interface/port channel assignments
+- `sonic dump` command to output NetBox config context as JSON for a specified SONiC switch
+- `baremetal dump` command to output deployment playbook for a given baremetal node
+- BGP configuration for VLAN interfaces with FHRP (First Hop Redundancy Protocol) support
+- Detection of untagged VLAN members to route BGP peering over VLAN interfaces instead of physical interfaces
+
+### Changed
+- Refactored Collections definitions in `osism/data/enums.py` to use Role class instead of nested lists for improved readability and maintainability
+- Provision state in `sonic list` now reads from NetBox custom field instead of deriving from device status
+- Updated supported Garden Linux version from 1877.2 to 1877.6
+- Physical interfaces that are untagged VLAN members are now excluded from BGP_NEIGHBOR and BGP_NEIGHBOR_AF configurations
+
+### Fixed
+- SONiC 400G to 4x100G breakout detection for SONiC format interfaces (Ethernet0, Ethernet2, Ethernet4, Ethernet6)
+
+### Dependencies
+- jc 1.25.5 → 1.25.6
+
+## [v0.20251104.0] - 2025-11-04
+
+### Added
+- Cloudpod flavors to the manage flavors command
+- Automatic `kolla_action_stop_ignore_missing=true` for kolla-ansible stop actions
+
+### Dependencies
+- community.docker 4.8.1 → 4.8.2
+- fastapi 0.119.1 → 0.120.4
+- huey 2.5.3 → 2.5.4
+- netbox-manager 0.20250915.0 → 0.20251029.0
+- openstack-flavor-manager 0.20251021.0 → 0.20251101.0
+- uv 0.9.4 → 0.9.7
+
+## [v0.20251101.0] - 2025-11-01
+
+### Dependencies
+- eslint 9.34.0 → 9.39.0

--- a/scripts/generate-changelog-input.sh
+++ b/scripts/generate-changelog-input.sh
@@ -1,0 +1,350 @@
+#!/bin/bash
+#
+# Generate changelog input file for Claude
+#
+# This script collects all commits and diffs between the latest tag (or a
+# specified tag) and the previous tag, then creates a file with a prompt
+# for Claude to generate a changelog entry.
+#
+# For large releases, commits are processed in batches to avoid prompt
+# length limits. Batching is based on diff size, not commit count.
+#
+# Usage: ./scripts/generate-changelog-input.sh [options] [tag]
+#
+# Options:
+#   -n, --no-run       Only generate the input file(s), do not run Claude
+#   -o, --output       Specify output file (default: changelog-input-<tag>.md)
+#   -s, --max-size     Max lines per batch (default: 2000)
+#   -h, --help         Show this help message
+#
+# Examples:
+#   ./scripts/generate-changelog-input.sh                     # Use latest tag, run Claude
+#   ./scripts/generate-changelog-input.sh v0.20251130.1       # Use specific tag, run Claude
+#   ./scripts/generate-changelog-input.sh -n                  # Only generate file
+#   ./scripts/generate-changelog-input.sh -s 3000             # 3000 lines per batch
+#
+
+set -e
+
+# Parse arguments
+LATEST_TAG=""
+OUTPUT_FILE=""
+RUN_CLAUDE=true
+MAX_BATCH_SIZE=2000
+
+show_help() {
+    echo "Usage: $0 [options] [tag]"
+    echo ""
+    echo "Options:"
+    echo "  -n, --no-run       Only generate the input file(s), do not run Claude"
+    echo "  -o, --output       Specify output file (default: changelog-input-<tag>.md)"
+    echo "  -s, --max-size     Max lines per batch (default: 2000)"
+    echo "  -h, --help         Show this help message"
+    echo ""
+    echo "Examples:"
+    echo "  $0                          # Use latest tag, run Claude"
+    echo "  $0 v0.20251130.1            # Use specific tag, run Claude"
+    echo "  $0 -n                       # Only generate file"
+    echo "  $0 -s 3000                  # 3000 lines per batch"
+    exit 0
+}
+
+while [ $# -gt 0 ]; do
+    case "$1" in
+        -n|--no-run)
+            RUN_CLAUDE=false
+            shift
+            ;;
+        -o|--output)
+            OUTPUT_FILE="$2"
+            shift 2
+            ;;
+        -s|--max-size)
+            MAX_BATCH_SIZE="$2"
+            shift 2
+            ;;
+        -h|--help)
+            show_help
+            ;;
+        v*)
+            LATEST_TAG="$1"
+            shift
+            ;;
+        *)
+            echo "Unknown option: $1"
+            echo "Use -h or --help for usage information"
+            exit 1
+            ;;
+    esac
+done
+
+# Get the latest tag if not specified
+if [ -z "$LATEST_TAG" ]; then
+    LATEST_TAG=$(git tag --sort=-version:refname | head -1)
+fi
+
+if [ -z "$LATEST_TAG" ]; then
+    echo "Error: No tags found in repository"
+    exit 1
+fi
+
+# Set default output file with tag name
+if [ -z "$OUTPUT_FILE" ]; then
+    OUTPUT_FILE="changelog-input-${LATEST_TAG}.md"
+fi
+
+# Verify the tag exists
+if ! git rev-parse "$LATEST_TAG" >/dev/null 2>&1; then
+    echo "Error: Tag '$LATEST_TAG' does not exist"
+    exit 1
+fi
+
+# Get the previous tag (the one before LATEST_TAG)
+PREVIOUS_TAG=$(git tag --sort=-version:refname | grep -A1 "^${LATEST_TAG}$" | tail -1)
+
+if [ -z "$PREVIOUS_TAG" ] || [ "$LATEST_TAG" = "$PREVIOUS_TAG" ]; then
+    echo "Error: No previous tag found before $LATEST_TAG"
+    exit 1
+fi
+
+echo "Generating changelog input..."
+echo "  Target tag:   $LATEST_TAG"
+echo "  Previous tag: $PREVIOUS_TAG"
+
+# Get the date from the tag name (format: v0.YYYYMMDD.X or vX.YYYYMMDD.X)
+# Extract YYYYMMDD from tag and convert to YYYY-MM-DD
+if [[ "$LATEST_TAG" =~ v[0-9]+\.([0-9]{4})([0-9]{2})([0-9]{2})\.[0-9]+ ]]; then
+    TAG_DATE="${BASH_REMATCH[1]}-${BASH_REMATCH[2]}-${BASH_REMATCH[3]}"
+else
+    # Fallback to tag creation date if tag doesn't match expected format
+    TAG_DATE=$(git for-each-ref --format='%(creatordate:short)' "refs/tags/$LATEST_TAG")
+fi
+
+# Get list of commits (oldest first for logical order)
+COMMITS=()
+while IFS= read -r commit; do
+    COMMITS+=("$commit")
+done < <(git log --reverse --format="%h" "$PREVIOUS_TAG".."$LATEST_TAG")
+TOTAL_COMMITS=${#COMMITS[@]}
+
+echo "  Total commits: $TOTAL_COMMITS"
+echo "  Max batch size: $MAX_BATCH_SIZE lines"
+
+# Create the prompt template
+PROMPT_TEMPLATE='# Changelog Generation Prompt
+
+Analyze the following Git commits and diffs and create CHANGELOG entries in the following format:
+
+```markdown
+### Added
+- New features (if any)
+
+### Changed
+- Changes to existing features (if any)
+
+### Fixed
+- Bug fixes (if any)
+
+### Removed
+- Removed features (if any)
+
+### Dependencies
+- package-name 1.0.0 → 1.1.0
+```
+
+Important notes:
+- Group related commits together
+- Ignore pure merge commits
+- Write entries in English
+- Use concise, understandable descriptions
+- Remove empty categories (e.g., if there are no "Removed" items)
+- Start each entry with a capital letter
+- Do not use periods at the end of entries
+- Include dependency updates from Renovate in the "Dependencies" section
+- Format dependency updates as: "package-name old_version → new_version" (use → arrow, lowercase package name)
+- Output ONLY the markdown changelog entries, no explanations
+
+---
+
+'
+
+# Max lines for a single diff (to prevent oversized commits)
+MAX_DIFF_LINES=1500
+
+# Function to get commit content
+get_commit_content() {
+    local commit="$1"
+    local content=""
+    local diff_content
+    local diff_lines
+
+    content+="## Commit: $commit"$'\n\n'
+    content+=$(git log -1 --format="**Author:** %an%n**Date:** %ci%n%n**Message:**%n%s%n%n%b" "$commit")
+    content+=$'\n\n### Diff\n\n```diff\n'
+
+    # Get diff and truncate if too large
+    diff_content=$(git show --format="" "$commit")
+    diff_lines=$(echo "$diff_content" | wc -l)
+
+    if [ "$diff_lines" -gt "$MAX_DIFF_LINES" ]; then
+        content+=$(echo "$diff_content" | head -n "$MAX_DIFF_LINES")
+        content+=$'\n\n... (diff truncated, was '"$diff_lines"' lines) ...\n'
+    else
+        content+="$diff_content"
+    fi
+
+    content+=$'\n```\n\n---\n\n'
+
+    echo "$content"
+}
+
+# Create batches based on size
+BATCH_FILES=()
+BATCH_NUM=1
+CURRENT_BATCH=""
+CURRENT_SIZE=0
+PROMPT_SIZE=$(echo "$PROMPT_TEMPLATE" | wc -l)
+
+for commit in "${COMMITS[@]}"; do
+    COMMIT_CONTENT=$(get_commit_content "$commit")
+    COMMIT_SIZE=$(echo "$COMMIT_CONTENT" | wc -l)
+
+    # If adding this commit would exceed the limit, save current batch and start new one
+    if [ $((CURRENT_SIZE + COMMIT_SIZE + PROMPT_SIZE)) -gt $MAX_BATCH_SIZE ] && [ -n "$CURRENT_BATCH" ]; then
+        BATCH_FILE="${OUTPUT_FILE%.md}-batch${BATCH_NUM}.md"
+        BATCH_FILES+=("$BATCH_FILE")
+
+        {
+            echo "$PROMPT_TEMPLATE"
+            echo "## Release Information"
+            echo ""
+            echo "- **Version:** $LATEST_TAG"
+            echo "- **Date:** $TAG_DATE"
+            echo "- **Batch:** $BATCH_NUM"
+            echo ""
+            echo "---"
+            echo ""
+            echo "# Commits in this batch"
+            echo ""
+            echo "$CURRENT_BATCH"
+        } > "$BATCH_FILE"
+
+        echo "  Created: $BATCH_FILE ($CURRENT_SIZE lines)"
+        BATCH_NUM=$((BATCH_NUM + 1))
+        CURRENT_BATCH=""
+        CURRENT_SIZE=0
+    fi
+
+    CURRENT_BATCH+="$COMMIT_CONTENT"
+    CURRENT_SIZE=$((CURRENT_SIZE + COMMIT_SIZE))
+done
+
+# Save the last batch
+if [ -n "$CURRENT_BATCH" ]; then
+    BATCH_FILE="${OUTPUT_FILE%.md}-batch${BATCH_NUM}.md"
+    BATCH_FILES+=("$BATCH_FILE")
+
+    {
+        echo "$PROMPT_TEMPLATE"
+        echo "## Release Information"
+        echo ""
+        echo "- **Version:** $LATEST_TAG"
+        echo "- **Date:** $TAG_DATE"
+        echo "- **Batch:** $BATCH_NUM"
+        echo ""
+        echo "---"
+        echo ""
+        echo "# Commits in this batch"
+        echo ""
+        echo "$CURRENT_BATCH"
+    } > "$BATCH_FILE"
+
+    echo "  Created: $BATCH_FILE ($CURRENT_SIZE lines)"
+fi
+
+NUM_BATCHES=${#BATCH_FILES[@]}
+echo "  Number of batches: $NUM_BATCHES"
+
+# Create the main output file with header
+cat > "$OUTPUT_FILE" << EOF
+# Changelog for $LATEST_TAG
+
+**Date:** $TAG_DATE
+**Previous Version:** $PREVIOUS_TAG
+**Total Commits:** $TOTAL_COMMITS
+
+---
+
+EOF
+
+echo ""
+echo "Output files created:"
+echo "  Main: $OUTPUT_FILE"
+for f in "${BATCH_FILES[@]}"; do
+    echo "  Batch: $f"
+done
+
+if [ "$RUN_CLAUDE" = true ]; then
+    echo ""
+    echo "Processing batches with Claude..."
+    echo ""
+
+    # Process each batch
+    for (( batch=0; batch<NUM_BATCHES; batch++ )); do
+        BATCH_FILE="${BATCH_FILES[$batch]}"
+        echo "Processing batch $((batch+1)) of $NUM_BATCHES..."
+
+        # Run Claude and append output to main file
+        RESULT=$(claude -p "$(cat "$BATCH_FILE")" 2>&1) || true
+
+        echo "" >> "$OUTPUT_FILE"
+        echo "## Batch $((batch+1))" >> "$OUTPUT_FILE"
+        echo "" >> "$OUTPUT_FILE"
+        echo "$RESULT" >> "$OUTPUT_FILE"
+        echo "" >> "$OUTPUT_FILE"
+    done
+
+    echo ""
+    echo "All batches processed. Now merging results..."
+    echo ""
+
+    # Create merge prompt
+    MERGE_PROMPT="Merge the following changelog batches into a single, clean changelog entry.
+
+Rules:
+- Combine all entries into one cohesive changelog
+- Remove duplicate entries
+- Group by category (Added, Changed, Fixed, Removed, Dependencies)
+- Remove empty categories
+- Keep the format consistent
+- Output ONLY the final markdown, starting with ## [$LATEST_TAG] - $TAG_DATE
+
+$(cat "$OUTPUT_FILE")"
+
+    # Run final merge
+    FINAL_RESULT=$(claude -p "$MERGE_PROMPT" 2>&1) || true
+
+    # Write final result
+    echo "$FINAL_RESULT" > "$OUTPUT_FILE"
+
+    echo "Final changelog written to: $OUTPUT_FILE"
+    echo ""
+    echo "Content:"
+    echo "----------------------------------------"
+    cat "$OUTPUT_FILE"
+    echo "----------------------------------------"
+
+    # Cleanup batch files
+    for f in "${BATCH_FILES[@]}"; do
+        rm -f "$f"
+    done
+else
+    echo ""
+    echo "Next steps:"
+    echo "  1. Run Claude on each batch file:"
+    for f in "${BATCH_FILES[@]}"; do
+        echo "     claude -p \"\$(cat $f)\""
+    done
+    echo "  2. Merge the results into $OUTPUT_FILE"
+    echo "  3. Add the generated changelog entry to CHANGELOG.md"
+fi


### PR DESCRIPTION
Add a helper script (scripts/generate-changelog-input.sh) that automates changelog generation by:
- Collecting commits and diffs between git tags
- Splitting large releases into batches to avoid prompt limits
- Running Claude to generate changelog entries
- Merging batch results into a final changelog

Features:
- Automatic tag detection or specific tag selection (-n for dry-run)
- Size-based batching (default: 2000 lines, configurable with -s)
- Diff truncation for oversized commits (>1500 lines)
- Dependency updates formatted as "package old → new"

Also adds initial CHANGELOG.md.

AI-assisted: Claude Code