### PR TITLE
Add manage amphora restore/rotate commands

### DIFF
--- a/osism/commands/amphora.py
+++ b/osism/commands/amphora.py
@@ -1,0 +1,135 @@
+# SPDX-License-Identifier: Apache-2.0
+
+from datetime import datetime, timezone
+from time import sleep
+
+from cliff.command import Command
+from dateutil import parser as dateutil_parser
+from loguru import logger
+import openstack
+
+from osism.commands import get_cloud_connection
+from osism.commands.octavia import wait_for_amphora_boot, wait_for_amphora_delete
+
+# Default age threshold for rotation (30 days in seconds)
+DEFAULT_ROTATION_AGE_SECONDS = 2592000
+
+
+class AmphoraRestore(Command):
+    """Restore amphorae in ERROR state by triggering failover."""
+
+    def get_parser(self, prog_name):
+        parser = super(AmphoraRestore, self).get_parser(prog_name)
+        parser.add_argument(
+            "--cloud",
+            type=str,
+            help="Cloud name in clouds.yaml",
+            default="admin",
+        )
+        parser.add_argument(
+            "--loadbalancer",
+            type=str,
+            help="Limit restore to amphorae of this loadbalancer ID",
+            default=None,
+        )
+        return parser
+
+    def take_action(self, parsed_args):
+        cloud = parsed_args.cloud
+        loadbalancer_id = parsed_args.loadbalancer
+
+        conn = get_cloud_connection(cloud)
+
+        if loadbalancer_id:
+            amphorae = conn.load_balancer.amphorae(
+                status="ERROR", loadbalancer_id=loadbalancer_id
+            )
+        else:
+            amphorae = conn.load_balancer.amphorae(status="ERROR")
+
+        for amphora in amphorae:
+            logger.info(
+                f"Amphora {amphora.id} of loadbalancer {amphora.loadbalancer_id} is in state ERROR, trigger amphora failover"
+            )
+            conn.load_balancer.failover_amphora(amphora.id)
+            sleep(10)  # wait for the octavia API
+
+            wait_for_amphora_boot(conn, amphora.loadbalancer_id)
+            wait_for_amphora_delete(conn, amphora.loadbalancer_id)
+
+
+class AmphoraRotate(Command):
+    """Rotate amphorae older than 30 days by triggering loadbalancer failover."""
+
+    def get_parser(self, prog_name):
+        parser = super(AmphoraRotate, self).get_parser(prog_name)
+        parser.add_argument(
+            "--cloud",
+            type=str,
+            help="Cloud name in clouds.yaml",
+            default="admin",
+        )
+        parser.add_argument(
+            "--loadbalancer",
+            type=str,
+            help="Limit rotation to amphorae of this loadbalancer ID",
+            default=None,
+        )
+        parser.add_argument(
+            "--force",
+            default=False,
+            help="Force rotation of amphorae regardless of age",
+            action="store_true",
+        )
+        return parser
+
+    def take_action(self, parsed_args):
+        cloud = parsed_args.cloud
+        loadbalancer_id = parsed_args.loadbalancer
+        force = parsed_args.force
+
+        conn = get_cloud_connection(cloud)
+
+        done = []
+
+        if loadbalancer_id:
+            amphorae = conn.load_balancer.amphorae(
+                status="ALLOCATED", loadbalancer_id=loadbalancer_id
+            )
+        else:
+            amphorae = conn.load_balancer.amphorae(status="ALLOCATED")
+
+        for amphora in amphorae:
+            rotate = False
+
+            if amphora.loadbalancer_id in done:
+                continue
+
+            duration = datetime.now(timezone.utc) - dateutil_parser.parse(
+                amphora.created_at
+            )
+            if duration.total_seconds() > DEFAULT_ROTATION_AGE_SECONDS:
+                logger.info(f"Amphora {amphora.id} is older than 30 days")
+                rotate = True
+            elif force:
+                logger.info(f"Force rotation of Amphora {amphora.id}")
+                rotate = True
+            else:
+                continue
+
+            if rotate:
+                logger.info(
+                    f"Amphora {amphora.id} of loadbalancer {amphora.loadbalancer_id} is rotated by a loadbalancer failover"
+                )
+                try:
+                    conn.load_balancer.failover_load_balancer(amphora.loadbalancer_id)
+                    sleep(10)  # wait for the octavia API
+
+                    done.append(amphora.loadbalancer_id)
+
+                    wait_for_amphora_boot(conn, amphora.loadbalancer_id)
+                    wait_for_amphora_delete(conn, amphora.loadbalancer_id)
+                except openstack.exceptions.ConflictException:
+                    logger.warning(
+                        f"Conflict while rotating loadbalancer {amphora.loadbalancer_id}, skipping"
+                    )

--- a/osism/commands/octavia.py
+++ b/osism/commands/octavia.py
@@ -1,0 +1,60 @@
+# SPDX-License-Identifier: Apache-2.0
+
+"""Common utilities for Octavia loadbalancer and amphora management."""
+
+from time import sleep
+
+from loguru import logger
+
+# Timing constants for waiting on amphora operations
+SLEEP_WAIT_FOR_AMPHORA_BOOT = 5
+TIMEOUT_WAIT_FOR_AMPHORA_BOOT = 120
+
+SLEEP_WAIT_FOR_AMPHORA_DELETE = 5
+TIMEOUT_WAIT_FOR_AMPHORA_DELETE = 60
+
+
+def wait_for_amphora_boot(conn, loadbalancer_id):
+    """Wait for all amphorae of a loadbalancer to finish booting.
+
+    Args:
+        conn: OpenStack connection object
+        loadbalancer_id: ID of the loadbalancer to wait for
+    """
+    logger.info(
+        f"Wait up to {TIMEOUT_WAIT_FOR_AMPHORA_BOOT} seconds for amphora boot of loadbalancer {loadbalancer_id}"
+    )
+
+    iterations = TIMEOUT_WAIT_FOR_AMPHORA_BOOT / SLEEP_WAIT_FOR_AMPHORA_BOOT
+
+    while iterations > 0:
+        amphorae = conn.load_balancer.amphorae(
+            loadbalancer_id=loadbalancer_id, status="BOOTING"
+        )
+        if not list(amphorae):
+            break
+        iterations -= 1
+        sleep(SLEEP_WAIT_FOR_AMPHORA_BOOT)
+
+
+def wait_for_amphora_delete(conn, loadbalancer_id):
+    """Wait for all amphorae of a loadbalancer to finish deletion.
+
+    Args:
+        conn: OpenStack connection object
+        loadbalancer_id: ID of the loadbalancer to wait for
+    """
+    logger.info(
+        f"Wait up to {TIMEOUT_WAIT_FOR_AMPHORA_DELETE} seconds for amphora delete of loadbalancer {loadbalancer_id}"
+    )
+
+    iterations = TIMEOUT_WAIT_FOR_AMPHORA_DELETE / SLEEP_WAIT_FOR_AMPHORA_DELETE
+
+    while iterations > 0:
+        amphorae = conn.load_balancer.amphorae(
+            loadbalancer_id=loadbalancer_id, status="PENDING_DELETE"
+        )
+        if not list(amphorae):
+            break
+        iterations -= 1
+        sleep(SLEEP_WAIT_FOR_AMPHORA_DELETE)

--- a/setup.cfg
+++ b/setup.cfg
@@ -100,6 +100,8 @@ osism.commands:
     manage loadbalancer reset = osism.commands.loadbalancer:LoadbalancerReset
     manage loadbalancer delete = osism.commands.loadbalancer:LoadbalancerDelete
     manage volume list = osism.commands.volume:VolumeList
+    manage amphora restore = osism.commands.amphora:AmphoraRestore
+    manage amphora rotate = osism.commands.amphora:AmphoraRotate
     manage baremetal burnin = osism.commands.baremetal:BaremetalBurnIn
     manage baremetal clean = osism.commands.baremetal:BaremetalClean
     manage baremetal delete = osism.commands.baremetal:BaremetalDelete


### PR DESCRIPTION
Add new CLI commands to handle defective Octavia amphorae:
- `osism manage amphora restore`: Restores amphorae in ERROR state by triggering amphora failover
- `osism manage amphora rotate`: Rotates amphorae older than 30 days by triggering loadbalancer failover (with --force option)

Based on amphora.py from osism/openstack-resource-manager.

AI-assisted: Claude Code