### PR TITLE
Add manage volume repair command for stuck volumes

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -100,6 +100,7 @@ osism.commands:
     manage loadbalancer reset = osism.commands.loadbalancer:LoadbalancerReset
     manage loadbalancer delete = osism.commands.loadbalancer:LoadbalancerDelete
     manage volume list = osism.commands.volume:VolumeList
+    manage volume repair = osism.commands.volume:VolumeRepair
     manage amphora restore = osism.commands.amphora:AmphoraRestore
     manage amphora rotate = osism.commands.amphora:AmphoraRotate
     manage baremetal burnin = osism.commands.baremetal:BaremetalBurnIn


### PR DESCRIPTION
Add new CLI command to repair Cinder volumes stuck in problematic states:
- DETACHING (> 2 hours): Aborts the detach operation
- CREATING (> 2 hours): Deletes the volume (with confirmation)
- ERROR_DELETING: Retries deletion (with confirmation)
- DELETING (> 2 hours): Resets status and retries deletion

Supports --yes flag for automatic confirmation of destructive operations.

Based on volume.py from osism/openstack-resource-manager.

AI-assisted: Claude Code