### PR TITLE
Add manage server clean command for cleaning up problematic servers

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -94,6 +94,7 @@ osism.commands:
     manage netbox = osism.commands.netbox:Manage
     manage redfish list = osism.commands.redfish:List
     manage server list = osism.commands.server:ServerList
+    manage server clean = osism.commands.server:ServerClean
     openstack stress = osism.commands.stress:OpenStackStress
     manage server migrate = osism.commands.server:ServerMigrate
     manage loadbalancer list = osism.commands.loadbalancer:LoadbalancerList


### PR DESCRIPTION
Adds a new CLI command to clean up servers with problematic status:
- Servers stuck in BUILD status for more than 2 hours (configurable)
- Servers in ERROR status

The command interactively prompts before deleting each server, with a --yes flag for automated cleanup.

Based on server.py from osism/openstack-resource-manager.

AI-assisted: Claude Code