### PR TITLE
Revert dependency cliff to v4.12.0

### DIFF
--- a/Pipfile
+++ b/Pipfile
@@ -12,7 +12,7 @@ PyYAML = "==6.0.3"
 ansible-runner = "==2.4.2"
 ara = "==1.7.3"
 celery = {version = "==5.5.3", extras = ["redis"]}
-cliff = "==4.13.0"
+cliff = "==4.12.0"
 deepdiff = "==8.6.1"
 docker = "==7.1.0"
 dtrack-auditor = "==1.5.0"

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,7 +5,7 @@ PyMySQL==1.1.2
 PyYAML==6.0.3
 ara==1.7.3
 celery[redis]==5.5.3
-cliff==4.13.0
+cliff==4.12.0
 deepdiff==8.6.1
 docker==7.1.0
 dtrack-auditor==1.5.0


### PR DESCRIPTION
cliff 4.13.0 has a bug with Python 3.13 where stevedore.ExtensionManager is used with subscript notation without `from __future__ import annotations`, causing a TypeError at runtime.