### PR TITLE
Add BGP_GLOBALS_AF l2vpn_evpn configuration for SONIC

### DIFF
--- a/files/sonic/config_db.json
+++ b/files/sonic/config_db.json
@@ -24,6 +24,11 @@
             "ibgp_equal_cluster_length": "false",
             "max_ebgp_paths": "2",
             "max_ibgp_paths": "2"
+        },
+        "default|l2vpn_evpn": {
+            "advertise-all-vni": "true",
+            "advertise-svi-ip": "true",
+            "dad-enabled": "true"
         }
     },
     "BGP_GLOBALS_AF_NETWORK": {},


### PR DESCRIPTION
Enable EVPN support in the default SONIC configuration by adding l2vpn_evpn address family with advertise-all-vni, advertise-svi-ip, and dad-enabled settings.

AI-assisted: Claude Code