### PR TITLE
Add VXLAN tunnel configuration for VRFs with VNI in SONIC

### DIFF
--- a/files/sonic/config_db.json
+++ b/files/sonic/config_db.json
@@ -451,6 +451,9 @@
             "enabled": "true"
         }
     },
+    "VXLAN_EVPN_NVO": {},
+    "VXLAN_TUNNEL": {},
+    "VXLAN_TUNNEL_MAP": {},
     "ZTP": {
         "config": {
             "admin-mode": "true"


### PR DESCRIPTION
Create VXLAN tunnel, NVO and tunnel map entries for VRFs that have a VNI configured (extracted from VRF name when RD is set).

- Add VXLAN_VTEP_NAME constant for configurable VTEP name
- Create VXLAN_TUNNEL with src_ip from router_id
- Create VXLAN_EVPN_NVO with source_vtep reference
- Create VXLAN_TUNNEL_MAP for each VRF with VNI
- Add empty VXLAN structures to base config_db.json

AI-assisted: Claude Code