### PR TITLE
Add BGP_GLOBALS_ROUTE_ADVERTISE for L2VPN_EVPN in SONIC

### DIFF
--- a/files/sonic/config_db.json
+++ b/files/sonic/config_db.json
@@ -32,6 +32,10 @@
         }
     },
     "BGP_GLOBALS_AF_NETWORK": {},
+    "BGP_GLOBALS_ROUTE_ADVERTISE": {
+        "default|L2VPN_EVPN|IPV4_UNICAST": {},
+        "default|L2VPN_EVPN|IPV6_UNICAST": {}
+    },
     "BGP_NEIGHBOR": {},
     "BGP_NEIGHBOR_AF": {},
     "BREAKOUT_CFG": {},

--- a/osism/tasks/conductor/sonic/config_generator.py
+++ b/osism/tasks/conductor/sonic/config_generator.py
@@ -1906,6 +1906,13 @@ def _add_vrf_configuration(config, vrf_info, netbox_interfaces):
             }
             logger.info(f"Added BGP_GLOBALS_AF {l2vpn_af_key} with RT {rt_value}")
 
+            # Add BGP_GLOBALS_ROUTE_ADVERTISE for VRF
+            ipv4_adv_key = f"{vrf_name}|L2VPN_EVPN|IPV4_UNICAST"
+            ipv6_adv_key = f"{vrf_name}|L2VPN_EVPN|IPV6_UNICAST"
+            config["BGP_GLOBALS_ROUTE_ADVERTISE"][ipv4_adv_key] = {}
+            config["BGP_GLOBALS_ROUTE_ADVERTISE"][ipv6_adv_key] = {}
+            logger.info(f"Added BGP_GLOBALS_ROUTE_ADVERTISE for VRF {vrf_name}")
+
         elif "table_id" in vrf_data:
             # VRF with table_id (no RD set in NetBox)
             config["VRF"][vrf_name] = {"vrf_table_id": vrf_data["table_id"]}


### PR DESCRIPTION
Add route advertise configuration for L2VPN_EVPN address family:
- Default entries in base config_db.json for default VRF
- VRF-specific entries for VRFs with VNI

AI-assisted: Claude Code