### PR TITLE
Remove unnecessary scope/family parameters from SONIC INTERFACE confi…

### DIFF
--- a/osism/tasks/conductor/sonic/config_generator.py
+++ b/osism/tasks/conductor/sonic/config_generator.py
@@ -710,11 +710,8 @@ def _add_interface_configurations(
                 # If IPv4 address is available, configure the interface with it
                 # Add base interface entry (similar to VLAN_INTERFACE and LOOPBACK_INTERFACE patterns)
                 config["INTERFACE"][port_name] = {}
-                # Add IP address suffixed entry with scope and family parameters
-                config["INTERFACE"][f"{port_name}|{ipv4_address}"] = {
-                    "scope": "global",
-                    "family": "IPv4",
-                }
+                # Add IP address suffixed entry
+                config["INTERFACE"][f"{port_name}|{ipv4_address}"] = {}
                 logger.info(
                     f"Configured interface {port_name} with IPv4 address {ipv4_address}"
                 )


### PR DESCRIPTION
…guration

SONiC automatically infers these values from the IP address. This makes the INTERFACE configuration consistent with VLAN_INTERFACE and LOOPBACK_INTERFACE which also use empty dictionaries.

AI-assisted: Claude Code