### PR TITLE
Feat/l2 vnis

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,3 @@
+{
+  "git.ignoreLimitWarning": true
+}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,3 +1,0 @@
-{
-  "git.ignoreLimitWarning": true
-}

--- a/osism/tasks/conductor/netbox.py
+++ b/osism/tasks/conductor/netbox.py
@@ -160,14 +160,18 @@ def get_device_vlans(device):
               {
                   'vlans': {vid: {'name': name, 'description': desc}},
                   'vlan_members': {vid: {'port_name': 'tagging_mode'}},
-                  'vlan_interfaces': {vid: {'addresses': [ip_with_prefix, ...]}}
+                  'vlan_interfaces': {vid: {'addresses': [ip_with_prefix, ...]}},
+                  'l2vni_vlans': {vid: vni}  -- VLANs tagged evpn-l2vni (VNI == VID)
               }
     """
     from .sonic.cache import get_cached_device_interfaces
+    from .sonic.constants import EVPN_L2VNI_TAG
 
     vlans = {}
     vlan_members = {}
     vlan_interfaces = {}
+    # Map of NetBox VLAN object id -> vid, collected while iterating interfaces
+    vlan_obj_ids = {}
 
     try:
         # Use cached interfaces instead of separate query
@@ -204,6 +208,7 @@ def get_device_vlans(device):
                         "name": vlan.name or f"Vlan{vid}",
                         "description": vlan.description or "",
                     }
+                vlan_obj_ids[vlan.id] = vid
 
                 # Add interface to VLAN members as untagged
                 if vid not in vlan_members:
@@ -223,6 +228,7 @@ def get_device_vlans(device):
                             "name": vlan.name or f"Vlan{vid}",
                             "description": vlan.description or "",
                         }
+                    vlan_obj_ids[vlan.id] = vid
 
                     # Add interface to VLAN members as tagged
                     if vid not in vlan_members:
@@ -259,6 +265,25 @@ def get_device_vlans(device):
                     # Skip if interface name doesn't follow Vlan<number> pattern
                     pass
 
+        # Determine which VLANs are tagged evpn-l2vni by fetching full VLAN objects
+        l2vni_vlans = {}
+        if vlan_obj_ids:
+            try:
+                full_vlans = list(
+                    utils.nb.ipam.vlans.filter(id=list(vlan_obj_ids.keys()))
+                )
+                for v in full_vlans:
+                    if any(
+                        getattr(t, "slug", None) == EVPN_L2VNI_TAG
+                        for t in getattr(v, "tags", [])
+                    ):
+                        l2vni_vlans[v.vid] = v.vid  # VNI equals VID
+                        logger.debug(
+                            f"VLAN {v.vid} tagged {EVPN_L2VNI_TAG}, will add L2 VXLAN_TUNNEL_MAP entry"
+                        )
+            except Exception as e:
+                logger.warning(f"Could not fetch VLAN tags for L2 VNI check: {e}")
+
     except Exception as e:
         logger.warning(f"Could not get VLANs for device {device.name}: {e}")
 
@@ -266,6 +291,7 @@ def get_device_vlans(device):
         "vlans": vlans,
         "vlan_members": vlan_members,
         "vlan_interfaces": vlan_interfaces,
+        "l2vni_vlans": l2vni_vlans,
     }
 
 

--- a/osism/tasks/conductor/sonic/config_generator.py
+++ b/osism/tasks/conductor/sonic/config_generator.py
@@ -274,7 +274,8 @@ def generate_sonic_config(device, hwsku, device_as_mapping=None, config_version=
         config["BREAKOUT_PORTS"].update(breakout_info["breakout_ports"])
 
     # Add port channel configuration
-    _add_portchannel_configuration(config, portchannel_info)
+    evpn_system_mac = device.config_context.get("_evpn_system_mac")
+    _add_portchannel_configuration(config, portchannel_info, evpn_system_mac)
 
     # Add VRF configuration
     _add_vrf_configuration(config, vrf_info, netbox_interfaces)
@@ -2067,17 +2068,20 @@ def _add_vrf_configuration(config, vrf_info, netbox_interfaces):
             )
 
 
-def _add_portchannel_configuration(config, portchannel_info):
+def _add_portchannel_configuration(config, portchannel_info, evpn_system_mac=None):
     """Add port channel configuration from NetBox."""
     if portchannel_info["portchannels"]:
         for pc_name, pc_data in portchannel_info["portchannels"].items():
             # Add PORTCHANNEL configuration
-            config["PORTCHANNEL"][pc_name] = {
+            pc_config = {
                 "admin_status": pc_data["admin_status"],
                 "fast_rate": pc_data["fast_rate"],
                 "min_links": pc_data["min_links"],
                 "mtu": pc_data["mtu"],
             }
+            if pc_data.get("evpn_lag") and evpn_system_mac:
+                pc_config["system_mac"] = evpn_system_mac
+            config["PORTCHANNEL"][pc_name] = pc_config
 
             # Add PORTCHANNEL_INTERFACE configuration to enable IPv6 link-local
             config["PORTCHANNEL_INTERFACE"][pc_name] = {

--- a/osism/tasks/conductor/sonic/config_generator.py
+++ b/osism/tasks/conductor/sonic/config_generator.py
@@ -278,7 +278,7 @@ def generate_sonic_config(device, hwsku, device_as_mapping=None, config_version=
     _add_portchannel_configuration(config, portchannel_info, evpn_system_mac)
 
     # Add VRF configuration
-    _add_vrf_configuration(config, vrf_info, netbox_interfaces)
+    _add_vrf_configuration(config, vrf_info, vlan_info, netbox_interfaces)
 
     # Set DATABASE VERSION from config_version parameter or default
     if "VERSIONS" not in config:
@@ -1927,12 +1927,13 @@ def _get_vrf_info(device):
     return vrf_info
 
 
-def _add_vrf_configuration(config, vrf_info, netbox_interfaces):
+def _add_vrf_configuration(config, vrf_info, vlan_info, netbox_interfaces):
     """Add VRF configuration to config.
 
     Args:
         config: Configuration dictionary to update
         vrf_info: VRF information dictionary from _get_vrf_info()
+        vlan_info: VLAN information dictionary from get_device_vlans()
         netbox_interfaces: Dict mapping SONiC names to NetBox interface info
     """
     # Track VRFs with VNI for VXLAN configuration
@@ -2019,8 +2020,11 @@ def _add_vrf_configuration(config, vrf_info, netbox_interfaces):
             config["BGP_GLOBALS"][vrf_name] = copy.deepcopy(default_bgp)
             logger.info(f"Added BGP_GLOBALS for VRF {vrf_name}")
 
-    # Add VXLAN configuration if there are VRFs with VNI
-    if vrfs_with_vni:
+    # Collect L2 VNI VLANs (tagged evpn-l2vni in NetBox, VNI == VID)
+    l2vni_vlans = vlan_info.get("l2vni_vlans", {})
+
+    # Add VXLAN configuration if there are VRFs with VNI or L2 VNI VLANs
+    if vrfs_with_vni or l2vni_vlans:
         # Get source IP from BGP_GLOBALS default router_id
         src_ip = config.get("BGP_GLOBALS", {}).get("default", {}).get("router_id", "")
 
@@ -2039,7 +2043,7 @@ def _add_vrf_configuration(config, vrf_info, netbox_interfaces):
         }
         logger.info(f"Added VXLAN_EVPN_NVO nvo1 with source_vtep {VXLAN_VTEP_NAME}")
 
-        # Add VXLAN_TUNNEL_MAP for each VRF with VNI
+        # Add VXLAN_TUNNEL_MAP for each VRF with VNI (L3 / IRB)
         for vrf_entry in vrfs_with_vni:
             vni = vrf_entry["vni"]
             vlan_name = f"Vlan{vni}"
@@ -2049,6 +2053,22 @@ def _add_vrf_configuration(config, vrf_info, netbox_interfaces):
                 "vni": str(vni),
             }
             logger.info(f"Added VXLAN_TUNNEL_MAP {map_key}")
+
+        # Add VXLAN_TUNNEL_MAP for each L2 VNI VLAN (pure L2, no VRF assignment)
+        vrf_vnis = {entry["vni"] for entry in vrfs_with_vni}
+        for vid, vni in l2vni_vlans.items():
+            if vni in vrf_vnis:
+                logger.debug(
+                    f"Skipping L2 VNI {vni} for Vlan{vid}: already covered by VRF tunnel map"
+                )
+                continue
+            vlan_name = f"Vlan{vid}"
+            map_key = f"{VXLAN_VTEP_NAME}|map_{vni}_{vlan_name}"
+            config["VXLAN_TUNNEL_MAP"][map_key] = {
+                "vlan": vlan_name,
+                "vni": str(vni),
+            }
+            logger.info(f"Added L2 VXLAN_TUNNEL_MAP {map_key}")
 
     # Add VRF assignments to interfaces
     for sonic_interface, vrf_name in vrf_info["interface_vrf_mapping"].items():

--- a/osism/tasks/conductor/sonic/constants.py
+++ b/osism/tasks/conductor/sonic/constants.py
@@ -8,6 +8,9 @@ BGP_AF_L2VPN_EVPN_TAG = "bgp-af-l2vpn-evpn"
 # Tag to enable EVPN Multihoming (evpn-lag mode) on a port channel
 EVPN_LAG_TAG = "evpn-lag"
 
+# Tag to enable L2 VxLAN (EVPN L2 VNI) for a VLAN — VNI equals VLAN ID
+EVPN_L2VNI_TAG = "evpn-l2vni"
+
 # Default AS prefix for local ASN calculation
 DEFAULT_LOCAL_AS_PREFIX = 4200
 

--- a/osism/tasks/conductor/sonic/constants.py
+++ b/osism/tasks/conductor/sonic/constants.py
@@ -5,6 +5,9 @@
 # Tag to add AF L2VPN EVPN to BGP neighbor
 BGP_AF_L2VPN_EVPN_TAG = "bgp-af-l2vpn-evpn"
 
+# Tag to enable EVPN Multihoming (evpn-lag mode) on a port channel
+EVPN_LAG_TAG = "evpn-lag"
+
 # Default AS prefix for local ASN calculation
 DEFAULT_LOCAL_AS_PREFIX = 4200
 

--- a/osism/tasks/conductor/sonic/interface.py
+++ b/osism/tasks/conductor/sonic/interface.py
@@ -7,7 +7,7 @@ import os
 import re
 from loguru import logger
 
-from .constants import PORT_TYPE_TO_SPEED_MAP, HIGH_SPEED_PORTS, PORT_CONFIG_PATH
+from .constants import PORT_TYPE_TO_SPEED_MAP, HIGH_SPEED_PORTS, PORT_CONFIG_PATH, EVPN_LAG_TAG
 from .cache import get_cached_device_interfaces
 
 # Global cache for port configurations to avoid repeated file reads
@@ -1044,12 +1044,24 @@ def detect_port_channels(device):
 
                 # Initialize port channel if not exists
                 if portchannel_name not in portchannels:
+                    # Find the full LAG interface object to check tags
+                    lag_interface = next(
+                        (iface for iface in lag_interfaces if iface.id == lag_parent.id),
+                        None,
+                    )
+                    evpn_lag = False
+                    if lag_interface and hasattr(lag_interface, "tags") and lag_interface.tags:
+                        evpn_lag = any(
+                            tag.slug == EVPN_LAG_TAG for tag in lag_interface.tags
+                        )
+
                     portchannels[portchannel_name] = {
                         "members": [],
                         "admin_status": "up",
                         "fast_rate": "true",
                         "min_links": "1",
                         "mtu": "9100",
+                        "evpn_lag": evpn_lag,
                     }
 
                 # Add member to port channel


### PR DESCRIPTION
Tag the VLANs you want stretched over VxLAN with the slug evpn-l2vni in NetBox → IPAM → VLANs. No VRF assignment is needed; the VNI will equal the VLAN ID.

AI-assisted: Claude Code