### PR TITLE
Bump ara from 1.7.3 to 1.7.5

### DIFF
--- a/Pipfile
+++ b/Pipfile
@@ -10,7 +10,7 @@ Jinja2 = "==3.1.6"
 PyMySQL = "==1.1.2"
 PyYAML = "==6.0.3"
 ansible-runner = "==2.4.2"
-ara = "==1.7.3"
+ara = "==1.7.5"
 celery = {version = "==5.6.2", extras = ["redis"]}
 cliff = "==4.13.2"
 deepdiff = "==8.6.2"

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,7 +4,7 @@ GitPython==3.1.46
 Jinja2==3.1.6
 PyMySQL==1.1.2
 PyYAML==6.0.3
-ara==1.7.3
+ara==1.7.5
 celery[redis]==5.6.2
 cliff==4.13.2
 deepdiff==8.6.2


### PR DESCRIPTION
During testbed deployments, Ansible logs intermittent warnings:

  [WARNING]: Failure using method (v2_playbook_on_play_start) in
  callback plugin (...): Expecting value: line 2 column 1 (char 1)

The root cause is that Django 5.0+ maps UUIDField to MariaDB's native UUID column type, which enforces RFC 4122 validation. Ansible's get_unique_id() generates non-RFC-4122 UUIDs (the last segment is a hex serial counter), causing MariaDB to reject them with OperationalError 1292 on POST /api/v1/plays. The ARA server returns an HTML 500 error page, which the ARA HTTP client cannot parse as JSON.

ARA 1.7.4 introduced a Char32UUIDField that forces CHAR(32) storage on MariaDB, sidestepping the strict UUID validation. The fix is applied via migration 0018_alter_play_uuid_alter_task_uuid, which ara-manage migrate runs automatically on container startup.

Bumping to 1.7.5 (latest point release) to pick up any subsequent bugfixes as well.

See: https://codeberg.org/ansible-community/ara/issues/617

AI-assisted: Claude Code