### PR TITLE
Fix black 26.3.1 formatting

### DIFF
--- a/osism/__main__.py
+++ b/osism/__main__.py
@@ -4,6 +4,5 @@ import sys
 
 from osism.main import main
 
-
 if __name__ == "__main__":
     sys.exit(main(sys.argv[1:]))

--- a/osism/commands/migrate.py
+++ b/osism/commands/migrate.py
@@ -7,7 +7,6 @@ from cliff.command import Command
 from loguru import logger
 import requests
 
-
 # Service-specific queue patterns for classic queue identification
 # Each service has a list of regex patterns that match its queues
 SERVICE_QUEUE_PATTERNS = {

--- a/osism/commands/volume.py
+++ b/osism/commands/volume.py
@@ -10,7 +10,6 @@ from prompt_toolkit import prompt
 import pytz
 from tabulate import tabulate
 
-
 # Time threshold for stuck volumes (2 hours in seconds)
 STUCK_VOLUME_THRESHOLD_SECONDS = 7200
 

--- a/osism/tasks/conductor/__init__.py
+++ b/osism/tasks/conductor/__init__.py
@@ -12,7 +12,6 @@ from osism.tasks.conductor.redfish import get_resources as _get_redfish_resource
 from osism.tasks.conductor.sonic import sync_sonic as _sync_sonic
 from osism.tasks.conductor.sonic import get_devices as _get_sonic_devices
 
-
 # App configuration
 app = Celery("conductor")
 app.config_from_object(Config)

--- a/osism/tasks/conductor/ironic.py
+++ b/osism/tasks/conductor/ironic.py
@@ -26,7 +26,6 @@ from osism.tasks.conductor.utils import (
     mask_secrets,
 )
 
-
 SUPPORTED_IPA_TYPES = {
     "yrzn001": {
         "osism-ipa-as": "frr_local_as",

--- a/osism/utils/__init__.py
+++ b/osism/utils/__init__.py
@@ -11,7 +11,6 @@ import yaml
 
 from osism import settings
 
-
 _redis = None
 _nb = None
 _secondary_nb_list = None

--- a/osism/utils/ssh.py
+++ b/osism/utils/ssh.py
@@ -7,7 +7,6 @@ from loguru import logger
 
 from osism import utils
 
-
 # Default path for SSH known_hosts file
 KNOWN_HOSTS_PATH = "/share/known_hosts"
 


### PR DESCRIPTION
## Summary
- Reformat code to comply with black 26.3.1 stable style (updated in osism/zuul-jobs#180)

## Test plan
- [ ] python-black Zuul job passes