### PR TITLE
Add SW-RAID support

### DIFF
--- a/osism/commands/baremetal.py
+++ b/osism/commands/baremetal.py
@@ -363,9 +363,26 @@ class BaremetalDeploy(Command):
                             f"Node {node.name} ({node.id}) could not set boot device to cdrom: {exc}"
                         )
 
+                deploy_steps = None
+                if node["target_raid_config"]:
+                    deploy_steps = [
+                        {
+                            "interface": "raid",
+                            "step": "apply_configuration",
+                            "args": {
+                                "delete_existing": True,
+                                "raid_config": node["target_raid_config"],
+                            },
+                            "priority": 90,
+                        }
+                    ]
+
                 try:
                     conn.baremetal.set_node_provision_state(
-                        node.id, provision_state, config_drive=config_drive
+                        node.id,
+                        provision_state,
+                        config_drive=config_drive,
+                        deploy_steps=deploy_steps,
                     )
                 except Exception as exc:
                     logger.warning(
@@ -1201,6 +1218,12 @@ class BaremetalClean(Command):
             for node in clean_nodes:
                 if not node:
                     continue
+
+                # NOTE: If the node has an agent raid interface, include step to delete the raid configuration
+                if node.get("raid_interface", "no-raid") != "no-raid":
+                    clean_steps = [
+                        {"interface": "raid", "step": "delete_configuration"}
+                    ] + clean_steps
 
                 if node.provision_state in ["available"]:
                     # NOTE: Clean is available in the "manageable" provision state, so we move the node into this state

--- a/osism/tasks/conductor/ironic.py
+++ b/osism/tasks/conductor/ironic.py
@@ -354,6 +354,8 @@ def _prettify_for_display(obj):
 def _sync_ironic_device(
     request_id, device, node_attributes, ports_attributes, adopt, force
 ):
+    # NOTE: Pop target_raid_config from node_attributes since they cannot be set using node updates
+    target_raid_config = node_attributes.pop("target_raid_config", None)
     osism_utils.push_task_output(request_id, f"Processing device {device.name}\n")
     node = openstack.baremetal_node_show(device.name, ignore_missing=True)
     if not node:
@@ -366,6 +368,14 @@ def _sync_ironic_device(
         # later be adopted with their provisioned data.
         node_attributes.update(dict(automated_clean=False))
         node = openstack.baremetal_node_create(device.name, node_attributes)
+        if target_raid_config:
+            resp_ok, resp_content = openstack.baremetal_node_set_target_raid_config(
+                node["uuid"], target_raid_config
+            )
+            if not resp_ok:
+                raise Exception(
+                    f"Error updating target_raid_config of baremetal node for {device.name}: {resp_content}"
+                )
     else:
         # NOTE: Check whether the baremetal node needs to be updated
         node_updates = {}
@@ -384,6 +394,14 @@ def _sync_ironic_device(
             )
             # NOTE: Do the actual updates with all values in node_attributes. Otherwise nested dicts like e.g. driver_info will be overwritten as a whole and contain only changed values
             node = openstack.baremetal_node_update(node["uuid"], node_attributes)
+            if ("target_raid_config" in node_updates or force) and target_raid_config:
+                resp_ok, resp_content = openstack.baremetal_node_set_target_raid_config(
+                    node["uuid"], target_raid_config
+                )
+                if not resp_ok:
+                    raise Exception(
+                        f"Error updating target_raid_config of baremetal node for {device.name}: {resp_content}"
+                    )
 
     node_ports = openstack.baremetal_port_list(
         details=False, attributes=dict(node_uuid=node["uuid"])

--- a/osism/tasks/openstack.py
+++ b/osism/tasks/openstack.py
@@ -402,6 +402,18 @@ def baremetal_port_delete(self, port_or_id):
     return result
 
 
+@app.task(bind=True, name="osism.tasks.openstack.baremetal_node_set_target_raid_config")
+def baremetal_node_set_target_raid_config(self, node_id_or_name, target_raid_config):
+    conn = utils.get_openstack_connection()
+    node = conn.baremetal.get_node(node_id_or_name)
+    response = conn.baremetal.put(
+        f"/nodes/{node['uuid']}/states/raid",
+        microversion="1.12",
+        json=target_raid_config,
+    )
+    return response.ok, response.content
+
+
 def get_cloud_password(cloud):
     """
     Load and decrypt the OpenStack password for a specific cloud profile


### PR DESCRIPTION
This introduces support for deploying nodes with RAID configurations. Raid configuration is executed as a deploy step, where the `raid_config` is taken from the nodes `target_raid_config`. Since `target_raid_config` is set all raid related cleaning steps work as expected. The `osism baremetal clean` command is extended to also delete raid configurations.

Usage:
* Add `target_raid_config` to netbox device `ironic_parameters`, e.g. for software RAID1 using maximum of available disks 
   ```
   ironic_parameters: target_raid_config: logical_disks: - size_gb: MAX raid_level: "1" is_root_volume: true controller: software
   ```
* Sync ironic: `osism sync ironic $NODE`
* Deploy node: `osism baremetal deploy $NODE`