### PR TITLE
Fix sonic list JSON serialization error

### DIFF
--- a/osism/commands/sonic.py
+++ b/osism/commands/sonic.py
@@ -1072,7 +1072,6 @@ class List(Command):
 
     def take_action(self, parsed_args):
         from osism.tasks import conductor
-        from osism.tasks.conductor.netbox import get_device_oob_ip
         from osism.tasks.conductor.sonic.constants import SUPPORTED_HWSKUS
 
         device_name = parsed_args.device
@@ -1080,11 +1079,6 @@ class List(Command):
         try:
             task = conductor.get_sonic_devices.delay(device_name=device_name)
             devices = task.wait()
-            if isinstance(devices, type(None)):
-                logger.error(
-                    "Error listing SONiC devices. Check the conductor log for details"
-                )
-                return 1
 
             logger.info(f"Found {len(devices)} devices matching criteria")
 
@@ -1101,90 +1095,28 @@ class List(Command):
             ]
 
             for device in devices:
-                # Get device name
-                device_name = device.name
+                name = device.get("name")
+                hwsku = device.get("hwsku")
 
-                # Get device role
-                device_role = "N/A"
-                try:
-                    if device.role and hasattr(device.role, "name"):
-                        device_role = device.role.name
-                except Exception as e:
-                    logger.debug(f"Could not get device role for {device_name}: {e}")
-
-                # Get OOB IP address
-                oob_ip = "N/A"
-                try:
-                    oob_result = get_device_oob_ip(device)
-                    if oob_result:
-                        oob_ip = oob_result[0]  # Get just the IP address
-                except Exception as e:
-                    logger.debug(f"Could not get OOB IP for {device_name}: {e}")
-
-                # Get primary IP address
-                primary_ip = "N/A"
-                try:
-                    if device.primary_ip4:
-                        # Extract IP address from CIDR notation
-                        primary_ip = str(device.primary_ip4).split("/")[0]
-                    elif device.primary_ip6:
-                        # Extract IP address from CIDR notation
-                        primary_ip = str(device.primary_ip6).split("/")[0]
-                except Exception as e:
-                    logger.debug(f"Could not get primary IP for {device_name}: {e}")
-
-                # Get HWSKU and Version from sonic_parameters custom field
-                hwsku = "N/A"
-                version = "N/A"
-                try:
-                    if (
-                        hasattr(device, "custom_fields")
-                        and "sonic_parameters" in device.custom_fields
-                        and device.custom_fields["sonic_parameters"]
-                        and isinstance(device.custom_fields["sonic_parameters"], dict)
-                    ):
-                        sonic_params = device.custom_fields["sonic_parameters"]
-                        if "hwsku" in sonic_params and sonic_params["hwsku"]:
-                            hwsku = sonic_params["hwsku"]
-                        if "version" in sonic_params and sonic_params["version"]:
-                            version = sonic_params["version"]
-                except Exception as e:
-                    logger.debug(
-                        f"Could not extract sonic_parameters for {device_name}: {e}"
+                if hwsku is None:
+                    provision_state = "No HWSKU"
+                elif hwsku not in SUPPORTED_HWSKUS:
+                    provision_state = "Unsupported HWSKU"
+                    logger.warning(
+                        f"Device {name} has unsupported HWSKU: {hwsku}. "
+                        f"Supported HWSKUs: {', '.join(SUPPORTED_HWSKUS)}"
                     )
-
-                # Determine provision state with HWSKU validation
-                provision_state = "N/A"
-                try:
-                    if hwsku == "N/A":
-                        provision_state = "No HWSKU"
-                    elif hwsku not in SUPPORTED_HWSKUS:
-                        provision_state = "Unsupported HWSKU"
-                        logger.warning(
-                            f"Device {device_name} has unsupported HWSKU: {hwsku}. "
-                            f"Supported HWSKUs: {', '.join(SUPPORTED_HWSKUS)}"
-                        )
-                    else:
-                        # For valid HWSKUs, get provision state from Netbox custom field
-                        if (
-                            hasattr(device, "custom_fields")
-                            and "provision_state" in device.custom_fields
-                            and device.custom_fields["provision_state"]
-                        ):
-                            provision_state = device.custom_fields["provision_state"]
-                except Exception as e:
-                    logger.debug(
-                        f"Could not determine provision state for {device_name}: {e}"
-                    )
+                else:
+                    provision_state = device.get("provision_state") or "N/A"
 
                 table_data.append(
                     [
-                        device_name,
-                        device_role,
-                        oob_ip,
-                        primary_ip,
-                        hwsku,
-                        version,
+                        name,
+                        device.get("role_name") or "N/A",
+                        device.get("oob_ip") or "N/A",
+                        device.get("primary_ip") or "N/A",
+                        hwsku or "N/A",
+                        device.get("version") or "N/A",
                         provision_state,
                     ]
                 )

--- a/osism/tasks/conductor/sonic/device.py
+++ b/osism/tasks/conductor/sonic/device.py
@@ -5,7 +5,10 @@
 from loguru import logger
 
 from osism import utils
-from osism.tasks.conductor.netbox import get_nb_device_query_list_sonic
+from osism.tasks.conductor.netbox import (
+    get_device_oob_ip,
+    get_nb_device_query_list_sonic,
+)
 from osism.tasks.conductor.sonic.constants import DEFAULT_SONIC_ROLES
 
 
@@ -84,49 +87,104 @@ def get_device_mac_address(device):
     return mac_address
 
 
-def get_devices(self, device_name=None):
+def _serialize_device(device):
+    """Convert a pynetbox device to a JSON-serializable dict for the list task.
+
+    The Celery result backend uses JSON, so pynetbox Record objects cannot
+    cross the task boundary directly. Each field is accessed defensively so
+    a single malformed NetBox record cannot fail serialization for the whole
+    list.
+    """
+    name = getattr(device, "name", None)
+
+    role_name = None
     try:
-        devices = []
-
-        if device_name:
-            # When specific device is requested, fetch it directly
-            try:
-                device = utils.nb.dcim.devices.get(name=device_name)
-                if device:
-                    # Check if device role matches allowed roles
-                    if device.role and device.role.slug in DEFAULT_SONIC_ROLES:
-                        devices.append(device)
-                        logger.debug(
-                            f"Found device: {device.name} with role: {device.role.slug}"
-                        )
-                    else:
-                        logger.warning(
-                            f"Device {device_name} has role '{device.role.slug if device.role else 'None'}' "
-                            f"which is not in allowed SONiC roles: {', '.join(DEFAULT_SONIC_ROLES)}"
-                        )
-                        return 1
-                else:
-                    logger.error(f"Device {device_name} not found in NetBox")
-                    return 1
-            except Exception as e:
-                logger.error(f"Error fetching device {device_name}: {e}")
-                return 1
-        else:
-            # Get device query list from NETBOX_FILTER_CONDUCTOR_SONIC
-            nb_device_query_list = get_nb_device_query_list_sonic()
-
-            for nb_device_query in nb_device_query_list:
-                # Query devices with the NETBOX_FILTER_CONDUCTOR_SONIC criteria
-                for device in utils.nb.dcim.devices.filter(**nb_device_query):
-                    # Check if device role matches allowed roles
-                    if device.role and device.role.slug in DEFAULT_SONIC_ROLES:
-                        devices.append(device)
-                        logger.debug(
-                            f"Found device: {device.name} with role: {device.role.slug}"
-                        )
-
+        if device.role and hasattr(device.role, "name"):
+            role_name = device.role.name
     except Exception as e:
-        logger.error(f"Error retrieving SONiC devices from NetBox: {e}")
-        return None
+        logger.debug(f"Could not get role for device {name}: {e}")
 
-    return devices
+    oob_ip = None
+    try:
+        oob_result = get_device_oob_ip(device)
+        if oob_result:
+            oob_ip = oob_result[0]
+    except Exception as e:
+        logger.debug(f"Could not get OOB IP for device {name}: {e}")
+
+    primary_ip = None
+    try:
+        if device.primary_ip4:
+            primary_ip = str(device.primary_ip4).split("/")[0]
+        elif device.primary_ip6:
+            primary_ip = str(device.primary_ip6).split("/")[0]
+    except Exception as e:
+        logger.debug(f"Could not get primary IP for device {name}: {e}")
+
+    hwsku = None
+    version = None
+    provision_state = None
+    try:
+        custom_fields = getattr(device, "custom_fields", {}) or {}
+        sonic_params = custom_fields.get("sonic_parameters")
+        if isinstance(sonic_params, dict):
+            hwsku = sonic_params.get("hwsku") or None
+            version = sonic_params.get("version") or None
+        provision_state = custom_fields.get("provision_state") or None
+    except Exception as e:
+        logger.debug(f"Could not read custom fields for device {name}: {e}")
+
+    return {
+        "name": name,
+        "role_name": role_name,
+        "oob_ip": oob_ip,
+        "primary_ip": primary_ip,
+        "hwsku": hwsku,
+        "version": version,
+        "provision_state": provision_state,
+    }
+
+
+def get_devices(device_name=None):
+    """Return serialized SONiC devices matching the query.
+
+    On success always returns a list (possibly empty when no devices match).
+    Raises RuntimeError for error conditions (device not found, wrong role,
+    NetBox failure) so callers can distinguish errors from empty results.
+    """
+    devices = []
+
+    if device_name:
+        try:
+            device = utils.nb.dcim.devices.get(name=device_name)
+        except Exception as e:
+            raise RuntimeError(f"Error fetching device {device_name}: {e}") from e
+
+        if not device:
+            raise RuntimeError(f"Device {device_name} not found in NetBox")
+
+        role_slug = device.role.slug if device.role else None
+        if role_slug not in DEFAULT_SONIC_ROLES:
+            raise RuntimeError(
+                f"Device {device_name} has role '{role_slug}' which is not "
+                f"in allowed SONiC roles: {', '.join(DEFAULT_SONIC_ROLES)}"
+            )
+
+        devices.append(device)
+        logger.debug(f"Found device: {device.name} with role: {role_slug}")
+    else:
+        try:
+            nb_device_query_list = get_nb_device_query_list_sonic()
+            for nb_device_query in nb_device_query_list:
+                for device in utils.nb.dcim.devices.filter(**nb_device_query):
+                    if device.role and device.role.slug in DEFAULT_SONIC_ROLES:
+                        devices.append(device)
+                        logger.debug(
+                            f"Found device: {device.name} with role: {device.role.slug}"
+                        )
+        except Exception as e:
+            raise RuntimeError(
+                f"Error retrieving SONiC devices from NetBox: {e}"
+            ) from e
+
+    return [_serialize_device(device) for device in devices]


### PR DESCRIPTION
The get_sonic_devices Celery task returned raw pynetbox Devices objects, which Celery cannot serialize with the default JSON result backend and raised "Object of type Devices is not JSON serializable". Pre-serialize devices into plain dicts in the conductor (including the OOB IP lookup) and consume dicts in the CLI.

Also drop the stray self parameter on get_devices that was swallowing the positional device_name argument, so osism sonic list <name> actually filters by name now.

AI-assisted: Claude Code