### PR TITLE
manage image octavia: log checksum URL HTTP status code

### DIFF
--- a/osism/commands/manage.py
+++ b/osism/commands/manage.py
@@ -419,6 +419,7 @@ class ImageOctavia(Command):
 
         logger.info(f"checksum_url: {url}.CHECKSUM")
         response_checksum = requests.get(f"{url}.CHECKSUM")
+        logger.info(f"checksum_url_status: {response_checksum.status_code}")
         splitted_checksum = response_checksum.text.strip().split(" ")
         logger.info(f"checksum: {splitted_checksum[0]}")
 


### PR DESCRIPTION
## Summary

- Adds a `checksum_url_status: <N>` log line immediately after fetching the octavia amphora `.CHECKSUM` file
- When the object storage returns a non-200 response the log previously showed only `checksum: <?xml...`, making it look like a bad checksum rather than an HTTP error
- No behaviour change; purely diagnostic

## Background

CI analysis of `testbed-deploy-*-with-tempest-ubuntu-24.04` found ~35 failures where `nbg1.your-objectstorage.com` transiently returns an XML error page for the `.CHECKSUM` URL. The status code (403, 404, 503, …) is needed to distinguish permission errors from transient outages, which informs the correct upstream fix.

## Test plan

- [ ] Verify `checksum_url_status: 200` appears in a passing `osism manage image octavia` run
- [ ] Confirm existing behaviour is unchanged (no new errors, no retry logic added)

🤖 Generated with [Claude Code](https://claude.com/claude-code)