### PR TITLE
sonic: Fix STATIC_ROUTE clobber in OOB management path

### DIFF
--- a/osism/tasks/conductor/sonic/config_generator.py
+++ b/osism/tasks/conductor/sonic/config_generator.py
@@ -263,7 +263,6 @@ def generate_sonic_config(device, hwsku, device_as_mapping=None, config_version=
         config["MGMT_INTERFACE"]["eth0"] = {"admin_status": "up"}
         config["MGMT_INTERFACE"][f"eth0|{oob_ip}/{prefix_len}"] = {}
         metalbox_ip = _get_metalbox_ip_for_device(device)
-        config["STATIC_ROUTE"] = {}
         config["STATIC_ROUTE"]["mgmt|0.0.0.0/0"] = {"nexthop": metalbox_ip}
     else:
         oob_ip = None


### PR DESCRIPTION
## Summary

- `generate_sonic_config()` reset `STATIC_ROUTE` to `{}` before writing the management default route, silently discarding any routes loaded from `/etc/sonic/config_db.json` on every sync.
- The reset was introduced in f4f2290 when base config loading did not exist yet — it was harmless at the time and went unnoticed when base config loading was added later.
- Fix: write the management route directly into the existing dict without resetting it first.

## Test plan

- [ ] Verify existing unit tests pass (`pytest tests/unit/tasks/conductor/sonic/`)
- [ ] Add a test that pre-populates `STATIC_ROUTE` in the base config and asserts entries survive the OOB management path (tracked as follow-up in PR #2237 review)

🤖 Generated with [Claude Code](https://claude.com/claude-code)