### PR TITLE
Fix NETBOX_FILTER_CONDUCTOR_* defaults to use status instead of state

### DIFF
--- a/osism/settings.py
+++ b/osism/settings.py
@@ -42,14 +42,21 @@ OPERATOR_USER = os.getenv("OSISM_OPERATOR_USER", "dragon")
 
 FRR_DUMMY_INTERFACE = os.getenv("OSISM_FRR_DUMMY_INTERFACE", "loopback0")
 
+DEFAULT_NETBOX_FILTER_CONDUCTOR_IRONIC = (
+    "[{'status': 'active', 'tag': ['managed-by-ironic']}]"
+)
+DEFAULT_NETBOX_FILTER_CONDUCTOR_SONIC = (
+    "[{'status': 'active', 'tag': ['managed-by-metalbox']}]"
+)
+
 NETBOX_FILTER_CONDUCTOR_IRONIC = os.getenv(
     "NETBOX_FILTER_CONDUCTOR_IRONIC",
-    "[{'state': 'active', 'tag': ['managed-by-ironic']}]",
+    DEFAULT_NETBOX_FILTER_CONDUCTOR_IRONIC,
 )
 
 NETBOX_FILTER_CONDUCTOR_SONIC = os.getenv(
     "NETBOX_FILTER_CONDUCTOR_SONIC",
-    "[{'state': 'active', 'tag': ['managed-by-metalbox']}]",
+    DEFAULT_NETBOX_FILTER_CONDUCTOR_SONIC,
 )
 
 # SONiC export configuration

--- a/tests/unit/test_settings.py
+++ b/tests/unit/test_settings.py
@@ -498,12 +498,12 @@ def test_netbox_filter_conductor_ironic_default(reload_settings, monkeypatch):
 
     assert (
         settings_module.NETBOX_FILTER_CONDUCTOR_IRONIC
-        == "[{'state': 'active', 'tag': ['managed-by-ironic']}]"
+        == settings_module.DEFAULT_NETBOX_FILTER_CONDUCTOR_IRONIC
     )
 
 
 def test_netbox_filter_conductor_ironic_override(reload_settings, monkeypatch):
-    override = "[{'state': 'active', 'tag': ['custom']}]"
+    override = "[{'status': 'active', 'tag': ['custom']}]"
     monkeypatch.setenv("NETBOX_FILTER_CONDUCTOR_IRONIC", override)
     reload_settings()
 
@@ -516,12 +516,12 @@ def test_netbox_filter_conductor_sonic_default(reload_settings, monkeypatch):
 
     assert (
         settings_module.NETBOX_FILTER_CONDUCTOR_SONIC
-        == "[{'state': 'active', 'tag': ['managed-by-metalbox']}]"
+        == settings_module.DEFAULT_NETBOX_FILTER_CONDUCTOR_SONIC
     )
 
 
 def test_netbox_filter_conductor_sonic_override(reload_settings, monkeypatch):
-    override = "[{'state': 'active', 'tag': ['custom-metalbox']}]"
+    override = "[{'status': 'active', 'tag': ['custom-metalbox']}]"
     monkeypatch.setenv("NETBOX_FILTER_CONDUCTOR_SONIC", override)
     reload_settings()
 


### PR DESCRIPTION
Commit 9bcb9af renamed the supported NetBox filter key from `state` to `status` in get_nb_device_query_list_{ironic,sonic}, but missed the default values in osism/settings.py. With the env var unset, the default fell through validation as "Unknown value in NETBOX_FILTER_CONDUCTOR_*".

AI-assisted: Claude Code