### PR TITLE
Decouple FACTS_MAX_AGE default from GATHER_FACTS_SCHEDULE

### DIFF
--- a/osism/settings.py
+++ b/osism/settings.py
@@ -30,8 +30,13 @@ NETBOX_TOKEN = str(
 IGNORE_SSL_ERRORS = os.getenv("IGNORE_SSL_ERRORS", "True") == "True"
 
 # 43200 seconds = 12 hours
-GATHER_FACTS_SCHEDULE = float(os.getenv("GATHER_FACTS_SCHEDULE", "43200.0"))
-FACTS_MAX_AGE = int(os.getenv("FACTS_MAX_AGE", str(int(GATHER_FACTS_SCHEDULE))))
+_DEFAULT_FACTS_INTERVAL_SECONDS = 43200
+GATHER_FACTS_SCHEDULE = float(
+    os.getenv("GATHER_FACTS_SCHEDULE", str(_DEFAULT_FACTS_INTERVAL_SECONDS))
+)
+# Intentionally independent of GATHER_FACTS_SCHEDULE: setting the schedule to 0
+# to disable periodic gathering must not force every fact to look stale.
+FACTS_MAX_AGE = int(os.getenv("FACTS_MAX_AGE", str(_DEFAULT_FACTS_INTERVAL_SECONDS)))
 INVENTORY_RECONCILER_SCHEDULE = float(
     os.getenv("INVENTORY_RECONCILER_SCHEDULE", "600.0")
 )

--- a/tests/unit/test_settings.py
+++ b/tests/unit/test_settings.py
@@ -395,9 +395,7 @@ def test_gather_facts_schedule_override_int_string_becomes_float(
     assert isinstance(settings_module.GATHER_FACTS_SCHEDULE, float)
 
 
-def test_facts_max_age_default_matches_int_of_gather_facts_schedule(
-    reload_settings, monkeypatch
-):
+def test_facts_max_age_default(reload_settings, monkeypatch):
     monkeypatch.delenv("GATHER_FACTS_SCHEDULE", raising=False)
     monkeypatch.delenv("FACTS_MAX_AGE", raising=False)
     reload_settings()
@@ -406,15 +404,25 @@ def test_facts_max_age_default_matches_int_of_gather_facts_schedule(
     assert isinstance(settings_module.FACTS_MAX_AGE, int)
 
 
-def test_facts_max_age_tracks_gather_facts_schedule_when_unset(
+def test_facts_max_age_independent_of_gather_facts_schedule(
+    reload_settings, monkeypatch
+):
+    monkeypatch.setenv("GATHER_FACTS_SCHEDULE", "0")
+    monkeypatch.delenv("FACTS_MAX_AGE", raising=False)
+    reload_settings()
+
+    # FACTS_MAX_AGE keeps its own default even if GATHER_FACTS_SCHEDULE is 0.
+    assert settings_module.FACTS_MAX_AGE == 43200
+
+
+def test_facts_max_age_independent_of_custom_gather_facts_schedule(
     reload_settings, monkeypatch
 ):
     monkeypatch.setenv("GATHER_FACTS_SCHEDULE", "120.5")
     monkeypatch.delenv("FACTS_MAX_AGE", raising=False)
     reload_settings()
 
-    # int(120.5) == 120 — the default for FACTS_MAX_AGE truncates the float.
-    assert settings_module.FACTS_MAX_AGE == 120
+    assert settings_module.FACTS_MAX_AGE == 43200
 
 
 def test_facts_max_age_explicit_override_wins(reload_settings, monkeypatch):


### PR DESCRIPTION
Previously FACTS_MAX_AGE fell back to GATHER_FACTS_SCHEDULE, so setting GATHER_FACTS_SCHEDULE=0 to disable the periodic schedule also forced the stale-facts threshold to 0, making every fact appear stale. FACTS_MAX_AGE now defaults to a fixed 43200 (12h) independent of the schedule.

AI-assisted: Claude Code