### PR TITLE
Pin pipenv in CI via ensure-pipenv and regenerate lock

### DIFF
--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -1786,10 +1786,10 @@
         },
         "pytz": {
             "hashes": [
-                "sha256:3378dde6a0c3d26719182142c56e60c7f9af7e968076f31aae569d72a0358ee1",
-                "sha256:f2fd16142fda348286a75e1a524be810bb05d444e5a081f37f7affc635035f7a"
+                "sha256:04156e608bee23d3792fd45c94ae47fae1036688e75032eea2e3bf0323d1f126",
+                "sha256:0e60b47b29f21574376f218fe21abc009894a2321ea16c6754f3cad6eb7cdd6a"
             ],
-            "version": "==2026.1.post1"
+            "version": "==2026.2"
         },
         "pyyaml": {
             "hashes": [
@@ -2203,11 +2203,11 @@
         },
         "wcwidth": {
             "hashes": [
-                "sha256:1a3a1e510b553315f8e146c54764f4fb6264ffad731b3d78088cdb1478ffbdad",
-                "sha256:cdc4e4262d6ef9a1a57e018384cbeb1208d8abbc64176027e2c2455c81313159"
+                "sha256:5d69154c429a82910e241c738cd0e2976fac8a2dd47a1a805f4afed1c0f136f2",
+                "sha256:90e3a7ea092341c44b99562e75d09e4d5160fe7a3974c6fb842a101a95e7eed0"
             ],
             "markers": "python_version >= '3.8'",
-            "version": "==0.6.0"
+            "version": "==0.7.0"
         },
         "websocket-client": {
             "hashes": [

--- a/playbooks/pre.yml
+++ b/playbooks/pre.yml
@@ -12,7 +12,6 @@
         name:
           - curl
           - jq
-          - pipenv
           - python3-docker
           - python3-requests
 
@@ -25,3 +24,4 @@
   roles:
     - ensure-docker
     - ensure-pip
+    - ensure-pipenv

--- a/playbooks/test-setup.yml
+++ b/playbooks/test-setup.yml
@@ -2,6 +2,9 @@
 - name: Test python setup
   hosts: all
 
+  vars:
+    python_venv_dir: /tmp/venv
+
   tasks:
     - name: Run test script
       ansible.builtin.shell:
@@ -12,7 +15,5 @@
           set -o pipefail
           set -x
 
-          export PATH=$PATH:$HOME/.local/bin
-
-          pipenv install
-          pipenv run pip install --no-deps .
+          {{ python_venv_dir }}/bin/pipenv install
+          {{ python_venv_dir }}/bin/pipenv run pip install --no-deps .

--- a/playbooks/test-unit.yml
+++ b/playbooks/test-unit.yml
@@ -2,6 +2,9 @@
 - name: Run unit tests
   hosts: all
 
+  vars:
+    python_venv_dir: /tmp/venv
+
   tasks:
     - name: Install dependencies
       ansible.builtin.shell:
@@ -12,10 +15,8 @@
           set -o pipefail
           set -x
 
-          export PATH=$PATH:$HOME/.local/bin
-
-          pipenv install --dev
-          pipenv run pip install .
+          {{ python_venv_dir }}/bin/pipenv install --dev --deploy
+          {{ python_venv_dir }}/bin/pipenv run pip install .
 
     - name: Run pytest
       ansible.builtin.shell:
@@ -26,6 +27,4 @@
           set -o pipefail
           set -x
 
-          export PATH=$PATH:$HOME/.local/bin
-
-          pipenv run pytest
+          {{ python_venv_dir }}/bin/pipenv run pytest


### PR DESCRIPTION
## Summary

- Switches `pre.yml` to the `ensure-pipenv` role from osism/zuul-jobs
  (after `ensure-pip`), following the same pattern as osism/netbox-manager#235
- Removes `pipenv` from the apt package list (Debian Bookworm ships
  2022.12.19, which has incompatible hash semantics with current pipenv)
- Updates `test-setup.yml` and `test-unit.yml` to invoke pipenv as
  `{{ python_venv_dir }}/bin/pipenv` (`/tmp/venv/bin/pipenv`)
- Adds `--deploy` to `pipenv install --dev` in `test-unit.yml` for
  strict lock-file verification on every run
- Regenerates `Pipfile.lock` with pipenv 2026.5.2 to resolve the hash
  mismatch introduced by PEP 503 name normalization in pipenv 2026.4.0;
  incidental lock bumps: pytz 2026.1.post1 → 2026.2, wcwidth 0.6.0 → 0.7.0

## Dependency

Requires https://github.com/osism/zuul-jobs/pull/182 (`ensure-pipenv` role) to be merged first.

## Test plan

- [ ] Verify Zuul unit-test and test-setup jobs pass with pinned pipenv
- [ ] Verify `pipenv install --dev --deploy` no longer reports stale lock locally

🤖 AI-assisted: Claude Code