### PR TITLE
sonic/config_generator: align syslog and mgmt_port values with schema

### DIFF
--- a/files/sonic/config_db.json
+++ b/files/sonic/config_db.json
@@ -335,7 +335,7 @@
     "MGMT_PORT": {
         "eth0": {
             "admin_status": "up",
-            "autoneg": "true",
+            "autoneg": "on",
             "description": "Management0",
             "mtu": "1500",
             "speed": "1000"

--- a/osism/tasks/conductor/sonic/config_generator.py
+++ b/osism/tasks/conductor/sonic/config_generator.py
@@ -2074,6 +2074,16 @@ def _add_portchannel_configuration(config, portchannel_info):
             )
 
 
+# Map common syslog severity aliases to the SONiC-accepted set.
+# SONiC schema accepts: none, debug, info, notice, warn, error, crit.
+_SYSLOG_SEVERITY_ALIASES = {
+    "informational": "info",
+    "warning": "warn",
+    "err": "error",
+    "critical": "crit",
+}
+
+
 def _add_log_server_configuration(config, device):
     """Add SYSLOG_SERVER configuration to device config.
 
@@ -2085,11 +2095,14 @@ def _add_log_server_configuration(config, device):
         proto = device.config_context.get("_segment_log_server_proto", "udp")
         severity = device.config_context.get("_segment_log_server_severity", "info")
         vrf = device.config_context.get("_segment_log_server_vrf", "mgmt")
+        proto = proto.strip().lower()
+        severity = severity.strip().lower()
+        severity = _SYSLOG_SEVERITY_ALIASES.get(severity, severity)
         config["SYSLOG_SERVER"] = {}
         for host in hosts:
             config["SYSLOG_SERVER"][host] = {}
             config["SYSLOG_SERVER"][host]["message-type"] = "log"
-            config["SYSLOG_SERVER"][host]["protocol"] = proto.upper()
+            config["SYSLOG_SERVER"][host]["protocol"] = proto
             config["SYSLOG_SERVER"][host]["remote-port"] = "514"
             config["SYSLOG_SERVER"][host]["severity"] = severity
             config["SYSLOG_SERVER"][host]["vrf_name"] = vrf

--- a/tests/unit/tasks/conductor/sonic/test_config_generator_log.py
+++ b/tests/unit/tasks/conductor/sonic/test_config_generator_log.py
@@ -24,23 +24,51 @@ def test_add_log_server_configuration_defaults():
     for host in ("10.1.1.1", "10.1.1.2"):
         assert config["SYSLOG_SERVER"][host] == {
             "message-type": "log",
-            "protocol": "UDP",
+            "protocol": "udp",
             "remote-port": "514",
             "severity": "info",
             "vrf_name": "mgmt",
         }
 
 
-def test_add_log_server_configuration_protocol_uppercased():
+@pytest.mark.parametrize(
+    "proto_in, proto_out",
+    [("tcp", "tcp"), ("TCP", "tcp"), ("Udp", "udp")],
+)
+def test_add_log_server_configuration_protocol_lowercased(proto_in, proto_out):
     config = {}
     device = _device_with_ctx(
         _segment_log_server_hosts=["10.1.1.1"],
-        _segment_log_server_proto="tcp",
+        _segment_log_server_proto=proto_in,
     )
 
     _add_log_server_configuration(config, device)
 
-    assert config["SYSLOG_SERVER"]["10.1.1.1"]["protocol"] == "TCP"
+    assert config["SYSLOG_SERVER"]["10.1.1.1"]["protocol"] == proto_out
+
+
+@pytest.mark.parametrize(
+    "severity_in, severity_out",
+    [
+        ("warning", "warn"),
+        ("WARNING", "warn"),
+        ("informational", "info"),
+        ("err", "error"),
+        ("critical", "crit"),
+        ("warn", "warn"),
+        ("info", "info"),
+    ],
+)
+def test_add_log_server_configuration_severity_aliases(severity_in, severity_out):
+    config = {}
+    device = _device_with_ctx(
+        _segment_log_server_hosts=["10.1.1.1"],
+        _segment_log_server_severity=severity_in,
+    )
+
+    _add_log_server_configuration(config, device)
+
+    assert config["SYSLOG_SERVER"]["10.1.1.1"]["severity"] == severity_out
 
 
 def test_add_log_server_configuration_custom_severity_and_vrf():


### PR DESCRIPTION
Three values produced by config generation did not match the SONiC schema enforced by the new Pydantic validator:

- MGMT_PORT.eth0.autoneg in the base config_db.json was "true"; the schema requires "on"|"off".
- _add_log_server_configuration uppercased the syslog protocol ("UDP"), but the schema requires lowercase "tcp"|"udp".
- _add_log_server_configuration passed the severity through unchanged, so common syslog aliases like "warning" or "critical" failed against the SONiC-accepted set (none, debug, info, notice, warn, error, crit).

Lowercase the protocol, lowercase and alias-map the severity (warning -> warn, informational -> info, err -> error, critical -> crit), fix the autoneg value in the base config, and update the existing tests to match.

AI-assisted: Claude Code