### PR TITLE
build: add cosign 409 diagnostic message

### DIFF
--- a/playbooks/build.yml
+++ b/playbooks/build.yml
@@ -128,7 +128,19 @@
 
           curl -O -L "https://github.com/sigstore/cosign/releases/latest/download/cosign-linux-amd64"
           chmod +x cosign-linux-amd64
-          ./cosign-linux-amd64 sign --yes --key env://COSIGN_PRIVATE_KEY "$repository:$version"
+          set +e
+          ./cosign-linux-amd64 sign --yes --key env://COSIGN_PRIVATE_KEY "$repository:$version" 2>&1 | tee cosign-output.txt
+          cosign_rc=${PIPESTATUS[0]}
+          set -e
+          if [[ $cosign_rc -ne 0 ]]; then
+            if grep -q "createLogEntryConflict" cosign-output.txt 2>/dev/null; then
+              echo "NOTE: https://github.com/sigstore/cosign/issues/4711 --"
+              echo "  Rekor accepted the signing bundle but the OCI .sig push then failed,"
+              echo "  causing this retry to see a duplicate Rekor entry. The next build"
+              echo "  will produce a fresh image digest and sign successfully."
+            fi
+            exit $cosign_rc
+          fi
 
       when: push_image | default(false) | bool
       changed_when: true


### PR DESCRIPTION
## Summary

When `cosign sign` fails with HTTP 409 `createLogEntryConflict`, the raw Rekor error gives no indication of the cause or when it will self-resolve. This adds a diagnostic NOTE after the error that points to the upstream bug and explains that the next build will succeed.

- Build still fails with the original non-zero exit code — no behaviour change for any other error
- Upstream bug: https://github.com/sigstore/cosign/issues/4711 (cosign v3.0.6, unfixed)
- Root cause: Rekor accepts the signing bundle, the OCI `.sig` push then fails transiently, and any retry of the full `cosign sign` command hits a duplicate Rekor entry permanently

## Test plan

- [ ] Verify CI passes on this branch
- [ ] Confirm the wrapper does not affect the success path (no `createLogEntryConflict` → no change in output or exit code)
- [ ] When the upstream bug is fixed in cosign, the wrapper can be removed

🤖 Generated with [Claude Code](https://claude.com/claude-code)