### PR TITLE
vault: avoid shell=True in subprocess calls

### DIFF
--- a/osism/commands/vault.py
+++ b/osism/commands/vault.py
@@ -84,9 +84,7 @@ class View(Command):
             return 1
 
         if content.startswith(b"$ANSIBLE_VAULT"):
-            return subprocess.call(
-                f"/usr/local/bin/ansible-vault view {path}", shell=True
-            )
+            return subprocess.call(["/usr/local/bin/ansible-vault", "view", path])
 
         logger.warning(f"File is not vault-encrypted, showing plain content: {path}")
         sys.stdout.write(content.decode("utf-8", errors="replace"))
@@ -104,7 +102,7 @@ class Decrypt(Command):
         path = parsed_args.path
         if not os.path.isabs(path):
             path = os.path.join("/opt/configuration", path)
-        subprocess.call(f"/usr/local/bin/ansible-vault decrypt {path}", shell=True)
+        subprocess.call(["/usr/local/bin/ansible-vault", "decrypt", path])
 
 
 # Well-known paths where secrets.yml files are typically found

--- a/osism/commands/vault.py
+++ b/osism/commands/vault.py
@@ -102,7 +102,7 @@ class Decrypt(Command):
         path = parsed_args.path
         if not os.path.isabs(path):
             path = os.path.join("/opt/configuration", path)
-        subprocess.call(["/usr/local/bin/ansible-vault", "decrypt", path])
+        return subprocess.call(["/usr/local/bin/ansible-vault", "decrypt", path])
 
 
 # Well-known paths where secrets.yml files are typically found

--- a/osism/commands/vault.py
+++ b/osism/commands/vault.py
@@ -67,6 +67,9 @@ class View(Command):
 
     def take_action(self, parsed_args):
         path = parsed_args.path
+        if path is None:
+            logger.error("No path specified")
+            return 1
         if not os.path.isabs(path):
             path = os.path.join("/opt/configuration", path)
 
@@ -100,6 +103,9 @@ class Decrypt(Command):
 
     def take_action(self, parsed_args):
         path = parsed_args.path
+        if path is None:
+            logger.error("No path specified")
+            return 1
         if not os.path.isabs(path):
             path = os.path.join("/opt/configuration", path)
         return subprocess.call(["/usr/local/bin/ansible-vault", "decrypt", path])

--- a/tests/unit/commands/test_vault.py
+++ b/tests/unit/commands/test_vault.py
@@ -26,7 +26,7 @@ def test_view_invokes_ansible_vault_for_encrypted_file(tmp_path):
         _make_view().take_action(parsed_args)
 
     mock_call.assert_called_once_with(
-        f"/usr/local/bin/ansible-vault view {path}", shell=True
+        ["/usr/local/bin/ansible-vault", "view", str(path)]
     )
 
 
@@ -59,7 +59,7 @@ def test_view_resolves_relative_path_against_opt_configuration():
     expected = "/opt/configuration/environments/openstack/secure.yml"
     open_mock.assert_called_once_with(expected, "rb")
     mock_call.assert_called_once_with(
-        f"/usr/local/bin/ansible-vault view {expected}", shell=True
+        ["/usr/local/bin/ansible-vault", "view", expected]
     )
 
 
@@ -108,5 +108,23 @@ def test_view_invokes_ansible_vault_for_vault_variants(tmp_path, header):
         _make_view().take_action(parsed_args)
 
     mock_call.assert_called_once_with(
-        f"/usr/local/bin/ansible-vault view {path}", shell=True
+        ["/usr/local/bin/ansible-vault", "view", str(path)]
+    )
+
+
+# --- Decrypt.take_action ---
+
+
+def test_decrypt_invokes_ansible_vault_without_shell(tmp_path):
+    path = tmp_path / "secrets.yml"
+    path.write_bytes(b"$ANSIBLE_VAULT;1.1;AES256\nciphertext\n")
+    cmd = vault.Decrypt(MagicMock(), MagicMock())
+    parser = cmd.get_parser("test")
+    parsed_args = parser.parse_args([str(path)])
+
+    with patch("osism.commands.vault.subprocess.call") as mock_call:
+        cmd.take_action(parsed_args)
+
+    mock_call.assert_called_once_with(
+        ["/usr/local/bin/ansible-vault", "decrypt", str(path)]
     )

--- a/tests/unit/commands/test_vault.py
+++ b/tests/unit/commands/test_vault.py
@@ -128,3 +128,16 @@ def test_decrypt_invokes_ansible_vault_without_shell(tmp_path):
     mock_call.assert_called_once_with(
         ["/usr/local/bin/ansible-vault", "decrypt", str(path)]
     )
+
+
+def test_decrypt_propagates_exit_code(tmp_path):
+    path = tmp_path / "secrets.yml"
+    path.write_bytes(b"$ANSIBLE_VAULT;1.1;AES256\nciphertext\n")
+    cmd = vault.Decrypt(MagicMock(), MagicMock())
+    parser = cmd.get_parser("test")
+    parsed_args = parser.parse_args([str(path)])
+
+    with patch("osism.commands.vault.subprocess.call", return_value=1):
+        rc = cmd.take_action(parsed_args)
+
+    assert rc == 1

--- a/tests/unit/commands/test_vault.py
+++ b/tests/unit/commands/test_vault.py
@@ -112,7 +112,34 @@ def test_view_invokes_ansible_vault_for_vault_variants(tmp_path, header):
     )
 
 
+def test_view_requires_path(loguru_logs):
+    parser = _make_view().get_parser("test")
+    parsed_args = parser.parse_args([])
+
+    with patch("osism.commands.vault.subprocess.call") as mock_call:
+        rc = _make_view().take_action(parsed_args)
+
+    assert rc == 1
+    mock_call.assert_not_called()
+    errors = [r for r in loguru_logs if r["level"] == "ERROR"]
+    assert any("No path" in r["message"] for r in errors)
+
+
 # --- Decrypt.take_action ---
+
+
+def test_decrypt_requires_path(loguru_logs):
+    cmd = vault.Decrypt(MagicMock(), MagicMock())
+    parser = cmd.get_parser("test")
+    parsed_args = parser.parse_args([])
+
+    with patch("osism.commands.vault.subprocess.call") as mock_call:
+        rc = cmd.take_action(parsed_args)
+
+    assert rc == 1
+    mock_call.assert_not_called()
+    errors = [r for r in loguru_logs if r["level"] == "ERROR"]
+    assert any("No path" in r["message"] for r in errors)
 
 
 def test_decrypt_invokes_ansible_vault_without_shell(tmp_path):


### PR DESCRIPTION
## Summary

- Replace `shell=True` string interpolation with list form in `View.take_action`
  and `Decrypt.take_action` — a user-supplied path containing shell metacharacters
  (e.g. `;`) could cause arbitrary command execution
- Propagate the `ansible-vault` exit code from `Decrypt.take_action`, which
  previously discarded it while `View.take_action` already returned it
- Guard both `View` and `Decrypt` against a missing `path` argument: `nargs="?"`
  makes the argument optional, but the code called `os.path.isabs(None)` and
  raised an unhelpful `TypeError` when it was omitted

## Test plan

- [ ] `pipenv run pytest tests/unit/commands/test_vault.py` — all 11 tests pass
- [ ] `pipenv run pytest` — full suite clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)