### PR TITLE
Retry SSH connection setup to fix intermittent publickey errors

### DIFF
--- a/osism/tasks/__init__.py
+++ b/osism/tasks/__init__.py
@@ -152,6 +152,7 @@ def run_ansible_in_environment(
     publish=True,
     locking=False,
     auto_release_time=3600,
+    ssh_retries=3,
 ):
     result = ""
     extracted_hosts = set()  # Local set for host deduplication
@@ -196,7 +197,7 @@ def run_ansible_in_environment(
     # connection a few times so these transient first-contact glitches no
     # longer abort the whole run.
     if "ANSIBLE_SSH_RETRIES" not in env:
-        env["ANSIBLE_SSH_RETRIES"] = "3"
+        env["ANSIBLE_SSH_RETRIES"] = str(ssh_retries)
 
     try:
         # handle sub environments

--- a/osism/tasks/__init__.py
+++ b/osism/tasks/__init__.py
@@ -185,6 +185,19 @@ def run_ansible_in_environment(
     logger.debug(f"Using per-task SSH ControlPath directory: {ssh_control_dir}")
     env["ANSIBLE_SSH_CONTROL_PATH_DIR"] = ssh_control_dir
 
+    # Because the per-task ControlPath directory above is unique per run and
+    # removed afterwards, there is no persistent ControlMaster socket reuse
+    # across runs anymore. Every run therefore cold-establishes the SSH
+    # connection to every host. With Ansible's default of ANSIBLE_SSH_RETRIES=0
+    # a single transient failure during this cold connection setup (e.g. a
+    # ControlMaster spawn race during the first task's connection burst)
+    # immediately fails the host as UNREACHABLE with "Permission denied
+    # (publickey)", even though an immediate re-run succeeds. Retry the
+    # connection a few times so these transient first-contact glitches no
+    # longer abort the whole run.
+    if "ANSIBLE_SSH_RETRIES" not in env:
+        env["ANSIBLE_SSH_RETRIES"] = "3"
+
     try:
         # handle sub environments
         if "." in environment:


### PR DESCRIPTION
Since #2134 the SSH ControlPath directory is unique per task and removed in the finally block, so there is no persistent ControlMaster socket reuse across runs anymore. Every run now cold-establishes the SSH connection to every host.

With Ansible's default ANSIBLE_SSH_RETRIES=0 a single transient failure during this cold connection setup makes the affected hosts fail immediately as UNREACHABLE with "Permission denied (publickey)", typically on the very first task that contacts the nodes (e.g. module-load) and for all hosts of the batch at once, while an immediate re-run succeeds. This is a regression of #2134 for the sequential single-playbook case, which previously was masked by persistent ControlMaster socket reuse.

Set ANSIBLE_SSH_RETRIES=3 (unless already provided via the environment) right next to the #2134 logic so transient first-contact glitches no longer abort the whole run.

AI-assisted: Claude Code