### PR TITLE
Fix cloudpod flavors hw_rng:allowed property

### DIFF
--- a/files/data/cloudpod.yml
+++ b/files/data/cloudpod.yml
@@ -19,7 +19,7 @@ mandatory:
     scs:disk0-type: network
     scs:name-v1: SCS-1L:1
     scs:name-v2: SCS-1L-1
-    hw_rng:allowed: "true"
+    hw_rng:allowed: "True"
   - name: SCS-1V-2
     cpus: 1
     ram: 2048
@@ -28,7 +28,7 @@ mandatory:
     scs:disk0-type: network
     scs:name-v1: SCS-1V:2
     scs:name-v2: SCS-1V-2
-    hw_rng:allowed: "true"
+    hw_rng:allowed: "True"
   - name: SCS-1V-4
     cpus: 1
     ram: 4096
@@ -37,7 +37,7 @@ mandatory:
     scs:disk0-type: network
     scs:name-v1: SCS-1V:4
     scs:name-v2: SCS-1V-4
-    hw_rng:allowed: "true"
+    hw_rng:allowed: "True"
   - name: SCS-1V-8
     cpus: 1
     ram: 8192
@@ -46,7 +46,7 @@ mandatory:
     scs:disk0-type: network
     scs:name-v1: SCS-1V:8
     scs:name-v2: SCS-1V-8
-    hw_rng:allowed: "true"
+    hw_rng:allowed: "True"
   - name: SCS-2V-4
     cpus: 2
     ram: 4096
@@ -55,7 +55,7 @@ mandatory:
     scs:disk0-type: network
     scs:name-v1: SCS-2V:4
     scs:name-v2: SCS-2V-4
-    hw_rng:allowed: "true"
+    hw_rng:allowed: "True"
   - name: SCS-2V-8
     cpus: 2
     ram: 8192
@@ -64,7 +64,7 @@ mandatory:
     scs:disk0-type: network
     scs:name-v1: SCS-2V:8
     scs:name-v2: SCS-2V-8
-    hw_rng:allowed: "true"
+    hw_rng:allowed: "True"
   - name: SCS-2V-16
     cpus: 2
     ram: 16384
@@ -73,7 +73,7 @@ mandatory:
     scs:disk0-type: network
     scs:name-v1: SCS-2V:16
     scs:name-v2: SCS-2V-16
-    hw_rng:allowed: "true"
+    hw_rng:allowed: "True"
   - name: SCS-4V-8
     cpus: 4
     ram: 8192
@@ -82,7 +82,7 @@ mandatory:
     scs:disk0-type: network
     scs:name-v1: SCS-4V:8
     scs:name-v2: SCS-4V-8
-    hw_rng:allowed: "true"
+    hw_rng:allowed: "True"
   - name: SCS-4V-16
     cpus: 4
     ram: 16384
@@ -91,7 +91,7 @@ mandatory:
     scs:disk0-type: network
     scs:name-v1: SCS-4V:16
     scs:name-v2: SCS-4V-16
-    hw_rng:allowed: "true"
+    hw_rng:allowed: "True"
   - name: SCS-4V-32
     cpus: 4
     ram: 32768
@@ -100,7 +100,7 @@ mandatory:
     scs:disk0-type: network
     scs:name-v1: SCS-4V:32
     scs:name-v2: SCS-4V-32
-    hw_rng:allowed: "true"
+    hw_rng:allowed: "True"
   - name: SCS-8V-16
     cpus: 8
     ram: 16384
@@ -109,7 +109,7 @@ mandatory:
     scs:disk0-type: network
     scs:name-v1: SCS-8V:16
     scs:name-v2: SCS-8V-16
-    hw_rng:allowed: "true"
+    hw_rng:allowed: "True"
   - name: SCS-8V-32
     cpus: 8
     ram: 32768
@@ -118,7 +118,7 @@ mandatory:
     scs:disk0-type: network
     scs:name-v1: SCS-8V:32
     scs:name-v2: SCS-8V-32
-    hw_rng:allowed: "true"
+    hw_rng:allowed: "True"
   - name: SCS-16V-64
     cpus: 16
     ram: 65536
@@ -127,7 +127,7 @@ mandatory:
     scs:disk0-type: network
     scs:name-v1: SCS-16V:64
     scs:name-v2: SCS-16V-64
-    hw_rng:allowed: "true"
+    hw_rng:allowed: "True"
   - name: SCS-2V-4-20s
     cpus: 2
     ram: 4096
@@ -136,7 +136,7 @@ mandatory:
     scs:disk0-type: ssd
     scs:name-v1: SCS-2V:4:20s
     scs:name-v2: SCS-2V-4-20s
-    hw_rng:allowed: "true"
+    hw_rng:allowed: "True"
   - name: SCS-4V-8-50s
     cpus: 4
     ram: 8192
@@ -145,7 +145,7 @@ mandatory:
     scs:disk0-type: ssd
     scs:name-v1: SCS-4V:8:50s
     scs:name-v2: SCS-4V-8-50s
-    hw_rng:allowed: "true"
+    hw_rng:allowed: "True"
   - name: SCS-8V-32-100s
     cpus: 8
     ram: 32768
@@ -154,7 +154,7 @@ mandatory:
     scs:disk0-type: ssd
     scs:name-v1: SCS-8V:32:100s
     scs:name-v2: SCS-8V-32-100s
-    hw_rng:allowed: "true"
+    hw_rng:allowed: "True"
   - name: SCS-16V-64-100s
     cpus: 16
     ram: 65536
@@ -163,4 +163,4 @@ mandatory:
     scs:disk0-type: ssd
     scs:name-v1: SCS-8V:32:100s
     scs:name-v2: SCS-8V-32-100s
-    hw_rng:allowed: "true"
+    hw_rng:allowed: "True"


### PR DESCRIPTION
The SCS flavor standard test expects an uppercase `True` for property `hw_rng:allowed` ([1]).

[1]
https://github.com/SovereignCloudStack/standards/blob/main/Tests/iaas/scs_0101_entropy/entropy_check.py#L28 https://github.com/SovereignCloudStack/standards/blob/main/Tests/iaas/scs_0101_entropy/entropy_check.py#L91