### PR TITLE
Return non-zero exit from get on query failure

### DIFF
--- a/osism/commands/get.py
+++ b/osism/commands/get.py
@@ -139,7 +139,7 @@ class Hostvars(Command):
             )
         except subprocess.CalledProcessError:
             logger.error(f"Host {host} not found in inventory.")
-            return
+            return 1
 
         data = json.loads(result)
         table = []
@@ -249,7 +249,7 @@ class Hosts(Command):
             )
         except subprocess.CalledProcessError:
             logger.error("Error loading inventory.")
-            return
+            return 1
 
         data = json.loads(result)
         table = []

--- a/tests/unit/commands/test_get.py
+++ b/tests/unit/commands/test_get.py
@@ -1,0 +1,91 @@
+# SPDX-License-Identifier: Apache-2.0
+
+"""Tests for the ``osism get`` commands.
+
+These focus on the exit-code contract: a command must return a non-zero exit
+status when the underlying query cannot be run (e.g. the inventory cannot be
+loaded), but must keep returning success when the query runs fine and simply
+yields an empty result.
+"""
+
+import json
+import subprocess
+from unittest.mock import MagicMock, patch
+
+from osism.commands import get
+
+
+def _make(cls):
+    return cls(MagicMock(), MagicMock())
+
+
+# --- Hosts.take_action ---
+
+
+def test_hosts_returns_nonzero_when_inventory_cannot_be_loaded():
+    cmd = _make(get.Hosts)
+    parsed_args = cmd.get_parser("test").parse_args([])
+
+    with patch(
+        "osism.commands.get.get_inventory_path",
+        return_value="/ansible/inventory/hosts.yml",
+    ), patch(
+        "osism.commands.get.subprocess.check_output",
+        side_effect=subprocess.CalledProcessError(1, "ansible-inventory"),
+    ):
+        result = cmd.take_action(parsed_args)
+
+    assert result == 1
+
+
+def test_hosts_returns_success_for_empty_inventory():
+    cmd = _make(get.Hosts)
+    parsed_args = cmd.get_parser("test").parse_args([])
+
+    with patch(
+        "osism.commands.get.get_inventory_path",
+        return_value="/ansible/inventory/hosts.yml",
+    ), patch(
+        "osism.commands.get.subprocess.check_output",
+        return_value=json.dumps({"_meta": {"hostvars": {}}}).encode(),
+    ), patch(
+        "osism.commands.get.get_hosts_from_inventory", return_value=[]
+    ):
+        result = cmd.take_action(parsed_args)
+
+    assert not result
+
+
+# --- Hostvars.take_action ---
+
+
+def test_hostvars_returns_nonzero_when_inventory_query_fails():
+    cmd = _make(get.Hostvars)
+    parsed_args = cmd.get_parser("test").parse_args(["somehost"])
+
+    with patch(
+        "osism.commands.get.get_inventory_path",
+        return_value="/ansible/inventory/hosts.yml",
+    ), patch(
+        "osism.commands.get.subprocess.check_output",
+        side_effect=subprocess.CalledProcessError(1, "ansible-inventory"),
+    ):
+        result = cmd.take_action(parsed_args)
+
+    assert result == 1
+
+
+def test_hostvars_returns_success_when_variable_absent_from_result():
+    cmd = _make(get.Hostvars)
+    parsed_args = cmd.get_parser("test").parse_args(["somehost", "missingvar"])
+
+    with patch(
+        "osism.commands.get.get_inventory_path",
+        return_value="/ansible/inventory/hosts.yml",
+    ), patch(
+        "osism.commands.get.subprocess.check_output",
+        return_value=json.dumps({"present": "value"}).encode(),
+    ):
+        result = cmd.take_action(parsed_args)
+
+    assert not result


### PR DESCRIPTION
## What

`osism get hostvars` and `osism get hosts` logged an error but then returned `None` when the underlying `ansible-inventory` subprocess failed. cliff turns a `take_action` return value of `None` into exit code 0 (`return_code = self.take_action(parsed_args) or 0`), so these commands exited **successfully** even when the inventory query could not be run at all — making them unsafe in `set -e` scripts and `&&` chains.

Both commands now `return 1` on `subprocess.CalledProcessError`, i.e. when the query itself could not be executed.

## Missing host

With the pinned `ansible-core` (2.18.9 — `release` repo `latest/base.yml`), `ansible-inventory --host <unknown>` does **not** return an empty result. It refuses the query with `ERROR! You must pass a single valid host to --host parameter` and exits 5. So `osism get hostvars <unknown-host>` now exits 1, matching its existing `Host not found in inventory.` error message.

## What stays exit 0 (empty results)

Empty results are deliberately left as success — a query that ran fine but had nothing to show:

- a host that exists but has no host vars (`ansible-inventory` prints `{}`, exits 0)
- a requested variable/fact absent from an otherwise successfully retrieved data set
- an inventory that lists no matching hosts

## A note on the convention

There is **no documented exit-code contract** for the `osism` CLI — the behaviour is emergent and inconsistent across commands. This PR does not attempt to define or enforce one. It only tries to make `osism get` match what looks like the prevailing convention elsewhere in the CLI: a non-zero exit signals an *operational failure* (the query could not be run), while an empty result set is treated as a valid, successful answer.

## Tests

Adds unit tests for both commands covering the failure path (raised `CalledProcessError` → exit 1) and the empty-result path (successful query with nothing to show → exit 0).