### PR TITLE
Drop unused sonic-yang-mgmt dependency

### DIFF
--- a/Pipfile
+++ b/Pipfile
@@ -31,7 +31,6 @@ pottery = "==3.0.1"
 prompt-toolkit = "==3.0.52"
 pyang = "==2.7.1"
 pynetbox = "==7.7.0"
-sonic-yang-mgmt = {git = "https://github.com/sonic-net/sonic-buildimage.git", ref = "9ef3658e5315002006ea1d6da2524ad14f77c928", subdirectory = "src/sonic-yang-mgmt"}
 pytest-testinfra = "==10.2.2"
 python-dateutil = "==2.9.0.post0"
 redfish = "==3.3.5"

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "c66644c81de04396752af98703789fbc3781dd85645118eff9e16fed54d3da64"
+            "sha256": "051268db3cab9c1a671c086d4695d66fcff7707e7c2f4954ca3f21ca9fbd4014"
         },
         "pipfile-spec": 6,
         "requires": {},
@@ -1994,11 +1994,6 @@
             ],
             "markers": "python_version >= '3.7'",
             "version": "==5.0.3"
-        },
-        "sonic-yang-mgmt": {
-            "git": "https://github.com/sonic-net/sonic-buildimage.git",
-            "ref": "9ef3658e5315002006ea1d6da2524ad14f77c928",
-            "subdirectory": "src/sonic-yang-mgmt"
         },
         "sqlalchemy": {
             "hashes": [


### PR DESCRIPTION
## What

Removes the `sonic-yang-mgmt` git dependency from `Pipfile` and `Pipfile.lock`.

## Why

`sonic-yang-mgmt` was added in #2191 for the original libyang-based SONiC config validator. #2253 replaced that validator with offline-generated Pydantic schemas and cleaned up `requirements.txt`, `requirements.sonic.txt` and the `Containerfile` — but left the dependency behind in `Pipfile`/`Pipfile.lock`.

Nothing imports `sonic_yang_mgmt` anymore:
- the runtime validator depends only on `pydantic` (see `osism/tasks/conductor/sonic/validator.py`)
- the schema generator (`tools/sonic_yang_to_pydantic.py`) uses `pyang`, which stays

It was also the only git dependency in the lockfile.

## Notes

- The `Pipfile.lock` `_meta` hash was recomputed with pipenv's own `calculate_pipfile_hash()` so the lockfile stays in sync with the Pipfile.
- `pyang` is intentionally kept — it is required by the schema generator.

🤖 Generated with [Claude Code](https://claude.com/claude-code)