### PR TITLE
Restrict SONiC SNMP and gNMI access to the OOB management network

### DIFF
--- a/osism/tasks/conductor/sonic/config_generator.py
+++ b/osism/tasks/conductor/sonic/config_generator.py
@@ -56,6 +56,10 @@ _metalbox_devices_cache: Optional[dict] = None
 # VXLAN VTEP name used for VXLAN tunnel configuration
 VXLAN_VTEP_NAME = "vtepServ"
 
+# Default listen port of the SONiC telemetry/gNMI container, used for the
+# GNMI_ONLY control-plane ACL rule when TELEMETRY|gnmi does not set a port.
+DEFAULT_GNMI_PORT = "8080"
+
 # Top-level scaffold keys that the orchestrator and downstream helpers index
 # into directly. Kept as a single source of truth so that the production code
 # and the test helpers cannot drift apart when keys are added or removed.
@@ -105,11 +109,11 @@ INHERITED_TABLE_KEYS = ("DEVICE_METADATA", "VERSIONS")
 # difference being only that the generator depends on this one as an input.
 # Distinct from inherited tables, which the generator also writes selected
 # fields into; the distinction is read-only vs. read-and-update, not the access
-# syntax (inherited tables are read via config.get() too). Empty for now; the
-# first consumer is the gNMI listen port, read from TELEMETRY. Must stay
-# disjoint from OWNED_TABLE_KEYS -- an image-consumed table dropped up front
-# would always read back empty.
-IMAGE_CONSUMED_TABLE_KEYS = ()
+# syntax (inherited tables are read via config.get() too). For example, the
+# gNMI listen port is read from TELEMETRY. Must stay disjoint from
+# OWNED_TABLE_KEYS -- an image-consumed table dropped up front would always
+# read back empty.
+IMAGE_CONSUMED_TABLE_KEYS = ("TELEMETRY",)
 
 # Owned tables that are also scaffolded: every scaffold key except the
 # inherited ones. The orchestrator setdefault-creates these up front, so
@@ -126,6 +130,8 @@ SCAFFOLDED_OWNED_TABLE_KEYS = tuple(
 # defaults (location "Data Center", contact "info@example.com") even when the
 # device has no SNMP data in NetBox.
 ON_DEMAND_OWNED_TABLE_KEYS = (
+    "ACL_RULE",
+    "ACL_TABLE",
     "ROUTE_REDISTRIBUTE",
     "SNMP_SERVER",
     "SNMP_AGENT_ADDRESS_CONFIG",
@@ -194,7 +200,8 @@ def generate_sonic_config(device, hwsku, device_as_mapping=None, config_version=
           base config but never modified by the generator. The defining
           property is behavioural (read-only), not the access syntax:
           inherited tables are also read via config.get(), so .get() alone
-          does not distinguish the two. Empty for now.
+          does not distinguish the two. IMAGE_CONSUMED_TABLE_KEYS lists the
+          current members.
         - Pass-through: every table the generator never references. Left
           untouched and unmanaged; not a supported place for operator
           customizations either.
@@ -424,6 +431,8 @@ def generate_sonic_config(device, hwsku, device_as_mapping=None, config_version=
         config["MGMT_INTERFACE"][f"eth0|{oob_ip}/{prefix_len}"] = {}
         metalbox_ip = _get_metalbox_ip_for_device(device)
         config["STATIC_ROUTE"]["mgmt|0.0.0.0/0"] = {"nexthop": metalbox_ip}
+        # Restrict control-plane services (SNMP, gNMI) to the OOB network
+        _add_ctrlplane_acls(config, oob_ip, prefix_len)
     else:
         oob_ip = None
 
@@ -2326,3 +2335,93 @@ def _add_snmp_configuration(config, device, oob_ip):
                 counter += 1
 
                 logger.debug(f"Added snmp_server_target {host}")
+
+
+def _get_gnmi_port(config):
+    """Return the gNMI server port for the GNMI_ONLY control-plane ACL rule.
+
+    The telemetry/gNMI container reads its listen port from
+    TELEMETRY|gnmi|port and falls back to 8080 when unset, so the ACL rule
+    follows the same lookup against the (image-consumed) TELEMETRY table,
+    treating a present-but-empty value (null, "") as unset like the
+    container does. A malformed value (non-numeric or outside 1-65535)
+    also falls back to the default, with a warning, rather than
+    propagating: the rule must always carry a bindable L4_DST_PORT --
+    caclmgrd otherwise skips the whole EXTERNAL_CLIENT table and gNMI
+    would silently stay unrestricted -- and the container cannot bind such
+    a value either, so the substituted default cannot mismatch a live gNMI
+    listener.
+    """
+    port = config.get("TELEMETRY", {}).get("gnmi", {}).get("port")
+    if port is None or str(port).strip() == "":
+        return DEFAULT_GNMI_PORT
+    try:
+        port_number = int(str(port).strip())
+    except ValueError:
+        port_number = -1
+    if not 1 <= port_number <= 65535:
+        logger.warning(
+            f"TELEMETRY|gnmi|port value {port!r} is not a usable TCP port; "
+            f"using default {DEFAULT_GNMI_PORT} for the GNMI_ONLY ACL rule"
+        )
+        return DEFAULT_GNMI_PORT
+    return str(port_number)
+
+
+def _add_ctrlplane_acls(config, oob_ip, prefix_len):
+    """Add control-plane ACLs restricting SNMP and gNMI to the OOB network.
+
+    Emits ACL_TABLE entries of type CTRLPLANE bound to the SNMP and
+    EXTERNAL_CLIENT (gNMI/telemetry) caclmgrd services, plus one ACL_RULE
+    per table accepting only the device's OOB management subnet (the
+    network-normalised oob_ip/prefix_len). caclmgrd installs an implicit
+    default-drop for every service bound in a CTRLPLANE table, so sources
+    outside the OOB subnet can no longer reach SNMP or gNMI. The SSH_ONLY
+    table (#2329) belongs here as well once implemented.
+
+    caclmgrd's EXTERNAL_CLIENT service has no built-in destination port
+    (verified against sonic-host-services 202211 through master): the rule
+    must carry it in L4_DST_PORT, otherwise caclmgrd skips the whole table
+    and the gNMI restriction would silently not exist.
+
+    ACL_TABLE and ACL_RULE are generator-owned (ON_DEMAND_OWNED_TABLE_KEYS),
+    so they are rebuilt from scratch on every regen and stay absent when the
+    device has no OOB IP. They are also multi-owner
+    (MULTI_OWNER_OWNED_TABLE_KEYS): the SSH_ONLY table (#2329) belongs here as
+    well once implemented, so this helper merges only its own SNMP_ONLY /
+    GNMI_ONLY keys per key rather than rebinding the table wholesale -- the
+    central owned-table drop in generate_sonic_config clears stale entries up
+    front, and per-key merge lets coexisting control-plane helpers compose. The
+    rules are IPv4 (SRC_IP); a non-IPv4 OOB IP logs a warning and emits nothing
+    rather than failing the whole config generation.
+    """
+    network = ipaddress.ip_network(f"{oob_ip}/{prefix_len}", strict=False)
+    if network.version != 4:
+        logger.warning(
+            f"OOB IP {oob_ip}/{prefix_len} is not IPv4; skipping control-plane ACLs"
+        )
+        return
+
+    accept_from_oob = {
+        "PRIORITY": "9999",
+        "PACKET_ACTION": "ACCEPT",
+        "SRC_IP": str(network),
+        "IP_TYPE": "IP",
+    }
+    config.setdefault("ACL_TABLE", {})
+    config["ACL_TABLE"]["SNMP_ONLY"] = {
+        "policy_desc": "SNMP_ONLY",
+        "type": "CTRLPLANE",
+        "services": ["SNMP"],
+    }
+    config["ACL_TABLE"]["GNMI_ONLY"] = {
+        "policy_desc": "GNMI_ONLY",
+        "type": "CTRLPLANE",
+        "services": ["EXTERNAL_CLIENT"],
+    }
+    config.setdefault("ACL_RULE", {})
+    config["ACL_RULE"]["SNMP_ONLY|RULE_1"] = dict(accept_from_oob)
+    config["ACL_RULE"]["GNMI_ONLY|RULE_1"] = {
+        **accept_from_oob,
+        "L4_DST_PORT": _get_gnmi_port(config),
+    }

--- a/tests/unit/tasks/conductor/sonic/test_config_generator_ctrlplane_acls.py
+++ b/tests/unit/tasks/conductor/sonic/test_config_generator_ctrlplane_acls.py
@@ -1,0 +1,148 @@
+# SPDX-License-Identifier: Apache-2.0
+
+"""Unit tests for ``_add_ctrlplane_acls`` in ``config_generator`` (#2330)."""
+
+import pytest
+
+from osism.tasks.conductor.sonic.config_generator import (
+    ON_DEMAND_OWNED_TABLE_KEYS,
+    TOP_LEVEL_SCAFFOLD_KEYS,
+    _add_ctrlplane_acls,
+)
+
+
+def test_add_ctrlplane_acls_emits_snmp_and_gnmi_ctrlplane_tables():
+    config = {}
+
+    _add_ctrlplane_acls(config, "10.42.0.5", 24)
+
+    assert config["ACL_TABLE"] == {
+        "SNMP_ONLY": {
+            "policy_desc": "SNMP_ONLY",
+            "type": "CTRLPLANE",
+            "services": ["SNMP"],
+        },
+        "GNMI_ONLY": {
+            "policy_desc": "GNMI_ONLY",
+            "type": "CTRLPLANE",
+            "services": ["EXTERNAL_CLIENT"],
+        },
+    }
+
+
+def test_add_ctrlplane_acls_rules_accept_network_normalised_oob_subnet():
+    """SRC_IP must carry the network address, not the device's host IP."""
+    config = {}
+
+    _add_ctrlplane_acls(config, "10.42.0.5", 24)
+
+    assert config["ACL_RULE"]["SNMP_ONLY|RULE_1"] == {
+        "PRIORITY": "9999",
+        "PACKET_ACTION": "ACCEPT",
+        "SRC_IP": "10.42.0.0/24",
+        "IP_TYPE": "IP",
+    }
+    assert config["ACL_RULE"]["GNMI_ONLY|RULE_1"] == {
+        "PRIORITY": "9999",
+        "PACKET_ACTION": "ACCEPT",
+        "SRC_IP": "10.42.0.0/24",
+        "IP_TYPE": "IP",
+        "L4_DST_PORT": "8080",
+    }
+
+
+def test_add_ctrlplane_acls_gnmi_rule_requires_dst_port_snmp_does_not():
+    """caclmgrd's EXTERNAL_CLIENT service has no built-in destination port;
+    without L4_DST_PORT in the rule it skips the whole table and the gNMI
+    restriction would silently not exist. SNMP has a fixed service port
+    (161) in caclmgrd's ACL_SERVICES, so its rule must not pin one."""
+    config = {}
+
+    _add_ctrlplane_acls(config, "10.42.0.5", 24)
+
+    assert config["ACL_RULE"]["GNMI_ONLY|RULE_1"]["L4_DST_PORT"] == "8080"
+    assert "L4_DST_PORT" not in config["ACL_RULE"]["SNMP_ONLY|RULE_1"]
+
+
+def test_add_ctrlplane_acls_gnmi_port_follows_telemetry_table():
+    """A TELEMETRY|gnmi|port from the base config wins over the 8080 default
+    (and non-string values are normalised to the string ConfigDB expects)."""
+    config = {"TELEMETRY": {"gnmi": {"port": 50051}}}
+
+    _add_ctrlplane_acls(config, "10.42.0.5", 24)
+
+    assert config["ACL_RULE"]["GNMI_ONLY|RULE_1"]["L4_DST_PORT"] == "50051"
+
+
+@pytest.mark.parametrize(
+    "port",
+    [None, "", "  ", "not-a-port", "8080.5", 0, 70000, -1],
+    ids=[
+        "null",
+        "empty",
+        "blank",
+        "non-numeric",
+        "float",
+        "zero",
+        "too-big",
+        "negative",
+    ],
+)
+def test_add_ctrlplane_acls_unusable_gnmi_port_falls_back_to_default(port):
+    """A present-but-unusable TELEMETRY|gnmi|port must not leak into the rule:
+    caclmgrd cannot bind it and would skip the whole EXTERNAL_CLIENT table,
+    silently leaving gNMI unrestricted. The helper substitutes the 8080
+    default instead -- safe, because the gNMI container cannot bind such a
+    value either, so there is no live listener the rule could mismatch."""
+    config = {"TELEMETRY": {"gnmi": {"port": port}}}
+
+    _add_ctrlplane_acls(config, "10.42.0.5", 24)
+
+    assert config["ACL_RULE"]["GNMI_ONLY|RULE_1"]["L4_DST_PORT"] == "8080"
+
+
+def test_add_ctrlplane_acls_merges_into_co_owned_tables_per_key():
+    """ACL_TABLE / ACL_RULE are multi-owner (SSH, SNMP, gNMI): the helper must
+    merge only its own keys, never rebind the table wholesale, so a sibling
+    control-plane helper's entries survive. Stale carry-over from a prior regen
+    is cleared by the central owned-table drop in generate_sonic_config, not
+    here (see the ownership model and MULTI_OWNER_OWNED_TABLE_KEYS)."""
+    config = {
+        "ACL_TABLE": {"SSH_ONLY": {"type": "CTRLPLANE", "services": ["SSH"]}},
+        "ACL_RULE": {"SSH_ONLY|RULE_1": {"PRIORITY": "9999"}},
+    }
+
+    _add_ctrlplane_acls(config, "10.42.0.5", 24)
+
+    # A sibling helper's entries are left untouched ...
+    assert config["ACL_TABLE"]["SSH_ONLY"] == {"type": "CTRLPLANE", "services": ["SSH"]}
+    assert config["ACL_RULE"]["SSH_ONLY|RULE_1"] == {"PRIORITY": "9999"}
+    # ... and this helper's own entries are added alongside them.
+    assert set(config["ACL_TABLE"]) == {"SSH_ONLY", "SNMP_ONLY", "GNMI_ONLY"}
+    assert set(config["ACL_RULE"]) == {
+        "SSH_ONLY|RULE_1",
+        "SNMP_ONLY|RULE_1",
+        "GNMI_ONLY|RULE_1",
+    }
+
+
+def test_add_ctrlplane_acls_non_ipv4_oob_ip_emits_nothing():
+    """The rules are IPv4-only (SRC_IP); an IPv6 OOB IP must not produce
+    half-correct tables — and must not break config generation either."""
+    config = {}
+
+    _add_ctrlplane_acls(config, "2001:db8::5", 64)
+
+    assert "ACL_TABLE" not in config
+    assert "ACL_RULE" not in config
+
+
+def test_ctrlplane_acl_tables_are_on_demand_owned():
+    """#2330 requires ACL_TABLE/ACL_RULE to be rebuilt from scratch on every
+    regen and absent without an OOB IP. Both guarantees hang on the keys
+    being on-demand owned: owned tables are dropped from the base config up
+    front, and on-demand (unlike scaffolded) tables are not re-created as
+    empty dicts."""
+    for key in ("ACL_TABLE", "ACL_RULE"):
+        assert key in ON_DEMAND_OWNED_TABLE_KEYS
+        assert key not in TOP_LEVEL_SCAFFOLD_KEYS

--- a/tests/unit/tasks/conductor/sonic/test_config_generator_orchestrator.py
+++ b/tests/unit/tasks/conductor/sonic/test_config_generator_orchestrator.py
@@ -17,6 +17,7 @@ from osism.tasks.conductor.sonic import config_generator
 from osism.tasks.conductor.sonic.config_generator import (
     OWNED_TABLE_KEYS,
     TOP_LEVEL_SCAFFOLD_KEYS,
+    _add_ctrlplane_acls,
     clear_all_caches,
     clear_metalbox_devices_cache,
     clear_metalbox_ip_cache,
@@ -95,6 +96,7 @@ def patch_orchestrator_helpers(mocker):
         _add_loopback_configuration=patch("_add_loopback_configuration"),
         _add_log_server_configuration=patch("_add_log_server_configuration"),
         _add_snmp_configuration=patch("_add_snmp_configuration"),
+        _add_ctrlplane_acls=patch("_add_ctrlplane_acls"),
         _add_vrf_configuration=patch("_add_vrf_configuration"),
         _add_portchannel_configuration=patch("_add_portchannel_configuration"),
         get_cached_device_interfaces=patch(
@@ -393,6 +395,74 @@ def test_generate_sonic_config_no_oob_ip_leaves_mgmt_empty_and_passes_none(
     assert "mgmt|0.0.0.0/0" not in config["STATIC_ROUTE"]
     _, _, snmp_oob = patch_orchestrator_helpers._add_snmp_configuration.call_args.args
     assert snmp_oob is None
+
+
+def test_generate_sonic_config_oob_ip_wires_ctrlplane_acls(
+    mocker, patch_orchestrator_helpers, make_orchestrator_device
+):
+    """With an OOB IP the orchestrator delegates the control-plane ACLs
+    (#2330) to ``_add_ctrlplane_acls`` with the raw OOB IP and prefix —
+    network normalisation is the helper's job."""
+    patch_base_config(mocker)
+    patch_orchestrator_helpers.get_device_oob_ip.return_value = ("10.42.0.5", 24)
+    device = make_orchestrator_device()
+
+    config = generate_sonic_config(device, "HWSKU")
+
+    patch_orchestrator_helpers._add_ctrlplane_acls.assert_called_once_with(
+        config, "10.42.0.5", 24
+    )
+
+
+def test_generate_sonic_config_gnmi_port_survives_owned_table_drop_end_to_end(
+    mocker, patch_orchestrator_helpers, make_orchestrator_device
+):
+    """End-to-end with the real ACL helper: a TELEMETRY|gnmi|port from the
+    base config must reach the generated GNMI_ONLY rule. TELEMETRY is
+    image-consumed while ACL_TABLE/ACL_RULE are owned and dropped up front,
+    so this pins the whole flow -- the port is read after the drop and
+    emitted into the final output -- which the wiring tests above (helper
+    mocked) and the helper unit tests (no orchestrator) only cover
+    compositionally."""
+    base = make_base_config()
+    base["TELEMETRY"] = {"gnmi": {"port": 50051}}
+    patch_base_config(mocker, base_config=base)
+    patch_orchestrator_helpers.get_device_oob_ip.return_value = ("10.42.0.5", 24)
+    # Pass the wired call through to the real helper instead of the fixture
+    # mock, keeping every other orchestrator dependency patched.
+    patch_orchestrator_helpers._add_ctrlplane_acls.side_effect = _add_ctrlplane_acls
+    device = make_orchestrator_device()
+
+    config = generate_sonic_config(device, "HWSKU")
+
+    assert config["ACL_TABLE"]["GNMI_ONLY"]["services"] == ["EXTERNAL_CLIENT"]
+    assert config["ACL_RULE"]["GNMI_ONLY|RULE_1"] == {
+        "PRIORITY": "9999",
+        "PACKET_ACTION": "ACCEPT",
+        "SRC_IP": "10.42.0.0/24",
+        "IP_TYPE": "IP",
+        "L4_DST_PORT": "50051",
+    }
+
+
+def test_generate_sonic_config_no_oob_ip_skips_ctrlplane_acls(
+    mocker, patch_orchestrator_helpers, make_orchestrator_device
+):
+    """Without an OOB IP no control-plane ACLs are wired and the owned
+    ACL_TABLE / ACL_RULE tables stay absent — stale base-config content is
+    removed by the up-front owned-table drop, not re-created."""
+    base = make_base_config()
+    base["ACL_TABLE"] = {"SNMP_ONLY": {"type": "CTRLPLANE"}}
+    base["ACL_RULE"] = {"SNMP_ONLY|RULE_1": {"PRIORITY": "9999"}}
+    patch_base_config(mocker, base_config=base)
+    patch_orchestrator_helpers.get_device_oob_ip.return_value = None
+    device = make_orchestrator_device()
+
+    config = generate_sonic_config(device, "HWSKU")
+
+    patch_orchestrator_helpers._add_ctrlplane_acls.assert_not_called()
+    assert "ACL_TABLE" not in config
+    assert "ACL_RULE" not in config
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
Closes #2330

## What this does

The generated SONiC ConfigDB bound the SNMP agent to the OOB IP in the mgmt VRF but never restricted which source networks can reach it, and the gNMI/telemetry server (static `TELEMETRY|gnmi` base entry) listened on all interfaces with no restriction at all.

This PR emits, per device with an OOB IP, control-plane ACLs handled by `caclmgrd`: `ACL_TABLE` entries of type `CTRLPLANE` bound to the `SNMP` and `EXTERNAL_CLIENT` (gNMI) services, each with an `ACL_RULE` that accepts only the device's network-normalised OOB management subnet. Binding a service in a CTRLPLANE table makes caclmgrd install an implicit default-drop for that service, so all other sources lose access.

## Commit walkthrough

1. **Restrict SONiC SNMP and gNMI access to the OOB network** — adds the shared `_add_ctrlplane_acls` helper (the home for #2329's `SSH_ONLY` as well), registers `ACL_TABLE`/`ACL_RULE` as generator-owned on-demand tables (dropped from the base config up front, rebuilt on every regen, absent without an OOB IP), wires the helper into `generate_sonic_config` inside the management-interface block, and covers the helper with unit tests (tables/rules emitted, network-normalised `SRC_IP`, `TELEMETRY|gnmi|port` handling, wholesale replacement of pre-existing entries, non-IPv4 skip, ownership registration).
2. **Add orchestrator wiring tests for control-plane ACLs** — patches `_add_ctrlplane_acls` in the orchestrator helper fixture like the other section helpers and pins the wiring: called exactly once with `(config, oob_ip, prefix_len)` when an OOB IP exists; not invoked (and the owned tables stay absent, including stale base-config entries) when there is none.

## Deviations from the issue

- **`L4_DST_PORT` added to the `GNMI_ONLY` rule.** The issue's example rule carries only `PRIORITY`/`PACKET_ACTION`/`SRC_IP`/`IP_TYPE`, and its note says `EXTERNAL_CLIENT` "maps to the configured `TELEMETRY|gnmi|port`". The issue asked to verify this against caclmgrd before relying on it — verification against `sonic-host-services` (202211, 202305, 202311, 202405, master) shows no `TELEMETRY`/`GNMI` lookup exists in any of these versions: `EXTERNAL_CLIENT` has no built-in destination port, the rule must provide it via `L4_DST_PORT`, and a CTRLPLANE table whose rules yield no destination port is **skipped entirely** (syslog warning only) — the issue's exact example would have been a silent no-op for gNMI. The generator therefore performs the `TELEMETRY|gnmi|port` mapping itself and writes it into the rule, falling back to the telemetry container default `8080` when the base config sets no port. The SNMP rule needs no port (fixed `161` in caclmgrd's `ACL_SERVICES`).
- **Non-IPv4 OOB IPs skip ACL generation with a warning** instead of crashing. The issue assumed `IPv4Network(...)` unconditionally; `get_device_oob_ip` can legitimately return an IPv6 address (NetBox `oob_ip` or a mgmt interface with only a v6 address), and an unguarded `IPv4Network` would abort the device's entire config generation. The skip path is logged and unit-tested.
- **`SSH_ONLY` is not emitted here** — that is #2329's scope (still open). The helper is written and documented as the shared home for it; adding SSH is a one-entry change.
- **No `sonic-acl` YANG model added.** The issue's "Consider adding..." relates to #2258; the validator continues to report `ACL_TABLE`/`ACL_RULE` as warnings ("No YANG schema for table..."), not errors, exactly as the issue describes.

## Verification

- `pipenv run pytest` — 1150 passed (full unit suite; includes the existing exhaustive owned-table stale-drop test, which automatically covers the two new owned tables)
- `pipenv run flake8` on the changed files — clean
- caclmgrd semantics verified against `sonic-net/sonic-host-services` branches 202211 → master (`ACL_SERVICES`, `EXTERNAL_CLIENT` port handling, `is_rule_ipv4`, implicit drop)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
