### PR TITLE
Add lightweight integration tests for Celery/Redis basics in CI

### DIFF
--- a/.zuul.yaml
+++ b/.zuul.yaml
@@ -135,6 +135,11 @@
     pre-run: playbooks/pre.yml
     run: playbooks/test-unit.yml
 
+- job:
+    name: python-osism-integration-tests
+    pre-run: playbooks/pre.yml
+    run: playbooks/test-integration.yml
+
 - project:
     merge-mode: squash-merge
     default-branch: main
@@ -148,6 +153,7 @@
         - container-image-python-osism-frontend-build
         - python-osism-test-setup
         - python-osism-unit-tests
+        - python-osism-integration-tests
     periodic-daily:
       jobs:
         - flake8
@@ -156,6 +162,7 @@
         - python-black
         - python-osism-test-setup
         - python-osism-unit-tests
+        - python-osism-integration-tests
     periodic-midnight:
       jobs:
         - container-image-python-osism-push

--- a/README.md
+++ b/README.md
@@ -19,3 +19,15 @@ Run a single test module:
 ```
 pipenv run pytest tests/unit/test_smoke.py
 ```
+
+## Running integration tests
+
+The integration tests in `tests/integration/` exercise the Celery/Redis task
+core (broker, queue routing, worker, result backend, Redis streams and locks)
+end-to-end. They require a reachable Redis and start a Celery worker from the
+same virtualenv; they are skipped automatically when Redis is not running.
+
+```
+docker run -d -p 6379:6379 redis:7-alpine
+REDIS_HOST=localhost pipenv run pytest tests/integration
+```

--- a/README.md
+++ b/README.md
@@ -31,3 +31,10 @@ same virtualenv; they are skipped automatically when Redis is not running.
 docker run -d -p 6379:6379 redis:7-alpine
 REDIS_HOST=localhost pipenv run pytest tests/integration
 ```
+
+> **Warning:** The suite mutates live state on the configured Redis. Most keys
+> are per-run (UUID-based), but the task-lock test reads, writes and removes the
+> fixed global key `osism:task_lock` on the selected `REDIS_DB`. Always point it
+> at a disposable Redis (such as the throwaway container above); running it
+> against a Redis shared with a real OSISM deployment would clobber an active
+> operator lock.

--- a/osism/commands/service.py
+++ b/osism/commands/service.py
@@ -17,6 +17,8 @@ class Run(Command):
         return parser
 
     def take_action(self, parsed_args):
+        from osism.tasks import Config
+
         # Check if tasks are locked before proceeding
         utils.check_task_lock_and_exit()
 
@@ -47,8 +49,16 @@ class Run(Command):
             ]
             ps = [
                 subprocess.Popen(
-                    f"celery -A {t} --broker=redis://redis beat -s /tmp/celerybeat-schedule-{t}.db",
-                    shell=True,
+                    [
+                        "celery",
+                        "-A",
+                        t,
+                        "--broker",
+                        Config.broker_url,
+                        "beat",
+                        "-s",
+                        f"/tmp/celerybeat-schedule-{t}.db",
+                    ]
                 )
                 for t in ts
             ]
@@ -57,10 +67,7 @@ class Run(Command):
                 p.wait()
 
         elif service == "flower":
-            p = subprocess.Popen(
-                "celery --broker=redis://redis flower",
-                shell=True,
-            )
+            p = subprocess.Popen(["celery", "--broker", Config.broker_url, "flower"])
             p.wait()
 
         elif service == "reconciler":

--- a/osism/tasks/__init__.py
+++ b/osism/tasks/__init__.py
@@ -13,7 +13,7 @@ from pathlib import Path
 
 from loguru import logger
 
-from osism import utils
+from osism import settings, utils
 
 # Regex pattern for extracting hosts from Ansible output
 HOST_PATTERN = re.compile(r"^(ok|changed|failed|skipping|unreachable):\s+\[([^\]]+)\]")
@@ -23,11 +23,14 @@ class Config:
     broker_connection_retry_on_startup = True
     enable_utc = True
     enable_ironic = os.environ.get("ENABLE_IRONIC", "True")
-    broker_url = "redis://redis"
-    result_backend = "redis://redis"
+    broker_url = os.environ.get(
+        "CELERY_BROKER_URL",
+        f"redis://{settings.REDIS_HOST}:{settings.REDIS_PORT}/{settings.REDIS_DB}",
+    )
+    result_backend = os.environ.get("CELERY_RESULT_BACKEND", broker_url)
     task_create_missing_queues = True
     task_default_queue = "default"
-    task_track_started = (True,)
+    task_track_started = True
     task_routes = {
         "osism.tasks.ansible.*": {"queue": "osism-ansible"},
         "osism.tasks.ceph.*": {"queue": "ceph-ansible"},

--- a/playbooks/test-integration.yml
+++ b/playbooks/test-integration.yml
@@ -1,0 +1,43 @@
+---
+- name: Run integration tests
+  hosts: all
+
+  vars:
+    python_venv_dir: /tmp/venv
+
+  tasks:
+    - name: Start Redis container
+      ansible.builtin.shell:
+        executable: /bin/bash
+        cmd: |
+          set -e
+          set -o pipefail
+          set -x
+
+          docker run -d --name redis -p 6379:6379 redis:7-alpine
+      changed_when: true
+
+    - name: Install dependencies
+      ansible.builtin.shell:
+        executable: /bin/bash
+        chdir: "{{ zuul.project.src_dir }}"
+        cmd: |
+          set -e
+          set -o pipefail
+          set -x
+
+          {{ python_venv_dir }}/bin/pipenv install --dev --deploy
+          {{ python_venv_dir }}/bin/pipenv run pip install .
+
+    - name: Run pytest
+      ansible.builtin.shell:
+        executable: /bin/bash
+        chdir: "{{ zuul.project.src_dir }}"
+        cmd: |
+          set -e
+          set -o pipefail
+          set -x
+
+          {{ python_venv_dir }}/bin/pipenv run pytest tests/integration
+      environment:
+        REDIS_HOST: localhost

--- a/playbooks/test-integration.yml
+++ b/playbooks/test-integration.yml
@@ -17,6 +17,24 @@
           docker run -d --name redis -p 6379:6379 redis:7-alpine
       changed_when: true
 
+    - name: Wait for Redis to be ready
+      ansible.builtin.shell:
+        executable: /bin/bash
+        cmd: |
+          set -e
+          set -o pipefail
+          set -x
+
+          for i in $(seq 1 30); do
+            if docker exec redis redis-cli ping | grep -q PONG; then
+              exit 0
+            fi
+            sleep 1
+          done
+          echo "Redis did not become ready within 30s" >&2
+          exit 1
+      changed_when: false
+
     - name: Install dependencies
       ansible.builtin.shell:
         executable: /bin/bash
@@ -41,3 +59,6 @@
           {{ python_venv_dir }}/bin/pipenv run pytest tests/integration
       environment:
         REDIS_HOST: localhost
+        # Fail the session if Redis is unreachable instead of skipping every
+        # test, so a Redis-startup failure turns the job red rather than green.
+        OSISM_REQUIRE_REDIS: "1"

--- a/setup.cfg
+++ b/setup.cfg
@@ -180,3 +180,5 @@ python_files = test_*.py
 python_classes = Test*
 python_functions = test_*
 addopts = -ra --strict-markers
+markers =
+    integration: integration tests requiring a reachable Redis and a Celery worker (run with: pytest tests/integration)

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -25,7 +25,26 @@ WORKER_QUEUE = "osism-ansible"
 # Celery treats a ``-n`` value without ``@`` as the host part (yielding
 # ``celery@ci-worker``), so the node name must be given explicitly.
 WORKER_NAME = "ci-worker@%h"
+# Node-name prefix the worker registers under (``ci-worker@<hostname>``). Used
+# to gate readiness on *this* worker rather than any worker on the broker.
+WORKER_NODE_PREFIX = WORKER_NAME.split("@", 1)[0] + "@"
 WORKER_BOOT_TIMEOUT = 60
+
+
+def _require_redis():
+    """Return ``True`` when an unreachable Redis must fail the session.
+
+    Set ``OSISM_REQUIRE_REDIS=1`` (as the CI job does) to turn the
+    skip-when-unreachable behaviour into a hard failure, so a Redis-startup
+    problem surfaces as a red job instead of an all-skipped green one. Left
+    unset locally, the suite keeps skipping when Redis is not running.
+    """
+    return os.environ.get("OSISM_REQUIRE_REDIS", "").lower() not in (
+        "",
+        "0",
+        "false",
+        "no",
+    )
 
 
 def _redis_reachable():
@@ -49,12 +68,18 @@ def _redis_reachable():
 
 
 def pytest_collection_modifyitems(config, items):
-    """Skip integration-marked tests when Redis is not reachable."""
+    """Skip integration-marked tests when Redis is not reachable.
+
+    With ``OSISM_REQUIRE_REDIS`` set, an unreachable Redis fails the session
+    instead -- otherwise an all-skipped run exits 0 and a broken Redis would
+    pass the CI gate green.
+    """
     if _redis_reachable():
         return
-    skip = pytest.mark.skip(
-        reason=f"Redis is not reachable on {settings.REDIS_HOST}:{settings.REDIS_PORT}"
-    )
+    reason = f"Redis is not reachable on {settings.REDIS_HOST}:{settings.REDIS_PORT}"
+    if _require_redis():
+        pytest.exit(f"{reason} but OSISM_REQUIRE_REDIS is set", returncode=1)
+    skip = pytest.mark.skip(reason=reason)
     for item in items:
         if "integration" in item.keywords:
             item.add_marker(skip)
@@ -100,7 +125,10 @@ def celery_worker(celery_app):
                 raise RuntimeError(
                     f"Celery worker exited early with code {proc.returncode}"
                 )
-            if celery_app.control.inspect().ping():
+            # Gate on *this* worker, not any worker answering on the broker, so a
+            # shared local broker cannot let the fixture pass before it is up.
+            replies = celery_app.control.inspect().ping() or {}
+            if any(name.startswith(WORKER_NODE_PREFIX) for name in replies):
                 break
             time.sleep(1)
         else:

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -1,0 +1,117 @@
+# SPDX-License-Identifier: Apache-2.0
+
+"""Fixtures and skip logic shared by the Celery/Redis integration tests.
+
+These tests exercise the real task-processing core (broker, queue routing,
+worker, result backend, Redis streams and distributed locks) against a live
+Redis. They are skipped automatically when Redis is not reachable -- for
+example during a local ``pytest`` run without the service -- so the suite stays
+green outside the dedicated CI job.
+"""
+
+import os
+import subprocess
+import time
+
+import pytest
+
+from osism import settings
+
+# Only the ``ansible`` Celery app is used as worker: it has no import-time
+# dependency on NetBox, OpenStack or ansible-core, unlike the other task
+# modules. ``osism.tasks.ansible.*`` is routed to the ``osism-ansible`` queue.
+WORKER_APP = "osism.tasks.ansible"
+WORKER_QUEUE = "osism-ansible"
+# Celery treats a ``-n`` value without ``@`` as the host part (yielding
+# ``celery@ci-worker``), so the node name must be given explicitly.
+WORKER_NAME = "ci-worker@%h"
+WORKER_BOOT_TIMEOUT = 60
+
+
+def _redis_reachable():
+    """Return ``True`` when the configured Redis answers a ping."""
+    try:
+        from redis import Redis
+
+        client = Redis(
+            host=settings.REDIS_HOST,
+            port=settings.REDIS_PORT,
+            db=settings.REDIS_DB,
+            socket_connect_timeout=1,
+        )
+        try:
+            client.ping()
+        finally:
+            client.close()
+        return True
+    except Exception:
+        return False
+
+
+def pytest_collection_modifyitems(config, items):
+    """Skip integration-marked tests when Redis is not reachable."""
+    if _redis_reachable():
+        return
+    skip = pytest.mark.skip(
+        reason=f"Redis is not reachable on {settings.REDIS_HOST}:{settings.REDIS_PORT}"
+    )
+    for item in items:
+        if "integration" in item.keywords:
+            item.add_marker(skip)
+
+
+@pytest.fixture(scope="session")
+def celery_app():
+    """The ``ansible`` Celery app, configured from the live broker URL."""
+    from osism.tasks import ansible
+
+    return ansible.app
+
+
+@pytest.fixture(scope="session")
+def celery_worker(celery_app):
+    """Start a Celery worker for the ``osism-ansible`` queue for the session.
+
+    The worker runs from the same virtualenv as the tests.
+    ``GATHER_FACTS_SCHEDULE=0`` prevents registration of the periodic
+    ``gather_facts`` task, which would try to run ``/run.sh`` in containers that
+    do not exist in CI.
+    """
+    proc = subprocess.Popen(
+        [
+            "celery",
+            "-A",
+            WORKER_APP,
+            "worker",
+            "-n",
+            WORKER_NAME,
+            "-Q",
+            WORKER_QUEUE,
+            "-c",
+            "1",
+        ],
+        env={**os.environ, "GATHER_FACTS_SCHEDULE": "0"},
+    )
+
+    try:
+        deadline = time.time() + WORKER_BOOT_TIMEOUT
+        while time.time() < deadline:
+            if proc.poll() is not None:
+                raise RuntimeError(
+                    f"Celery worker exited early with code {proc.returncode}"
+                )
+            if celery_app.control.inspect().ping():
+                break
+            time.sleep(1)
+        else:
+            raise RuntimeError(
+                f"Celery worker did not become ready within {WORKER_BOOT_TIMEOUT}s"
+            )
+        yield proc
+    finally:
+        proc.terminate()
+        try:
+            proc.wait(timeout=30)
+        except subprocess.TimeoutExpired:
+            proc.kill()
+            proc.wait()

--- a/tests/integration/test_celery.py
+++ b/tests/integration/test_celery.py
@@ -1,0 +1,45 @@
+# SPDX-License-Identifier: Apache-2.0
+
+"""Celery round-trip and worker-visibility integration tests.
+
+These validate the broker, queue routing (``osism-ansible``), worker and result
+backend end-to-end against a live Redis and a worker started from the same
+virtualenv.
+"""
+
+import pytest
+
+pytestmark = pytest.mark.integration
+
+
+def test_noop_round_trip(celery_worker):
+    """Dispatching ``noop`` returns ``True`` through the result backend.
+
+    A single round-trip exercises the broker, the ``osism-ansible`` queue
+    routing, the worker and the result backend.
+    """
+    from osism.tasks import ansible
+
+    result = ansible.noop.delay()
+
+    assert result.get(timeout=60) is True
+
+
+def test_worker_is_visible(celery_worker):
+    """``app.control.inspect().ping()`` sees the running worker.
+
+    This is the mechanism behind ``osism get status workers``: a fresh Celery
+    client configured from ``Config`` inspects the worker over the broker. The
+    ``celery_worker`` fixture starts it as ``ci-worker@<hostname>``.
+    """
+    from celery import Celery
+
+    from osism.tasks import Config
+
+    app = Celery("status")
+    app.config_from_object(Config)
+
+    replies = app.control.inspect().ping()
+
+    assert replies
+    assert any(name.startswith("ci-worker@") for name in replies)

--- a/tests/integration/test_locking.py
+++ b/tests/integration/test_locking.py
@@ -1,0 +1,41 @@
+# SPDX-License-Identifier: Apache-2.0
+
+"""Distributed-locking integration tests against a live Redis.
+
+Covers the Redlock helper used by ``run_ansible_in_environment`` for per-play
+locking and the task-lock flag used by ``osism lock`` / ``osism unlock``.
+"""
+
+import uuid
+
+import pytest
+
+from osism import utils
+
+pytestmark = pytest.mark.integration
+
+
+def test_redlock_acquire_and_release():
+    """A Redlock can be acquired and released against the live Redis."""
+    lock = utils.create_redlock(key=f"itest-lock-{uuid.uuid4()}")
+
+    assert lock.acquire(timeout=10)
+    lock.release()
+
+
+def test_task_lock_set_check_remove():
+    """``set_task_lock`` / ``is_task_locked`` / ``remove_task_lock`` round-trip."""
+    # Start from a known-unlocked state so the test is independent of prior runs.
+    utils.remove_task_lock()
+    assert utils.is_task_locked() is None
+
+    assert utils.set_task_lock(user="tester", reason="integration test") is True
+
+    lock_info = utils.is_task_locked()
+    assert lock_info is not None
+    assert lock_info["locked"] is True
+    assert lock_info["user"] == "tester"
+    assert lock_info["reason"] == "integration test"
+
+    assert utils.remove_task_lock() is True
+    assert utils.is_task_locked() is None

--- a/tests/integration/test_redis_streams.py
+++ b/tests/integration/test_redis_streams.py
@@ -1,0 +1,30 @@
+# SPDX-License-Identifier: Apache-2.0
+
+"""Redis-streams task-output integration tests.
+
+``push_task_output`` / ``finish_task_output`` / ``fetch_task_output`` are the
+mechanism ``osism apply`` uses to stream task logs; they round-trip through a
+Redis stream keyed by the task id and are testable with Redis alone.
+"""
+
+import uuid
+
+import pytest
+
+from osism import utils
+
+pytestmark = pytest.mark.integration
+
+
+def test_task_output_round_trip(capsys):
+    """Output pushed to a task stream is read back with its return code."""
+    task_id = f"itest-{uuid.uuid4()}"
+
+    utils.push_task_output(task_id, "first line\n")
+    utils.push_task_output(task_id, "second line\n")
+    utils.finish_task_output(task_id, rc=3)
+
+    rc = utils.fetch_task_output(task_id, timeout=10)
+
+    assert rc == 3
+    assert capsys.readouterr().out == "first line\nsecond line\n"

--- a/tests/unit/tasks/test_config.py
+++ b/tests/unit/tasks/test_config.py
@@ -1,0 +1,107 @@
+# SPDX-License-Identifier: Apache-2.0
+
+"""Unit tests for the Celery ``Config`` broker/result-backend precedence.
+
+``Config.broker_url`` and ``Config.result_backend`` are class attributes
+resolved once at import time from the (also import-frozen) ``settings.REDIS_*``
+values. Asserting the precedence logic therefore requires reloading both
+``osism.settings`` and ``osism.tasks`` after changing the environment --
+``monkeypatch.setenv`` alone would leave the cached attributes in place and the
+test would pass for the wrong reason.
+"""
+
+import importlib
+
+import pytest
+
+import osism.settings
+import osism.tasks
+
+# Environment variables that feed ``broker_url`` / ``result_backend``.
+CELERY_ENV = (
+    "CELERY_BROKER_URL",
+    "CELERY_RESULT_BACKEND",
+    "REDIS_HOST",
+    "REDIS_PORT",
+    "REDIS_DB",
+)
+
+
+@pytest.fixture(autouse=True)
+def _restore_task_config():
+    """Reload ``settings`` / ``osism.tasks`` after each test.
+
+    Without this the reloaded modules would leak a test's custom environment
+    (frozen into ``Config``) into later tests.
+    """
+    yield
+    importlib.reload(osism.settings)
+    importlib.reload(osism.tasks)
+
+
+@pytest.fixture
+def config_with_env(monkeypatch):
+    """Return a fresh ``Config`` after applying ``env`` and reloading modules."""
+
+    def _build(env):
+        for key in CELERY_ENV:
+            monkeypatch.delenv(key, raising=False)
+        for key, value in env.items():
+            monkeypatch.setenv(key, value)
+        importlib.reload(osism.settings)
+        importlib.reload(osism.tasks)
+        return osism.tasks.Config
+
+    return _build
+
+
+def test_broker_url_derived_from_redis_settings(config_with_env):
+    """Without an override, ``broker_url`` is derived from ``REDIS_*``."""
+    config = config_with_env(
+        {"REDIS_HOST": "redis.example", "REDIS_PORT": "6399", "REDIS_DB": "5"}
+    )
+
+    assert config.broker_url == "redis://redis.example:6399/5"
+
+
+def test_celery_broker_url_overrides_derived(config_with_env):
+    """``CELERY_BROKER_URL`` wins over the derived ``REDIS_*`` URL."""
+    config = config_with_env(
+        {
+            "REDIS_HOST": "redis.example",
+            "REDIS_PORT": "6399",
+            "REDIS_DB": "5",
+            "CELERY_BROKER_URL": "redis://broker.example:6380/2",
+        }
+    )
+
+    assert config.broker_url == "redis://broker.example:6380/2"
+
+
+def test_result_backend_overrides_independently(config_with_env):
+    """``CELERY_RESULT_BACKEND`` overrides independently of the broker URL."""
+    config = config_with_env(
+        {
+            "CELERY_BROKER_URL": "redis://broker.example:6380/2",
+            "CELERY_RESULT_BACKEND": "redis://backend.example:6381/3",
+        }
+    )
+
+    assert config.broker_url == "redis://broker.example:6380/2"
+    assert config.result_backend == "redis://backend.example:6381/3"
+
+
+def test_result_backend_defaults_to_broker_url(config_with_env):
+    """Absent ``CELERY_RESULT_BACKEND``, ``result_backend`` equals ``broker_url``."""
+    config = config_with_env(
+        {"REDIS_HOST": "redis", "REDIS_PORT": "6379", "REDIS_DB": "0"}
+    )
+
+    assert config.result_backend == config.broker_url
+
+
+def test_task_track_started_is_true(config_with_env):
+    """``task_track_started`` is the boolean ``True`` (not a truthy 1-tuple)."""
+    config = config_with_env({})
+
+    assert config.task_track_started is True


### PR DESCRIPTION
Closes #2368.

Adds a lightweight integration-test job that covers the Celery/Redis
task-processing core (broker, queue routing, worker, result backend, Redis
streams for task output, distributed locks) end-to-end in CI, plus the
prerequisite that makes the broker URL configurable.

## Change set (in commit order)

### 1. Derive Celery broker URL from settings and environment
`osism/tasks/__init__.py`, `osism/commands/service.py`

- `Config.broker_url` / `Config.result_backend` were hardcoded to
  `redis://redis`, with the same literals duplicated in the `beat` and
  `flower` service commands. They now derive from `REDIS_HOST` /
  `REDIS_PORT` / `REDIS_DB` (the same settings `osism.utils._init_redis`
  already honors), overridable via `CELERY_BROKER_URL` /
  `CELERY_RESULT_BACKEND`. The default of `REDIS_HOST` is `redis`, so this
  is backwards compatible.
- `service.py` now references `Config.broker_url` (single source of truth)
  for `beat`/`flower`, removing the duplicated literals.
- Fixed `task_track_started`, which was the tuple `(True,)` instead of the
  intended bool (it only worked because a non-empty tuple is truthy).

This is what lets the tests point Celery at a local Redis via
`REDIS_HOST=localhost`.

### 2. Add Celery/Redis integration tests
`tests/integration/`, `setup.cfg`, `README.md`

- `test_celery.py` — **round-trip**: `ansible.noop.delay()` →
  `result.get(timeout=60) is True` (broker + `osism-ansible` routing +
  worker + result backend); **worker visibility**: a fresh `Celery`
  client configured from `Config` sees the worker via
  `inspect().ping()` (the mechanism behind `osism get status workers`).
- `test_redis_streams.py` — `push_task_output` / `finish_task_output` /
  `fetch_task_output` round-trip (the path `osism apply` uses to stream
  logs).
- `test_locking.py` — `create_redlock` acquire/release and
  `set_task_lock` / `is_task_locked` / `remove_task_lock`.
- `conftest.py` starts the worker as a session-scoped fixture from the
  same venv, running only the `ansible` Celery app (no import-time
  dependency on NetBox/OpenStack/ansible-core) with
  `GATHER_FACTS_SCHEDULE=0` so the periodic `gather_facts` task is not
  registered. It polls `inspect().ping()` until the worker is ready and
  terminates it on teardown.
- Tests carry an `integration` marker (registered in `setup.cfg` for the
  `--strict-markers` run) and are **skipped when Redis is not reachable**,
  so a local `pytest` is unaffected.

### 3. Add Zuul integration-test job
`.zuul.yaml`, `playbooks/test-integration.yml`

- New `python-osism-integration-tests` job added to the `check` and
  `periodic-daily` pipelines. It reuses `playbooks/pre.yml` (which already
  sets up Docker via `ensure-docker`), starts a `redis:7-alpine`
  container, installs the package with pipenv exactly like the unit-test
  job, and runs `pytest tests/integration` with `REDIS_HOST=localhost`.

## Notes / deviations

- The unit-test job is already restricted to `tests/unit` via
  `testpaths = tests/unit` in `setup.cfg`, so a bare `pytest` never
  collects `tests/integration` — the issue's first concern is already
  satisfied. The `integration` marker + Redis-reachability skip are still
  added (the marker is required by `--strict-markers`, and the skip keeps
  `pytest tests/integration` green locally without Redis).
- No `CHANGELOG.md` entry: this repo maintains the changelog in batched,
  post-release commits that map merged PR numbers to release versions, so
  per-PR entries are out of convention here.
- Follow-ups listed in the issue (compose-based variant, API/beat/revoke
  coverage) are intentionally out of scope.

## Local verification

- `black --check` — clean (6 files)
- `flake8` — clean
- `pytest tests/integration` — not run locally (no Redis); exercised by
  the new CI job.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
