### PR TITLE
Add an osism openstack command that wraps the OpenStack CLI

### DIFF
--- a/osism/commands/openstack.py
+++ b/osism/commands/openstack.py
@@ -1,0 +1,128 @@
+# SPDX-License-Identifier: Apache-2.0
+
+import argparse
+import subprocess
+
+from cliff.command import Command
+from loguru import logger
+
+
+class _PassthroughParser(argparse.ArgumentParser):
+    """Argument parser for a transparent OpenStack CLI passthrough.
+
+    ``argparse.REMAINDER`` only starts capturing at the first *positional*
+    token, so any OpenStack global option placed before the subcommand
+    (``--os-interface``, ``--os-region-name``, ...) would be matched against
+    this wrapper's own options and rejected. cliff calls ``parse_args()`` in
+    ``App.run_subcommand``; delegating that to ``parse_known_args()`` lets the
+    wrapper consume only its own options (``--cloud``) and forward everything
+    else verbatim, preserving order.
+
+    Note: cliff's *app-level* parser still consumes its own global options
+    (``--debug``, ``-v``/``-q``, ``--log-file``) before this parser ever runs,
+    so those cannot be forwarded to the OpenStack CLI.
+    """
+
+    def parse_args(self, args=None, namespace=None):
+        namespace, arguments = self.parse_known_args(args, namespace)
+        namespace.arguments = arguments
+        return namespace
+
+
+class Run(Command):
+    """Run the OpenStack CLI against a configured cloud.
+
+    Everything other than the ``--cloud`` selector is forwarded verbatim to
+    the ``openstack`` CLI, including global options that precede the
+    subcommand, e.g. ``osism openstack --os-region-name RegionOne server
+    list``. Select the cloud profile with ``--cloud`` rather than
+    ``--os-cloud``; the latter is injected automatically and rejected when
+    passed through.
+    """
+
+    def get_parser(self, prog_name):
+        # Build our own parser instead of super().get_parser(): we need the
+        # _PassthroughParser class, allow_abbrev=False so a forwarded token
+        # like "--clou" is not silently expanded to this wrapper's --cloud,
+        # and add_help=False so -h/--help is forwarded to the OpenStack CLI.
+        parser = _PassthroughParser(
+            prog=prog_name,
+            description=self.get_description(),
+            add_help=False,
+            allow_abbrev=False,
+        )
+        parser.add_argument(
+            "--cloud",
+            type=str,
+            default="admin",
+            help="Cloud name in clouds.yaml (default: %(default)s)",
+        )
+        return parser
+
+    def take_action(self, parsed_args):
+        from osism.tasks.openstack import get_cloud_helpers
+
+        # The cloud profile is selected with --cloud; injecting it as
+        # --os-cloud as well would be ambiguous and order-dependent. This is a
+        # best-effort guard: it matches "--os-cloud"/"--os-cloud=" exactly and
+        # does not catch an argparse-style abbreviation (e.g. "--os-clou") that
+        # openstackclient might still expand downstream.
+        if any(
+            arg == "--os-cloud" or arg.startswith("--os-cloud=")
+            for arg in parsed_args.arguments
+        ):
+            logger.error(
+                "Do not pass '--os-cloud' through to the OpenStack CLI; "
+                "use the '--cloud' option to select the cloud profile."
+            )
+            return 1
+
+        setup_cloud_environment, _, cleanup_cloud_environment = get_cloud_helpers()
+
+        _, temp_files, original_cwd, success = setup_cloud_environment(
+            parsed_args.cloud
+        )
+        # setup_cloud_environment may have copied temp files and/or changed the
+        # working directory before failing, so always clean up once it ran.
+        try:
+            if not success:
+                logger.error(
+                    f"Failed to set up cloud environment for '{parsed_args.cloud}'"
+                )
+                return 1
+
+            command = ["openstack", "--os-cloud", parsed_args.cloud] + list(
+                parsed_args.arguments
+            )
+            # Log only the leading subcommand tokens and an argument count: the
+            # forwarded vector routinely carries secrets (e.g. 'user create
+            # --password ...', '--secret ...') that must not end up in durable
+            # debug logs.
+            subcommand = []
+            for arg in parsed_args.arguments:
+                if arg.startswith("-"):
+                    break
+                subcommand.append(arg)
+            logger.debug(
+                "Running 'openstack {}' against cloud '{}' ({} argument(s))".format(
+                    " ".join(subcommand) or "<no subcommand>",
+                    parsed_args.cloud,
+                    len(parsed_args.arguments),
+                )
+            )
+
+            try:
+                # No shell=True and command is a list, so the passed-through
+                # arguments are exec'd directly without shell interpretation;
+                # this is an intentional, transparent CLI passthrough.
+                # nosemgrep: python.lang.security.audit.dangerous-subprocess-use-audit
+                result = subprocess.run(command, check=False)
+                return result.returncode
+            except FileNotFoundError:
+                logger.error(
+                    "OpenStack CLI ('openstack') not found. "
+                    "Is python-openstackclient installed in the image?"
+                )
+                return 1
+        finally:
+            cleanup_cloud_environment(temp_files, original_cwd)

--- a/requirements.txt
+++ b/requirements.txt
@@ -26,6 +26,7 @@ prompt-toolkit==3.0.52
 pynetbox==7.7.0
 pytest-testinfra==10.2.2
 python-dateutil==2.9.0.post0
+python-openstackclient==9.0.0
 redfish==3.3.5
 setuptools==82.0.1
 sqlmodel==0.0.38

--- a/setup.cfg
+++ b/setup.cfg
@@ -95,6 +95,7 @@ osism.commands:
     manage redfish list = osism.commands.redfish:List
     manage server list = osism.commands.server:ServerList
     manage server clean = osism.commands.server:ServerClean
+    openstack = osism.commands.openstack:Run
     openstack stress = osism.commands.stress:OpenStackStress
     manage server migrate = osism.commands.server:ServerMigrate
     manage loadbalancer list = osism.commands.loadbalancer:LoadbalancerList

--- a/tests/unit/commands/test_openstack.py
+++ b/tests/unit/commands/test_openstack.py
@@ -1,0 +1,187 @@
+# SPDX-License-Identifier: Apache-2.0
+
+"""Tests for the ``osism openstack`` passthrough command.
+
+These cover the wrapper contract:
+
+- subcommands and parameters are passed straight through to the
+  ``openstack`` CLI, defaulting to the ``admin`` cloud;
+- OpenStack global options that precede the subcommand (e.g.
+  ``--os-interface``, ``--os-region-name``) are forwarded verbatim
+  rather than rejected;
+- ``--cloud`` selects a different cloud profile;
+- passing ``--os-cloud`` through is rejected in favour of ``--cloud``;
+- a failed cloud setup short-circuits before the CLI is invoked but
+  still cleans up the (possibly partial) cloud environment;
+- the CLI's exit code is propagated as the command's return code;
+- registering ``openstack`` alongside ``openstack stress`` does not
+  shadow the existing stress subcommand (cliff longest-prefix routing).
+"""
+
+from unittest.mock import MagicMock, patch
+
+from osism.commands import openstack
+
+
+def _run(args, *, setup_return, run_returncode=0):
+    cmd = openstack.Run(MagicMock(), MagicMock())
+    parsed_args = cmd.get_parser("test").parse_args(args)
+
+    setup = MagicMock(return_value=setup_return)
+    cleanup = MagicMock()
+    run = MagicMock()
+    run.return_value.returncode = run_returncode
+
+    with patch(
+        "osism.tasks.openstack.get_cloud_helpers",
+        return_value=(setup, MagicMock(), cleanup),
+    ), patch("osism.commands.openstack.subprocess.run", run):
+        result = cmd.take_action(parsed_args)
+
+    return result, setup, cleanup, run
+
+
+def test_passes_arguments_through_with_default_cloud():
+    result, setup, cleanup, run = _run(
+        ["server", "list", "-f", "json"],
+        setup_return=(None, ["/tmp/clouds.yaml"], "/orig", True),
+    )
+
+    assert result == 0
+    setup.assert_called_once_with("admin")
+    run.assert_called_once()
+    assert run.call_args.args[0] == [
+        "openstack",
+        "--os-cloud",
+        "admin",
+        "server",
+        "list",
+        "-f",
+        "json",
+    ]
+    cleanup.assert_called_once_with(["/tmp/clouds.yaml"], "/orig")
+
+
+def test_forwards_leading_global_options():
+    # Regression test for the passthrough contract: OpenStack global options
+    # placed *before* the subcommand must be forwarded verbatim, not rejected.
+    # argparse.REMAINDER captures only from the first positional token, so the
+    # parser delegates to parse_known_args to keep these intact.
+    #
+    # cliff's *app-level* parser consumes its own globals (--debug, -v/-q,
+    # --log-file) before this command's parser runs, so those never reach the
+    # passthrough and are intentionally not exercised here; --os-interface /
+    # --os-region-name are forwarded because the app parser does not know them.
+    result, setup, cleanup, run = _run(
+        ["--os-interface", "public", "--os-region-name", "RegionOne", "server", "list"],
+        setup_return=(None, [], "/orig", True),
+    )
+
+    assert result == 0
+    setup.assert_called_once_with("admin")
+    assert run.call_args.args[0] == [
+        "openstack",
+        "--os-cloud",
+        "admin",
+        "--os-interface",
+        "public",
+        "--os-region-name",
+        "RegionOne",
+        "server",
+        "list",
+    ]
+
+
+def test_cloud_option_selects_cloud():
+    result, setup, cleanup, run = _run(
+        ["--cloud", "octavia", "image", "list"],
+        setup_return=(None, [], "/orig", True),
+    )
+
+    assert result == 0
+    setup.assert_called_once_with("octavia")
+    assert run.call_args.args[0][:5] == [
+        "openstack",
+        "--os-cloud",
+        "octavia",
+        "image",
+        "list",
+    ]
+
+
+def test_returns_one_when_cloud_setup_fails():
+    result, setup, cleanup, run = _run(
+        ["server", "list"],
+        setup_return=(None, ["/tmp/clouds.yaml"], "/orig", False),
+    )
+
+    assert result == 1
+    run.assert_not_called()
+    # setup may have copied temp files / changed cwd before failing, so the
+    # environment is still cleaned up.
+    cleanup.assert_called_once_with(["/tmp/clouds.yaml"], "/orig")
+
+
+def test_rejects_passed_through_os_cloud():
+    for args in (
+        ["server", "list", "--os-cloud", "other"],
+        ["server", "list", "--os-cloud=other"],
+    ):
+        result, setup, cleanup, run = _run(
+            args,
+            setup_return=(None, [], "/orig", True),
+        )
+
+        assert result == 1
+        setup.assert_not_called()
+        run.assert_not_called()
+        cleanup.assert_not_called()
+
+
+def test_propagates_openstack_exit_code():
+    result, setup, cleanup, run = _run(
+        ["server", "show", "missing"],
+        setup_return=(None, [], "/orig", True),
+        run_returncode=2,
+    )
+
+    assert result == 2
+    cleanup.assert_called_once()
+
+
+def test_returns_one_when_openstack_binary_missing():
+    cmd = openstack.Run(MagicMock(), MagicMock())
+    parsed_args = cmd.get_parser("test").parse_args(["server", "list"])
+
+    setup = MagicMock(return_value=(None, [], "/orig", True))
+    cleanup = MagicMock()
+
+    with patch(
+        "osism.tasks.openstack.get_cloud_helpers",
+        return_value=(setup, MagicMock(), cleanup),
+    ), patch(
+        "osism.commands.openstack.subprocess.run",
+        side_effect=FileNotFoundError,
+    ):
+        result = cmd.take_action(parsed_args)
+
+    assert result == 1
+    cleanup.assert_called_once_with([], "/orig")
+
+
+def test_openstack_subcommands_route_correctly():
+    from cliff.commandmanager import CommandManager
+
+    # CommandManager reads *installed* entry-point metadata, not the source
+    # tree, so this assertion depends on a current editable install. After
+    # editing setup.cfg without reinstalling, stale egg-info makes this fail
+    # with a misleading "Unknown command ..."; it is green in CI (fresh
+    # install) and after `pip install -e .` locally.
+    manager = CommandManager("osism.commands")
+
+    _, stress_name, _ = manager.find_command(["openstack", "stress"])
+    assert stress_name == "openstack stress"
+
+    _, name, remainder = manager.find_command(["openstack", "server", "list"])
+    assert name == "openstack"
+    assert remainder == ["server", "list"]


### PR DESCRIPTION
## Summary

Adds an `osism openstack` command that transparently wraps the OpenStack
CLI from inside the osism container image. It passes all subcommands and
parameters straight through to the `openstack` client, defaults to the
`admin` cloud, and lets the cloud be selected with `--cloud`.

Credentials are loaded the same way the flavor-manager and image-manager
do — via `setup_cloud_environment`/`get_cloud_helpers` from
`osism/tasks/openstack.py`, which decrypts `secrets.yml`/`secure.yml`
from the configuration repository. This removes the need for a separate
openstack container that cannot read the encrypted `secure.yml`.

The command runs the client in-process (`subprocess.run`), structurally
mirroring the existing `osism openstack stress` command, so stdout/stderr
and the exit code pass through unmodified — the behaviour an operator
expects from a transparent wrapper.

Closes #2391

## Changes (in commit order)

1. **Declare `python-openstackclient` runtime dependency** —
   `requirements.txt`. The `openstack` binary the command shells out to
   ships with `python-openstackclient`, which was not a declared
   dependency (only the `openstacksdk` library was). Pinned to `9.0.0`,
   the highest release compatible with the pinned `openstacksdk==4.10.0`
   (it requires `openstacksdk>=4.6.0`; 10.x requires `>=4.12.0`/`>=4.14.0`
   and would conflict).
2. **Add and register `osism openstack` passthrough command** —
   `osism/commands/openstack.py` + `setup.cfg`. The command and its entry
   point land together so the CLI is never half-registered. `--os-cloud`
   is injected so the client selects the profile whose password
   `setup_cloud_environment` wrote into the temporary `clouds.yaml`.
   Both `openstack` and the existing `openstack stress` entry points are
   registered; cliff resolves the longest matching command prefix, so
   `openstack stress` keeps routing to `OpenStackStress` while
   `openstack server list` routes to the new command.
3. **Add unit tests** — `tests/unit/commands/test_openstack.py`. Cover
   argument passthrough with the default `admin` cloud, `--cloud`
   selection, the setup-failure short circuit, exit-code propagation, a
   missing `openstack` binary, and the cliff routing coexistence with
   `openstack stress`.
4. **Document `osism openstack` in CHANGELOG** — `CHANGELOG.md`.

## Notes for reviewers

- **Execution model.** The issue says load credentials "the same way the
  flavor-manager and image-manager do," which dispatch a Celery task on
  the `openstack` worker queue. This change reuses the *same credential
  helpers* but runs the client **in-process** (like `osism openstack
  stress`) rather than via a Celery task. Only the in-process model
  delivers a true transparent wrapper — real exit codes and stdio/TTY
  passthrough; a Celery round-trip would stream output through Redis and
  lose exit-code/interactivity transparency.
- **`stress` is now a reserved word under `osism openstack`.** Plain
  `openstack` has no `stress` subcommand, so nothing real is lost.
- **Working directory.** `setup_cloud_environment` `os.chdir("/tmp")`, so
  relative paths in passed-through commands resolve against `/tmp`. This
  is pre-existing behaviour shared with `stress`/the managers, not
  introduced here.

---

_Drafted by [planwerk-review](https://github.com/planwerk/planwerk-review) e69a237 with Claude:claude-opus-4-8_
