### PR TITLE
Show Ironic UUID in baremetal list

### DIFF
--- a/osism/commands/baremetal.py
+++ b/osism/commands/baremetal.py
@@ -84,6 +84,7 @@ class BaremetalList(Command):
             for b in baremetal:
                 row = [
                     b["name"],
+                    b["id"],
                     b["power_state"] if b["power_state"] is not None else "n/a",
                     b["provision_state"],
                     b["maintenance"],
@@ -94,6 +95,7 @@ class BaremetalList(Command):
 
             headers = [
                 "Name",
+                "UUID",
                 "Power State",
                 "Provision State",
                 "Maintenance",
@@ -104,8 +106,8 @@ class BaremetalList(Command):
 
                 for row in result:
                     info = get_baremetal_node_netbox_info(row[0])
-                    row.insert(1, info.get("device_role") or "N/A")
-                headers.insert(1, "Device Role")
+                    row.insert(2, info.get("device_role") or "N/A")
+                headers.insert(2, "Device Role")
 
             print(
                 tabulate(

--- a/tests/unit/commands/test_baremetal.py
+++ b/tests/unit/commands/test_baremetal.py
@@ -46,6 +46,38 @@ def test_node_not_found_returns_1(cls):
     assert _run_not_found(cls) == 1
 
 
+# --- BaremetalList output ---
+
+
+def test_list_includes_uuid_column(capsys):
+    # The node UUID must be shown so it can be cross-referenced with Ironic logs.
+    cmd = baremetal.BaremetalList(MagicMock(), MagicMock())
+    parsed_args = cmd.get_parser("test").parse_args([])
+
+    node = {
+        "name": "node1",
+        "id": "11111111-2222-3333-4444-555555555555",
+        "power_state": "power on",
+        "provision_state": "active",
+        "maintenance": False,
+    }
+    conn = MagicMock()
+    conn.baremetal.nodes.return_value = [node]
+
+    setup = MagicMock(return_value=("pw", [], None, True))
+    getconn = MagicMock(return_value=conn)
+    cleanup = MagicMock()
+    with patch(
+        "osism.tasks.openstack.get_cloud_helpers",
+        return_value=(setup, getconn, cleanup),
+    ):
+        cmd.take_action(parsed_args)
+
+    out = capsys.readouterr().out
+    assert "UUID" in out
+    assert node["id"] in out
+
+
 # --- BaremetalDump failure paths ---
 
 


### PR DESCRIPTION
Adds a `UUID` column to the output of `osism baremetal list` so node UUIDs are visible and can be cross-referenced with Ironic logs and other tooling.

The UUID is read from the node's `id` field, consistent with how the rest of the baremetal commands reference it. With `--netbox`, the column order stays `Name, UUID, Device Role, Power State, Provision State, Maintenance`.

A success-path test for `BaremetalList` is added that verifies both the `UUID` header and the node UUID appear in the output.

Closes osism/issues#1394

🤖 Generated with [Claude Code](https://claude.com/claude-code)