### PR TITLE
sonic: Use auth-priv for group access

### DIFF
--- a/files/sonic/config_db.json
+++ b/files/sonic/config_db.json
@@ -420,7 +420,7 @@
         "monitoring": {}
     },
     "SNMP_SERVER_GROUP_ACCESS": {
-        "monitoring|Default|usm|auth-no-priv": {
+        "monitoring|Default|usm|auth-priv": {
             "contextMatch": "exact",
             "notifyView": "None",
             "readView": "rview",


### PR DESCRIPTION
We create user accounts with auth-priv, make sure the group policy matches.