### PR TITLE
Drop next-generation mariadb/rabbitmq/loadbalancer roles

### DIFF
--- a/osism/commands/apply.py
+++ b/osism/commands/apply.py
@@ -279,7 +279,6 @@ class Run(Command):
         timeout,
         task_timeout,
     ):
-        from celery import group
         from osism.data.playbooks import MAP_ROLE2ENVIRONMENT, MAP_ROLE2RUNTIME
         from osism.tasks import ansible, ceph, kolla, kubernetes
 
@@ -312,24 +311,6 @@ class Run(Command):
             t = kubernetes.run.si(
                 environment, role, arguments, auto_release_time=task_timeout
             )
-        elif role == "loadbalancer-ng":
-            if sub:
-                environment = f"{environment}.{sub}"
-            g = group(
-                kolla.run.si(
-                    environment, playbook, arguments, auto_release_time=task_timeout
-                )
-                for playbook in enums.LOADBALANCER_PLAYBOOKS
-            )
-            t = (
-                kolla.run.si(
-                    environment,
-                    "loadbalancer-ng",
-                    arguments,
-                    auto_release_time=task_timeout,
-                )
-                | g
-            )
         elif environment == "kolla":
             if sub:
                 environment = f"{environment}.{sub}"
@@ -337,10 +318,7 @@ class Run(Command):
             if role.startswith("kolla-"):
                 role = role[6:]
 
-            if role in ["mariadb-ng", "rabbitmq-ng"]:
-                kolla_arguments = [f"-e kolla_action_ng={action}"] + arguments
-            else:
-                kolla_arguments = [f"-e kolla_action={action}"] + arguments
+            kolla_arguments = [f"-e kolla_action={action}"] + arguments
 
             if (
                 role not in ["common"]

--- a/osism/data/enums.py
+++ b/osism/data/enums.py
@@ -23,34 +23,6 @@ class Role:
         self.dependencies = dependencies or []
 
 
-LOADBALANCER_PLAYBOOKS = [
-    "loadbalancer-aodh",
-    "loadbalancer-barbican",
-    "loadbalancer-blazar",
-    "loadbalancer-ceph-rgw",
-    "loadbalancer-cinder",
-    "loadbalancer-designate",
-    "loadbalancer-glance",
-    "loadbalancer-gnocchi",
-    "loadbalancer-grafana",
-    "loadbalancer-heat",
-    "loadbalancer-horizon",
-    "loadbalancer-ironic",
-    "loadbalancer-keystone",
-    "loadbalancer-magnum",
-    "loadbalancer-manila",
-    "loadbalancer-mariadb",
-    "loadbalancer-memcached",
-    "loadbalancer-neutron",
-    "loadbalancer-nova",
-    "loadbalancer-octavia",
-    "loadbalancer-opensearch",
-    "loadbalancer-placement",
-    "loadbalancer-prometheus",
-    "loadbalancer-rabbitmq",
-    "loadbalancer-skydive",
-]
-
 VALIDATE_PLAYBOOKS = {
     "barbican-config": {
         "runtime": "kolla-ansible",
@@ -158,7 +130,7 @@ MAP_ROLE2ROLE = {
                     dependencies=[
                         Role("opensearch"),
                         Role(
-                            "mariadb-ng",
+                            "mariadb",
                             dependencies=[
                                 Role("horizon"),
                                 Role(
@@ -187,7 +159,7 @@ MAP_ROLE2ROLE = {
                 Role("openvswitch", dependencies=[Role("ovn")]),
                 Role("memcached"),
                 Role("redis"),
-                Role("rabbitmq-ng"),
+                Role("rabbitmq"),
             ],
         ),
         Role(
@@ -242,13 +214,13 @@ MAP_ROLE2ROLE = {
                     dependencies=[
                         Role("letsencrypt"),
                         Role("opensearch"),
-                        Role("mariadb-ng"),
+                        Role("mariadb"),
                     ],
                 ),
                 Role("openvswitch", dependencies=[Role("ovn")]),
                 Role("memcached"),
                 Role("redis"),
-                Role("rabbitmq-ng"),
+                Role("rabbitmq"),
             ],
         ),
     ],
@@ -386,13 +358,13 @@ MAP_ROLE2ROLE = {
                     dependencies=[
                         Role("letsencrypt"),
                         Role("opensearch"),
-                        Role("mariadb-ng"),
+                        Role("mariadb"),
                     ],
                 ),
                 Role("openvswitch", dependencies=[Role("ovn")]),
                 Role("memcached"),
                 Role("redis"),
-                Role("rabbitmq-ng"),
+                Role("rabbitmq"),
             ],
         ),
     ],

--- a/tests/unit/data/test_enums.py
+++ b/tests/unit/data/test_enums.py
@@ -1,7 +1,6 @@
 # SPDX-License-Identifier: Apache-2.0
 
 from osism.data.enums import (
-    LOADBALANCER_PLAYBOOKS,
     MAP_ROLE2ROLE,
     VALIDATE_PLAYBOOKS,
     Role,
@@ -95,38 +94,6 @@ def test_role_accepts_nested_dependencies():
 
     assert role.dependencies[0].name == "neutron"
     assert role.dependencies[0].dependencies[0].name == "nova"
-
-
-# ---------------------------------------------------------------------------
-# LOADBALANCER_PLAYBOOKS
-# ---------------------------------------------------------------------------
-
-
-def test_loadbalancer_playbooks_is_non_empty_list():
-    assert isinstance(LOADBALANCER_PLAYBOOKS, list)
-    assert LOADBALANCER_PLAYBOOKS
-
-
-def test_loadbalancer_playbooks_entries_are_non_empty_strings():
-    for entry in LOADBALANCER_PLAYBOOKS:
-        assert isinstance(entry, str)
-        assert entry
-
-
-def test_loadbalancer_playbooks_entries_share_prefix():
-    for entry in LOADBALANCER_PLAYBOOKS:
-        assert entry.startswith("loadbalancer-")
-
-
-def test_loadbalancer_playbooks_entries_have_service_suffix():
-    for entry in LOADBALANCER_PLAYBOOKS:
-        suffix = entry.removeprefix("loadbalancer-")
-        assert suffix
-        assert not suffix.startswith("-")
-
-
-def test_loadbalancer_playbooks_has_no_duplicates():
-    assert len(LOADBALANCER_PLAYBOOKS) == len(set(LOADBALANCER_PLAYBOOKS))
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## What

Stops referencing the `-ng` roles and uses the regular `mariadb`, `rabbitmq` and `loadbalancer` roles instead.

## Why

The "next generation" plays were only ever a tech preview intended to improve the regular mariadb/rabbitmq/loadbalancer plays. They were never maintained intensively. Removing the client-side references avoids confusion with the actual roles.

This complements the removal of the `kolla-*-ng` playbooks in osism/container-image-kolla-ansible#929.

## Details

- Renamed the `mariadb-ng` and `rabbitmq-ng` roles to `mariadb` and `rabbitmq` in `MAP_ROLE2ROLE`, keeping their dependency trees intact.
- Dropped the `loadbalancer-ng` special case in `apply`, so `loadbalancer` runs through the regular kolla path.
- Removed the now-unused `kolla_action_ng` handling and the `LOADBALANCER_PLAYBOOKS` list (plus its tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)