### PR TITLE
Use aria2 prefetch fallback for octavia image import

### DIFF
--- a/Containerfile
+++ b/Containerfile
@@ -41,6 +41,7 @@ apk add --no-cache --virtual .build-deps \
   musl-dev \
   openldap-dev
 apk add --no-cache \
+  aria2 \
   cdrkit \
   coreutils \
   git \

--- a/osism/commands/manage.py
+++ b/osism/commands/manage.py
@@ -468,8 +468,12 @@ class ImageOctavia(Command):
             "--cloud",
             cloud,
             "--deactivate",
+            # One web-download attempt only: the amphora image source is
+            # chronically slow, so retrying web-download just wastes another
+            # multi-minute doomed transfer. On the first failure the default
+            # --prefetch on-stuck falls back to aria2 + glance-direct.
             "--stuck-retry",
-            "1",
+            "0",
         ]
 
         task_signature = openstack.image_manager.si(

--- a/osism/commands/manage.py
+++ b/osism/commands/manage.py
@@ -481,7 +481,10 @@ class ImageOctavia(Command):
                 f"It takes a moment until task {task.task_id} (image-manager) has been started and output is visible here."
             )
 
-        return handle_task(task, wait, format="script", timeout=3600)
+        # A larger budget than the other image tasks: on a stuck web-download
+        # the image-manager falls back to aria2 + glance-direct, which adds a
+        # local download and staging on top of the import.
+        return handle_task(task, wait, format="script", timeout=5400)
 
 
 class Images(Command):


### PR DESCRIPTION
## What

Wires the OSISM manager to use the aria2 + glance-direct import fallback for the
octavia amphora image, whose source download from object storage is chronically
slow (see osism/issues#1411).

## Changes

- Install `aria2` in the manager image (provides `aria2c` for the prefetch path).
- Raise the octavia image task timeout (3600 → 5400 s) to accommodate a local
  download + staging on top of the import.
- Set octavia `--stuck-retry 0`: a single web-download attempt, then fall back to
  aria2 + glance-direct (the default `--prefetch on-stuck`) — retrying the slow
  source just wastes another multi-minute transfer.

## Merge order

`--stuck-retry 0` is only safe once the fallback exists in the installed
image-manager; shipping it earlier would leave octavia with a single web-download
attempt and no fallback — less resilient than today's two attempts. So this PR is
kept in **draft** and merged only together with the pin bump:

1. merge osism/openstack-image-manager#1252 (the engine)
2. cut an `openstack-image-manager` release containing it
3. bump `requirements.openstack-image-manager.txt` to that release **on this
   branch**, take this PR out of draft, and merge

`aria2` install and the timeout bump are harmless on their own; keeping them here
with the pin makes the whole change atomic.

## Related

- osism/issues#1411

🤖 Generated with [Claude Code](https://claude.com/claude-code)
