### PR TITLE
manage images: default --cloud to admin

### DIFF
--- a/osism/commands/manage.py
+++ b/osism/commands/manage.py
@@ -531,7 +531,7 @@ class Images(Command):
             action="store_true",
         )
         parser.add_argument(
-            "--cloud", type=str, help="Cloud name in clouds.yaml", default="openstack"
+            "--cloud", type=str, help="Cloud name in clouds.yaml", default="admin"
         )
         parser.add_argument(
             "--filter",

--- a/tests/unit/commands/test_manage_wiring.py
+++ b/tests/unit/commands/test_manage_wiring.py
@@ -29,6 +29,15 @@ def _stub_args(**overrides) -> MagicMock:
     return args
 
 
+def test_images_cloud_default_matches_shipped_profile():
+    # The shipped cfg-cookiecutter clouds.yml provides 'admin' (not 'openstack'),
+    # so a bare `osism manage images` must default to a profile that exists.
+    cmd = manage.Images(MagicMock(), MagicMock())
+    parser = cmd.get_parser("manage images")
+    args = parser.parse_args([])
+    assert args.cloud == "admin"
+
+
 def test_w1_octavia_wires_validators_to_call_sites():
     cmd = manage.ImageOctavia(MagicMock(), MagicMock())
     args = _stub_args()


### PR DESCRIPTION
## Problem

A bare `osism manage images` fails on every standard OSISM deployment with:

```
ConfigException: Cloud openstack was not found.
```

The `Images` command defaulted `--cloud` to `openstack`, a profile that `cfg-cookiecutter`'s `clouds.yml` never ships — it provides `admin`, `admin-system`, and `octavia`. The `openstack` value was inherited from the standalone `openstack-image-manager` tool rather than OSISM's own operator-profile convention.

This diverged from the sibling subcommands, all of which already default to `admin`:

| Subcommand | old default | in shipped `clouds.yml`? |
|---|---|---|
| `manage images` | `openstack` | no → fails bare |
| `manage flavors` | `admin` | yes → works bare |
| `manage project *` | `admin` | yes → works bare |

## Change

- Default `manage images` `--cloud` to `admin`, so the documented bare invocation works out of the box.
- Add a regression guard asserting the parsed default.
