### PR TITLE
test: guard run_ansible_in_environment arg word-splitting

### DIFF
--- a/tests/unit/tasks/test_init.py
+++ b/tests/unit/tasks/test_init.py
@@ -363,6 +363,28 @@ def test_run_ansible_list_arguments_joined(runner_mocks):
     assert command.endswith("-e a=b -l all")
 
 
+def test_run_ansible_list_multitoken_element_word_split_not_quoted(runner_mocks):
+    # REGRESSION GUARD -- do NOT "fix" the list join in
+    # run_ansible_in_environment by shlex.quote()-ing each element. Callers
+    # deliberately pack several shell words into ONE list element and rely on
+    # the unquoted " ".join(arguments) plus the /bin/sh -c in Popen(shell=True)
+    # to word-split them into separate argv, e.g.:
+    #   commands/set.py, commands/noset.py:  ["-e status=True", f"-l {host}"]
+    #   commands/validate.py:                "-e kolla_action=config_validate"
+    #   commands/apply.py:                   [f"-e kolla_action={action}"] + args
+    # The run-<environment>.sh scripts forward args via "$@" (no re-split), so
+    # that outer-shell split is load-bearing. A per-element shlex.quote() would
+    # glue "-e status=True" into a single token and break -e/-l parsing. To make
+    # a value with shell metacharacters safe (e.g. a regex "(A|B)" in
+    # tempest_include_regex), split each element on whitespace FIRST and quote
+    # the resulting tokens, or normalize the callers to emit already-split
+    # tokens -- never a bare per-element quote.
+    run_ansible(arguments=["-e status=True", "-l host"])
+    command = runner_mocks.popen.call_args.args[0]
+    assert command.endswith("-e status=True -l host")
+    assert "'-e status=True'" not in command
+
+
 def test_run_ansible_string_arguments_passed_through(runner_mocks):
     run_ansible(arguments="-e a=b")
     command = runner_mocks.popen.call_args.args[0]


### PR DESCRIPTION
## What

Adds a unit-test regression guard for the argument-joining behaviour of
`run_ansible_in_environment` in `osism/tasks/__init__.py`. **Test only — no
behaviour change.**

## Why

`run_ansible_in_environment` joins a *list* of arguments with plain spaces
(`" ".join(arguments)`) and runs the result through
`subprocess.Popen(..., shell=True)`, so `/bin/sh` word-splits each element into
separate argv. Several callers deliberately rely on this — they pack multiple
shell words into a **single** list element:

- `commands/set.py`, `commands/noset.py`: `["-e status=True", f"-l {host}"]`
- `commands/validate.py`: `"-e kolla_action=config_validate"`
- `commands/apply.py`: `[f"-e kolla_action={action}"] + arguments`

The `run-<environment>.sh` scripts forward args via `"$@"` (no re-split), so the
outer-shell split is load-bearing.

This makes the join fragile in a non-obvious way: a value containing a shell
metacharacter (e.g. `tempest_include_regex=(A|B)`) breaks at `/bin/sh`
(`Syntax error: "(" unexpected`). The tempting one-line "fix" —
`" ".join(shlex.quote(a) for a in arguments)` — would **regress** the callers
above by gluing `-e status=True` into a single token, and the existing
`test_run_ansible_list_arguments_joined` would not catch it (it uses only
single-word elements, on which `shlex.quote` is a no-op).

## What the guard does

Pins the multi-token behaviour: a space-containing element must stay word-split
and must **not** be per-element quoted. It fails under a naive per-element
`shlex.quote`, and its comment records the safe alternatives (split each element
on whitespace first *then* quote, or normalise the callers to emit already-split
tokens) so a future metacharacter-safety fix is done without breaking the
split-dependent callers.

🤖 Generated with [Claude Code](https://claude.com/claude-code)