### PR TITLE
Add integration tests for the Ansible facts freshness check

### DIFF
--- a/osism/utils/__init__.py
+++ b/osism/utils/__init__.py
@@ -661,11 +661,12 @@ def check_ansible_facts(max_age=None):
             truncated_value = data
             if isinstance(truncated_value, (bytes, str)):
                 truncated_value = truncated_value[:200]
-            logger.debug(
-                "Skipping malformed ansible_facts entry for key %r: %r",
-                key,
-                truncated_value,
-                exc_info=True,
+            # loguru formats with str.format and knows no exc_info kwarg, so
+            # printf-style placeholders would be logged verbatim and the
+            # traceback dropped.
+            logger.opt(exception=True).debug(
+                f"Skipping malformed ansible_facts entry for key {key!r}: "
+                f"{truncated_value!r}"
             )
             continue
 

--- a/tests/integration/test_facts.py
+++ b/tests/integration/test_facts.py
@@ -1,0 +1,189 @@
+# SPDX-License-Identifier: Apache-2.0
+
+"""Integration tests for ``osism.utils.check_ansible_facts()``.
+
+The function scans Redis for ``ansible_facts*`` keys with a cursor-based
+``SCAN`` loop and reads ``ansible_date_time.epoch`` from each JSON value to
+decide whether the cached facts are stale, reporting the outcome through
+loguru. The unit tests cover the same scenarios against a ``MagicMock``
+client; running them against a live Redis exercises what the mocks stand in
+for: the cursor loop, keys and values arriving as ``bytes``, and JSON that
+round-tripped through a Redis server. The suite is skipped automatically when
+Redis is not reachable (see ``conftest.py``).
+"""
+
+import json
+import time
+import uuid
+
+import pytest
+
+from osism import utils
+
+pytestmark = pytest.mark.integration
+
+# Passed explicitly to every call: the ``settings.FACTS_MAX_AGE`` default is 12
+# hours, which would tie the stale case to the environment.
+MAX_AGE = 300
+
+
+@pytest.fixture
+def seed_facts():
+    """Seed ``ansible_facts<host>`` keys and remove them after the test."""
+    keys = []
+
+    def _seed(host, value):
+        key = f"ansible_facts{host}"
+        utils.redis.set(key, value)
+        keys.append(key)
+
+    yield _seed
+
+    for key in keys:
+        utils.redis.delete(key)
+
+
+def _host():
+    """Return a hostname unique to one test.
+
+    The ``itest-`` prefix keeps it clear of ``LOCAL_FACT_HOSTS``, whose facts
+    ``check_ansible_facts()`` skips outright.
+    """
+    return f"itest-{uuid.uuid4()}"
+
+
+def _facts(epoch):
+    """Return a facts blob carrying ``epoch``.
+
+    Ansible stores the epoch as a string, and ``check_ansible_facts()`` casts
+    it with ``float()``, so the string form is what the test seeds.
+    """
+    return json.dumps({"ansible_date_time": {"epoch": str(int(epoch))}})
+
+
+def _messages(records, level, needle):
+    """Return the captured messages at ``level`` that contain ``needle``."""
+    return [
+        record["message"]
+        for record in records
+        if record["level"] == level and needle in record["message"]
+    ]
+
+
+def test_no_facts_warns_about_empty_cache(loguru_logs):
+    """An empty facts cache is reported as such.
+
+    ``check_ansible_facts()`` scans the whole database, so a Redis holding
+    real facts cannot produce this case. Skip there rather than deleting data
+    that does not belong to the suite; the CI container starts empty.
+    """
+    leftover = sorted(
+        key.decode() for key in utils.redis.scan_iter(match="ansible_facts*")
+    )
+    if leftover:
+        pytest.skip(f"Redis already holds ansible_facts keys: {leftover}")
+
+    utils.check_ansible_facts(max_age=MAX_AGE)
+
+    assert _messages(loguru_logs, "WARNING", "No Ansible facts found in Redis cache")
+
+
+def test_fresh_facts_produce_no_warning(seed_facts, loguru_logs):
+    """A host whose facts are current is not reported."""
+    host = _host()
+    seed_facts(host, _facts(time.time()))
+
+    utils.check_ansible_facts(max_age=MAX_AGE)
+
+    assert not _messages(loguru_logs, "WARNING", host)
+
+
+def test_stale_facts_report_the_stale_host_only(seed_facts, loguru_logs):
+    """Facts older than ``max_age`` are reported, fresh ones are not."""
+    stale_host = _host()
+    fresh_host = _host()
+    seed_facts(stale_host, _facts(time.time() - 9999))
+    seed_facts(fresh_host, _facts(time.time()))
+
+    utils.check_ansible_facts(max_age=MAX_AGE)
+
+    stale_messages = _messages(
+        loguru_logs, "WARNING", f"Host '{stale_host}': facts are"
+    )
+    assert stale_messages
+    assert all("seconds old" in message for message in stale_messages)
+    assert _messages(loguru_logs, "WARNING", "Run 'osism sync facts' to update facts.")
+    assert not _messages(loguru_logs, "WARNING", fresh_host)
+
+
+def test_stale_facts_are_reported_across_scan_batches(seed_facts, loguru_logs):
+    """Every stale host is reported when ``SCAN`` needs more than one call.
+
+    ``check_ansible_facts()`` collects the keys of every batch before reading
+    them. The other tests seed too few keys to leave the first batch, so
+    replacing the loop with a single ``SCAN`` call keeps them green; only
+    enough hosts to force a second call covers it.
+    """
+    hosts = [_host() for _ in range(200)]
+    for host in hosts:
+        seed_facts(host, _facts(time.time() - 9999))
+
+    # COUNT is a hint, not a limit, so the number of keys one call covers is
+    # not guaranteed. Fail loudly if a single batch swallows the keyspace
+    # instead of passing without having exercised pagination.
+    cursor, _ = utils.redis.scan(0, match="ansible_facts*", count=100)
+    assert cursor != 0
+
+    utils.check_ansible_facts(max_age=MAX_AGE)
+
+    # One line per host proves the batches accumulated; exactly one line
+    # proves they were not counted twice, which matters because SCAN may
+    # return a key more than once and the collected keys are not deduplicated.
+    for host in hosts:
+        assert len(_messages(loguru_logs, "WARNING", f"Host '{host}': facts are")) == 1
+
+
+def test_facts_without_epoch_are_skipped(seed_facts, loguru_logs):
+    """Facts lacking ``ansible_date_time.epoch`` are skipped, not reported."""
+    host = _host()
+    seed_facts(host, json.dumps({"ansible_hostname": "node-1"}))
+
+    utils.check_ansible_facts(max_age=MAX_AGE)
+
+    assert _messages(
+        loguru_logs, "DEBUG", f"Host '{host}': facts missing ansible_date_time.epoch"
+    )
+    assert not _messages(loguru_logs, "WARNING", host)
+
+
+def test_malformed_json_is_skipped(seed_facts, loguru_logs):
+    """A value that is not JSON is skipped without failing the check."""
+    host = _host()
+    seed_facts(host, "{ not valid json")
+
+    utils.check_ansible_facts(max_age=MAX_AGE)
+
+    skipped = _messages(loguru_logs, "DEBUG", "Skipping malformed ansible_facts entry")
+    assert any(host in message for message in skipped)
+    assert not _messages(loguru_logs, "WARNING", host)
+
+
+def test_empty_value_is_skipped(seed_facts, loguru_logs):
+    """An empty value is skipped silently and the scan continues.
+
+    Absence of output says nothing about what happened to the remaining keys,
+    so stale hosts are seeded alongside: turning the ``continue`` into a
+    ``return`` or ``break`` drops their report and fails the test.
+    """
+    host = _host()
+    seed_facts(host, "")
+    stale_hosts = [_host() for _ in range(5)]
+    for stale_host in stale_hosts:
+        seed_facts(stale_host, _facts(time.time() - 9999))
+
+    utils.check_ansible_facts(max_age=MAX_AGE)
+
+    assert not _messages(loguru_logs, "WARNING", host)
+    assert not _messages(loguru_logs, "DEBUG", host)
+    for stale_host in stale_hosts:
+        assert _messages(loguru_logs, "WARNING", f"Host '{stale_host}': facts are")


### PR DESCRIPTION
Closes #2403.

`check_ansible_facts()` (`osism/utils/__init__.py:596`) is what `osism apply` calls before running plays (`osism/commands/apply.py:422`) to warn operators about a missing or outdated facts cache. Its unit tests (`tests/unit/utils/test_init_task_output.py:450`) drive it through a `MagicMock` client, so the parts most likely to regress are the parts the mocks simulate: the cursor-based `SCAN` loop, the bytes decoding of keys and values, and JSON parsing of data a real server returned.

This adds `tests/integration/test_facts.py`, which exercises those paths against the live Redis the `python-osism-integration-tests` job provides. No source file changes.

## The commit

- `Add integration tests for the Ansible facts freshness check` — one new module with six tests and a module-local `seed_facts` fixture.

## What the tests cover

| Test | Seeded value | Checks |
|---|---|---|
| `test_no_facts_warns_about_empty_cache` | nothing | the "No Ansible facts found in Redis cache" warning |
| `test_fresh_facts_produce_no_warning` | current epoch | no warning names the host |
| `test_stale_facts_report_the_stale_host_only` | one host at `now-9999`, one fresh | the stale host is named with its age, the fresh one is not |
| `test_facts_without_epoch_are_skipped` | facts without `ansible_date_time.epoch` | the skip is logged at debug level, no warning |
| `test_malformed_json_is_skipped` | `{ not valid json` | `json.JSONDecodeError` is caught, the skip is logged at debug level |
| `test_empty_value_is_skipped` | empty string | the host is skipped silently |

Two properties keep the module deterministic against a Redis that is not empty. Hostnames are `itest-<uuid4>`, and every assertion is scoped to a seeded hostname or to a message unique to its scenario, so unrelated keys cannot fail the suite. `check_ansible_facts()` scans the whole database, so the empty-cache case cannot be produced on a Redis holding real facts; that test skips and names the leftover keys rather than deleting data the suite does not own.

`max_age=300` is passed explicitly everywhere, since the `settings.FACTS_MAX_AGE` default of 12 hours would tie the stale case to the environment.

## Verification

Against a throwaway `redis:7-alpine`:

- `pytest tests/integration/test_facts.py` — 6 passed, run twice in a row, with `KEYS 'ansible_facts*'` empty afterwards.
- With a foreign `ansible_facts` key present: the empty-cache test is reported as skipped, the key survives, and the other five tests stay green.
- Without Redis: 6 skipped; with `OSISM_REQUIRE_REDIS=1` the session exits non-zero.
- `black --check` and `flake8` are clean.

Three mutations of `check_ansible_facts()` were each caught by the matching test and then reverted: disabling the staleness comparison failed `test_stale_facts_report_the_stale_host_only`, downgrading the empty-cache warning failed `test_no_facts_warns_about_empty_cache`, and removing the missing-epoch debug line failed `test_facts_without_epoch_are_skipped`.

Part of #2400 (Tier 1).
