### PR TITLE
Add integration tests for Celery error, state and revoke paths

### DIFF
--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -12,6 +12,7 @@ green outside the dedicated CI job.
 import os
 import subprocess
 import time
+from pathlib import Path
 
 import pytest
 
@@ -29,6 +30,24 @@ WORKER_NAME = "ci-worker@%h"
 # to gate readiness on *this* worker rather than any worker on the broker.
 WORKER_NODE_PREFIX = WORKER_NAME.split("@", 1)[0] + "@"
 WORKER_BOOT_TIMEOUT = 60
+# Test-only tasks (see that module's docstring for why they exist). The worker
+# imports it relative to its cwd, which is pinned to the repository root below.
+WORKER_INCLUDE = "tests.integration.worker_tasks"
+
+
+def _find_repo_root():
+    """Return the repository root, found by its ``setup.cfg`` marker.
+
+    Walking up from this file instead of hard-coding ``parents[2]`` fails
+    loudly here rather than as an opaque import error at worker boot.
+    """
+    for parent in Path(__file__).resolve().parents:
+        if (parent / "setup.cfg").exists():
+            return parent
+    raise RuntimeError("no repository root with setup.cfg above conftest.py")
+
+
+REPO_ROOT = _find_repo_root()
 
 
 def _require_redis():
@@ -100,7 +119,10 @@ def celery_worker(celery_app):
     The worker runs from the same virtualenv as the tests.
     ``GATHER_FACTS_SCHEDULE=0`` prevents registration of the periodic
     ``gather_facts`` task, which would try to run ``/run.sh`` in containers that
-    do not exist in CI.
+    do not exist in CI. ``--include`` registers the test-only lifecycle tasks
+    from ``tests/integration/worker_tasks.py``; ``cwd`` is pinned to the
+    repository root so that import resolves regardless of where pytest was
+    launched. A broken include surfaces as an early worker exit below.
     """
     proc = subprocess.Popen(
         [
@@ -114,8 +136,11 @@ def celery_worker(celery_app):
             WORKER_QUEUE,
             "-c",
             "1",
+            "--include",
+            WORKER_INCLUDE,
         ],
         env={**os.environ, "GATHER_FACTS_SCHEDULE": "0"},
+        cwd=REPO_ROOT,
     )
 
     try:

--- a/tests/integration/test_celery_lifecycle.py
+++ b/tests/integration/test_celery_lifecycle.py
@@ -1,0 +1,113 @@
+# SPDX-License-Identifier: Apache-2.0
+
+"""Celery task-lifecycle integration tests: failure, STARTED and revocation.
+
+These extend the noop round-trip in ``test_celery.py`` with the result-backend
+behaviour the operator-facing flows rely on: an exception raised in the worker
+reaches the caller through ``AsyncResult.get()``, ``task_track_started``
+reports ``STARTED`` while a task runs, and ``osism.utils.revoke_task``
+terminates a running task. The tasks they dispatch are registered on the
+worker via ``tests/integration/worker_tasks.py``.
+"""
+
+import time
+import uuid
+
+import pytest
+
+from osism import utils
+from tests.integration.worker_tasks import itest_block, itest_fail
+
+pytestmark = pytest.mark.integration
+
+# Timeouts in seconds, sized for slow CI machines: how long a dispatched task
+# may take to deliver its result, and how long a state transition may take to
+# become visible in the result backend.
+RESULT_TIMEOUT = 60
+STATE_TIMEOUT = 30
+# Task durations in seconds: long enough that polling cannot miss STARTED, and
+# far enough past the revoke that the revoke test never races its task's
+# natural end. ``itest_block`` carries its own hard time limit, so a test that
+# fails before revoking does not block the worker for the full duration.
+BLOCK_SHORT = 3
+BLOCK_LONG = 300
+
+
+def _wait_for_state(result, states, timeout=STATE_TIMEOUT):
+    """Poll ``result.state`` until it is one of ``states`` and return it.
+
+    Fails the test instead of hanging when the deadline passes.
+    """
+    deadline = time.monotonic() + timeout
+    state = result.state
+    while time.monotonic() < deadline:
+        state = result.state
+        if state in states:
+            return state
+        time.sleep(0.1)
+    pytest.fail(
+        f"task {result.id} did not reach {states} within {timeout}s "
+        f"(last state: {state})"
+    )
+
+
+def test_failing_task_propagates_exception(celery_worker):
+    """An exception raised in the worker reaches the caller via ``get()``.
+
+    ``RuntimeError`` is a builtin, so the result backend re-raises the
+    original exception class with the original message.
+    """
+    message = f"itest-fail-{uuid.uuid4()}"
+
+    result = itest_fail.delay(message)
+
+    with pytest.raises(RuntimeError, match=message):
+        result.get(timeout=RESULT_TIMEOUT)
+    assert result.failed() is True
+    assert result.state == "FAILURE"
+
+
+def test_started_state_is_reported(celery_worker):
+    """``task_track_started`` reports ``STARTED`` while a task runs.
+
+    The task body runs for ``BLOCK_SHORT`` seconds against a 0.1 s poll
+    interval, so a run that observes ``SUCCESS`` or ``FAILURE`` first either
+    never reported ``STARTED`` or lost the whole task duration to a stalled
+    poll loop.
+    """
+    result = itest_block.delay(BLOCK_SHORT)
+
+    state = _wait_for_state(result, {"STARTED", "SUCCESS", "FAILURE"})
+
+    assert state == "STARTED", (
+        f"got {state} first -- either task_track_started stopped working, "
+        f"or this poll loop stalled for the full {BLOCK_SHORT}s window"
+    )
+    assert result.get(timeout=RESULT_TIMEOUT) == BLOCK_SHORT
+    assert result.state == "SUCCESS"
+
+
+def test_revoke_running_task(celery_worker):
+    """``osism.utils.revoke_task`` terminates a running task.
+
+    The revoke is issued only after ``STARTED`` was observed: revoking a
+    still-queued task would merely discard it from the queue and never
+    exercise ``terminate=True`` against a running pool child.
+    """
+    from celery.exceptions import TaskRevokedError
+
+    from osism.tasks import ansible
+
+    result = itest_block.delay(BLOCK_LONG)
+    state = _wait_for_state(result, {"STARTED", "SUCCESS", "FAILURE"})
+    assert state == "STARTED"
+
+    assert utils.revoke_task(result.id) is True
+
+    assert _wait_for_state(result, {"REVOKED", "SUCCESS", "FAILURE"}) == "REVOKED"
+    with pytest.raises(TaskRevokedError):
+        result.get(timeout=RESULT_TIMEOUT)
+
+    # The prefork pool replaces the terminated child; prove the session-scoped
+    # worker stays usable for tests that run after this one.
+    assert ansible.noop.delay().get(timeout=RESULT_TIMEOUT) is True

--- a/tests/integration/worker_tasks.py
+++ b/tests/integration/worker_tasks.py
@@ -1,0 +1,39 @@
+# SPDX-License-Identifier: Apache-2.0
+
+"""Test-only Celery tasks registered on the ``ansible`` app.
+
+None of the production tasks on the ``ansible`` app raises deliberately or
+blocks, so the lifecycle tests (failure propagation, ``STARTED`` tracking,
+revocation) register their own tasks here. The ``celery_worker`` fixture
+starts the worker with ``--include=tests.integration.worker_tasks`` so the
+worker process knows them; a task defined inside a test file would only exist
+in the pytest process.
+
+The explicit ``osism.tasks.ansible.*`` names matter: ``Config.task_routes``
+routes by that pattern onto the ``osism-ansible`` queue the worker consumes.
+With their auto-generated names (``tests.integration.worker_tasks.*``) the
+tasks would land on the ``default`` queue and never run.
+"""
+
+import time
+
+from osism.tasks.ansible import app
+
+# Hard time limit for ``itest_block``, in seconds. The revoke test dispatches it
+# with a duration long enough to never race the task's natural end; should that
+# test fail before issuing the revoke, this bound keeps the blocked task from
+# occupying the single-concurrency worker for the rest of the session. Chosen
+# well above the time a test may wait for a state transition, so it never
+# preempts a revoke.
+BLOCK_TIME_LIMIT = 60
+
+
+@app.task(name="osism.tasks.ansible.itest_fail")
+def itest_fail(message):
+    raise RuntimeError(message)
+
+
+@app.task(name="osism.tasks.ansible.itest_block", time_limit=BLOCK_TIME_LIMIT)
+def itest_block(seconds):
+    time.sleep(seconds)
+    return seconds


### PR DESCRIPTION
Extends the Celery integration coverage beyond the noop round-trip with three
lifecycle tests against the live Redis broker and the real worker subprocess.

One commit, e240b64:

- `tests/integration/worker_tasks.py` (new) registers two test-only tasks on
  the `ansible` app: `itest_fail` raises `RuntimeError`, `itest_block` sleeps
  and returns its argument. The explicit `osism.tasks.ansible.*` names route
  them onto the `osism-ansible` queue the worker consumes; with their
  auto-generated names they would land on the unconsumed `default` queue.
- `tests/integration/conftest.py` starts the session worker with
  `--include=tests.integration.worker_tasks` and pins its `cwd` to the
  repository root so the module resolves regardless of where pytest was
  launched. A broken include surfaces as the fixture's existing early-exit
  `RuntimeError` instead of a hang.
- `tests/integration/test_celery_lifecycle.py` (new) adds the three tests: an
  exception raised in the worker reaches the caller through
  `AsyncResult.get()` and leaves the task in `FAILURE`; `task_track_started`
  reports `STARTED` while a task runs; `osism.utils.revoke_task` terminates a
  running task, the state ends `REVOKED`, `get()` raises `TaskRevokedError`,
  and a final noop round-trip proves the prefork pool respawned its child.
  All waits go through a `time.monotonic()` deadline helper that fails the
  test instead of hanging.

The tests carry `pytestmark = pytest.mark.integration`, skip without a
reachable Redis, and run for real in the `python-osism-integration-tests`
job. `black --check` and `flake8` pass locally.

Closes #2404

