### PR TITLE
Add parameter to only erase metadata to baremetal clean

### DIFF
--- a/osism/commands/baremetal.py
+++ b/osism/commands/baremetal.py
@@ -1184,6 +1184,12 @@ class BaremetalClean(Command):
             help="Clean given baremetal node when in provision state available",
         )
         parser.add_argument(
+            "--metadata-only",
+            default=False,
+            help="Only erase metadata on disks",
+            action="store_true",
+        )
+        parser.add_argument(
             "--all",
             default=False,
             help="Clean all baremetal nodes in provision state available",
@@ -1201,6 +1207,7 @@ class BaremetalClean(Command):
         cloud = parsed_args.cloud
         all_nodes = parsed_args.all
         name = parsed_args.name
+        metadata_only = parsed_args.metadata_only
         yes_i_really_really_mean_it = parsed_args.yes_i_really_really_mean_it
 
         if not all_nodes and not name:
@@ -1213,7 +1220,10 @@ class BaremetalClean(Command):
             )
             return 1
 
-        clean_steps = [{"interface": "deploy", "step": "erase_devices"}]
+        if metadata_only:
+            clean_steps = [{"interface": "deploy", "step": "erase_devices_metadata"}]
+        else:
+            clean_steps = [{"interface": "deploy", "step": "erase_devices"}]
 
         from osism.tasks.openstack import get_cloud_helpers
 
@@ -1243,7 +1253,10 @@ class BaremetalClean(Command):
                     continue
 
                 # NOTE: If the node has an agent raid interface, include step to delete the raid configuration
-                if node.get("raid_interface", "no-raid") != "no-raid":
+                if (
+                    not metadata_only
+                    and node.get("raid_interface", "no-raid") != "no-raid"
+                ):
                     clean_steps = [
                         {"interface": "raid", "step": "delete_configuration"}
                     ] + clean_steps

--- a/tests/unit/commands/test_baremetal.py
+++ b/tests/unit/commands/test_baremetal.py
@@ -1323,6 +1323,7 @@ def test_burnin_unsupported_state_warns(loguru_logs):
 # --- BaremetalClean ---
 
 ERASE_DEVICES_STEP = {"interface": "deploy", "step": "erase_devices"}
+ERASE_METADATA_STEP = {"interface": "deploy", "step": "erase_devices_metadata"}
 RAID_DELETE_STEP = {"interface": "raid", "step": "delete_configuration"}
 
 
@@ -1355,6 +1356,30 @@ def test_clean_raid_interface_prepends_delete_configuration():
 
     conn.baremetal.set_node_provision_state.assert_called_once_with(
         node.id, "clean", clean_steps=[RAID_DELETE_STEP, ERASE_DEVICES_STEP]
+    )
+
+
+def test_clean_metadata_only_uses_erase_devices_metadata():
+    node = FakeNode(provision_state="manageable")
+    conn = MagicMock()
+    conn.baremetal.find_node.return_value = node
+
+    _run_baremetal_clean(["node1", "--metadata-only"], conn)
+
+    conn.baremetal.set_node_provision_state.assert_called_once_with(
+        node.id, "clean", clean_steps=[ERASE_METADATA_STEP]
+    )
+
+
+def test_clean_metadata_only_skips_delete_configuration_on_raid_node():
+    node = FakeNode(provision_state="manageable", raid_interface="agent")
+    conn = MagicMock()
+    conn.baremetal.find_node.return_value = node
+
+    _run_baremetal_clean(["node1", "--metadata-only"], conn)
+
+    conn.baremetal.set_node_provision_state.assert_called_once_with(
+        node.id, "clean", clean_steps=[ERASE_METADATA_STEP]
     )
 
 


### PR DESCRIPTION
When specified the `erase_device_metadata` clean step will be executed, thus only erasing metadata on the disk.
On some hatdware devices secure erase will fail with an error, that prevents the fallback erasure of metadata from being executed. Adding this parameter will allow to trigger the metadata cleaning explicitly and thus provide a workround to clean these nodes, albeit in a less sophisticated and incomplete way.