### PR TITLE
Build the SNMP vault only when secrets exist

### DIFF
--- a/osism/tasks/conductor/sonic/config_generator.py
+++ b/osism/tasks/conductor/sonic/config_generator.py
@@ -2393,14 +2393,14 @@ def _add_snmp_configuration(config, device, oob_ip):
     in the config_context of the device.
     """
 
-    # Create vault instance for Custom Field decryption
-    vault = get_vault()
-
-    # Decrypt secrets Custom Field
+    # Decrypt the secrets Custom Field. The vault needs the key file and
+    # Redis, and get_vault() logs ERRORs where those are absent, so it is
+    # only built when there are secrets to decrypt.
     node_secrets = device.custom_fields.get("secrets", {})
     if node_secrets is None:
         node_secrets = {}
-    deep_decrypt(node_secrets, vault)
+    if node_secrets:
+        deep_decrypt(node_secrets, get_vault())
 
     # Configure SNMP location and contact
     location = device.config_context.get("_segment_snmp_server_location", "Data Center")

--- a/tests/unit/tasks/conductor/sonic/test_config_generator_snmp.py
+++ b/tests/unit/tasks/conductor/sonic/test_config_generator_snmp.py
@@ -169,3 +169,42 @@ def test_add_snmp_configuration_secrets_none_treated_as_empty(patch_snmp_secrets
         "shaKey": "OBFUSCATEDAUTHSECRET",
         "aesKey": "OBFUSCATEDPRIVSECRET",
     }
+
+
+def test_add_snmp_configuration_no_secrets_skips_vault(mocker):
+    """Without encrypted secrets there is nothing to decrypt, so the vault
+    (which needs the container key file and Redis) must not be built at
+    all -- ``get_vault`` logs ERRORs in environments without a vault."""
+    get_vault_mock = mocker.patch(
+        "osism.tasks.conductor.sonic.config_generator.get_vault"
+    )
+    deep_decrypt_mock = mocker.patch(
+        "osism.tasks.conductor.sonic.config_generator.deep_decrypt"
+    )
+    config = {}
+
+    _add_snmp_configuration(config, _snmp_device(), oob_ip=None)
+    _add_snmp_configuration(
+        config, _snmp_device(custom_fields={"secrets": None}), oob_ip=None
+    )
+
+    get_vault_mock.assert_not_called()
+    deep_decrypt_mock.assert_not_called()
+    assert "SNMP_SERVER" in config
+
+
+def test_add_snmp_configuration_with_secrets_uses_vault(mocker):
+    get_vault_mock = mocker.patch(
+        "osism.tasks.conductor.sonic.config_generator.get_vault"
+    )
+    deep_decrypt_mock = mocker.patch(
+        "osism.tasks.conductor.sonic.config_generator.deep_decrypt",
+        side_effect=lambda data, vault: None,
+    )
+    config = {}
+    device = _snmp_device(custom_fields={"secrets": {"snmp_auth": "$ANSIBLE_VAULT..."}})
+
+    _add_snmp_configuration(config, device, oob_ip=None)
+
+    get_vault_mock.assert_called_once()
+    deep_decrypt_mock.assert_called_once()


### PR DESCRIPTION
`_add_snmp_configuration` built a `VaultLib` for **every** device before it
looked at whether that device had anything encrypted to decrypt.

`get_vault()` needs two things that only exist inside a worker container: the
key file `/share/ansible_vault_password.key`, and the encrypted vault password
stored in Redis. Where either is missing, the failure is logged rather than
raised, three times per synced device:

1. `get_ansible_vault_password()` fails to open the key file and logs
   `Unable to get ansible vault password` before re-raising.
2. The `FileNotFoundError` is not a `ValueError`, so it lands in `get_vault()`'s
   generic handler, which logs `Unable to get vault secret: ...`
3. ...and then `Dropping encrypted entries`.

So a SONiC sync outside a worker — local development, or any run against a
NetBox with no vault configured — produces three ERROR-level records per
device, for devices that carry no secrets at all.

## The change

Vault construction is deferred until the device actually carries a non-empty
`secrets` custom field:

```python
node_secrets = device.custom_fields.get("secrets", {})
if node_secrets is None:
    node_secrets = {}
if node_secrets:
    deep_decrypt(node_secrets, get_vault())
```

Devices **with** encrypted secrets are decrypted exactly as before. Devices
without them no longer touch the key file or Redis. Note that `deep_decrypt` on
an empty dict was already a no-op, so nothing is lost by skipping it — the only
behavioural change is that the vault is not built.

## Tests

Two cases added to the existing `test_config_generator_snmp.py`, pinning both
directions:

- `test_add_snmp_configuration_no_secrets_skips_vault` — neither `get_vault` nor
  `deep_decrypt` is called, for both a missing and an explicitly `None` custom
  field. This fails without the fix.
- `test_add_snmp_configuration_with_secrets_uses_vault` — both are still called
  when secrets are present, so the preserved path is guarded too.

## Provenance

This fell out of ongoing work on an end-to-end golden test for SONiC config
generation, which generates config against a plain NetBox with no vault
configured and treats any ERROR-level log record as a failure. The bug it
surfaced is independent of that work, so it is split out here on its own — the
noise it removes affects any non-worker environment, and the fix touches only
`config_generator.py`.
