### PR TITLE
Refuse breakouts that claim other ports

### DIFF
--- a/osism/tasks/conductor/sonic/interface.py
+++ b/osism/tasks/conductor/sonic/interface.py
@@ -641,6 +641,20 @@ def get_connected_interfaces(device, portchannel_info=None):
     return _get_connected_interfaces(device, portchannel_info)
 
 
+def _breakout_child_collisions(children, master, port_config):
+    """Children that are separate ports of this HWSKU rather than free slots.
+
+    Breakout children are named after the master's lane offsets, which assumes
+    every slot below the next master is unused. That holds for every port of
+    every bundled HWSKU but one: on Accton-AS7726-32X the last 100G port
+    (Ethernet124, four lanes) is followed by Ethernet125 and Ethernet126, two
+    independent 10G SFP+ ports occupying two of its four child slots. Claiming
+    those as children rewrites their lanes, speed and alias, so a breakout that
+    would do it has to be refused.
+    """
+    return [c for c in children if c != master and c in port_config]
+
+
 def detect_breakout_ports(device):
     """Detect breakout ports from NetBox device interfaces using the centralized breakout logic.
 
@@ -767,14 +781,6 @@ def detect_breakout_ports(device):
                                 # Calculate physical port number (1/1 -> port 1, 1/2 -> port 2, etc.)
                                 physical_port_num = f"{module}/{port}"
 
-                                # Add breakout config for master port
-                                breakout_cfgs[master_port] = {
-                                    "breakout_owner": "MANUAL",
-                                    "brkout_mode": brkout_mode,
-                                    "port": physical_port_num,
-                                }
-
-                                # Add all subports to breakout_ports
                                 min_subport = breakout_group[0][0]
 
                                 # Determine the offset multiplier based on master port lane count
@@ -797,12 +803,31 @@ def detect_breakout_ports(device):
                                                 f"8 lanes, using offset multiplier {offset_multiplier}"
                                             )
 
-                                for subport, iface in breakout_group:
-                                    current_offset = (
-                                        subport - min_subport
-                                    ) * offset_multiplier
-                                    sonic_port_num = base_port_num + current_offset
-                                    port_name = f"Ethernet{sonic_port_num}"
+                                children = [
+                                    "Ethernet"
+                                    f"{base_port_num + (subport - min_subport) * offset_multiplier}"
+                                    for subport, _iface in breakout_group
+                                ]
+                                collisions = _breakout_child_collisions(
+                                    children, master_port, port_config
+                                )
+                                if collisions:
+                                    logger.error(
+                                        f"Breakout of {master_port} would claim "
+                                        f"{', '.join(collisions)}, which are separate "
+                                        f"ports on this HWSKU; skipping the group"
+                                    )
+                                    continue
+
+                                # Add breakout config for master port
+                                breakout_cfgs[master_port] = {
+                                    "breakout_owner": "MANUAL",
+                                    "brkout_mode": brkout_mode,
+                                    "port": physical_port_num,
+                                }
+
+                                # Add all subports to breakout_ports
+                                for port_name in children:
                                     breakout_ports[port_name] = {"master": master_port}
 
                                 logger.debug(
@@ -861,6 +886,24 @@ def detect_breakout_ports(device):
                                     physical_port_index = (base_port_400g // 8) + 1
                                     physical_port_num = f"1/{physical_port_index}"
 
+                                    children = [
+                                        f"Ethernet{port_num_400g}"
+                                        for port_num_400g, _iface in (
+                                            sonic_400g_breakout_group
+                                        )
+                                    ]
+                                    collisions = _breakout_child_collisions(
+                                        children, master_port, port_config
+                                    )
+                                    if collisions:
+                                        logger.error(
+                                            f"400G breakout of {master_port} would "
+                                            f"claim {', '.join(collisions)}, which are "
+                                            f"separate ports on this HWSKU; skipping "
+                                            f"the group"
+                                        )
+                                        continue
+
                                     # Add breakout config for master port
                                     breakout_cfgs[master_port] = {
                                         "breakout_owner": "MANUAL",
@@ -869,11 +912,7 @@ def detect_breakout_ports(device):
                                     }
 
                                     # Add all ports to breakout_ports
-                                    for (
-                                        port_num_400g,
-                                        iface,
-                                    ) in sonic_400g_breakout_group:
-                                        port_name = f"Ethernet{port_num_400g}"
+                                    for port_name in children:
                                         breakout_ports[port_name] = {
                                             "master": master_port
                                         }
@@ -955,6 +994,10 @@ def detect_breakout_ports(device):
                     physical_port_index = (base_port // 4) + 1
                     physical_port_num = f"1/{physical_port_index}"
 
+                    # NOTE: the topology gate above already refuses a group whose
+                    # intermediate slots are ports in port_config, which is the
+                    # same condition _breakout_child_collisions() tests. No
+                    # separate collision check is needed on this path.
                     # Add breakout config for master port
                     breakout_cfgs[master_port] = {
                         "breakout_owner": "MANUAL",
@@ -963,7 +1006,7 @@ def detect_breakout_ports(device):
                     }
 
                     # Add all ports to breakout_ports
-                    for port_num, iface in sonic_breakout_group:
+                    for port_num, _iface in sonic_breakout_group:
                         port_name = f"Ethernet{port_num}"
                         breakout_ports[port_name] = {"master": master_port}
 

--- a/tests/unit/tasks/conductor/sonic/_detection_helpers.py
+++ b/tests/unit/tasks/conductor/sonic/_detection_helpers.py
@@ -6,7 +6,21 @@ Used by ``test_breakout_detection`` and ``test_port_channel_detection``;
 the module is private (``_``-prefixed) so pytest does not collect it.
 """
 
+from pathlib import Path
 from types import SimpleNamespace
+
+
+def repo_root():
+    """Return the repository root, found by its ``setup.cfg`` marker.
+
+    Walking up beats hard-coding a parent depth, which silently breaks when a
+    test module moves. ``tests/integration/conftest.py`` locates the root the
+    same way, for the same reason.
+    """
+    for parent in Path(__file__).resolve().parents:
+        if (parent / "setup.cfg").exists():
+            return parent
+    raise RuntimeError("no repository root with setup.cfg above this file")
 
 
 def _make_sonic_device(device_id=1, name="sw1", hwsku="TEST-HWSKU"):

--- a/tests/unit/tasks/conductor/sonic/test_breakout_detection.py
+++ b/tests/unit/tasks/conductor/sonic/test_breakout_detection.py
@@ -16,7 +16,7 @@ import pytest
 from osism.tasks.conductor.sonic import interface as interface_module
 from osism.tasks.conductor.sonic.interface import detect_breakout_ports
 
-from ._detection_helpers import _make_iface, _make_sonic_device
+from ._detection_helpers import _make_iface, _make_sonic_device, repo_root
 
 # ---------------------------------------------------------------------------
 # Helpers
@@ -568,3 +568,128 @@ def test_detect_breakout_ports_sonic_standard_speed_resolved_from_port_type(
     result = detect_breakout_ports(device)
 
     assert result["breakout_cfgs"]["Ethernet0"]["brkout_mode"] == "4x25G"
+
+
+# ---------------------------------------------------------------------------
+# Child slots occupied by another port
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def real_port_config(monkeypatch):
+    """Load a port_config from the .ini files actually shipped in this repo.
+
+    The helpers above build port_configs with one or two entries, which cannot
+    express a child slot already occupied by another port -- the one shape that
+    makes a breakout unsafe, and the reason this class of bug went unnoticed.
+    These tests need the real file.
+    """
+
+    def _load(hwsku):
+        monkeypatch.setattr(
+            interface_module,
+            "PORT_CONFIG_PATH",
+            str(repo_root() / "files" / "sonic" / "port_config"),
+        )
+        interface_module.clear_port_config_cache()
+        return interface_module.get_port_config(hwsku)
+
+    yield _load
+    interface_module.clear_port_config_cache()
+
+
+def test_netbox_format_breakout_refused_when_child_slot_is_another_port(
+    patch_breakout_helpers, real_port_config
+):
+    """Eth1/32 on Accton-AS7726-32X is Ethernet124, a four-lane 100G port whose
+    third and fourth child slots are Ethernet125 and Ethernet126 -- independent
+    10G SFP+ ports. Breaking it out would rewrite their lanes, speed and alias,
+    so the group is dropped whole, master BREAKOUT_CFG included.
+    """
+    port_config = real_port_config("Accton-AS7726-32X")
+    assert {"Ethernet125", "Ethernet126"} <= set(port_config)
+
+    device = _make_sonic_device()
+    interfaces = _netbox_breakout_interfaces(speed=25_000_000, port=32)
+    patch_breakout_helpers(interfaces=interfaces, port_config=port_config)
+
+    result = detect_breakout_ports(device)
+
+    assert result["breakout_cfgs"] == {}
+    assert result["breakout_ports"] == {}
+
+
+def test_netbox_format_breakout_allowed_when_child_slots_are_free(
+    patch_breakout_helpers, real_port_config
+):
+    """The same HWSKU's first port must still break out: Ethernet0's children
+    are Ethernet1-3, none of which is a port in its own right.
+    """
+    port_config = real_port_config("Accton-AS7726-32X")
+
+    device = _make_sonic_device()
+    interfaces = _netbox_breakout_interfaces(speed=25_000_000, port=1)
+    patch_breakout_helpers(interfaces=interfaces, port_config=port_config)
+
+    result = detect_breakout_ports(device)
+
+    assert result["breakout_cfgs"]["Ethernet0"]["brkout_mode"] == "4x25G"
+    assert sorted(result["breakout_ports"]) == [
+        "Ethernet0",
+        "Ethernet1",
+        "Ethernet2",
+        "Ethernet3",
+    ]
+
+
+def test_sonic_format_breakout_already_refused_by_the_topology_gate(
+    patch_breakout_helpers, real_port_config
+):
+    """The same collision reached through SONiC-format names rather than
+    Eth1/<port>/<subport>. This path needs no collision check: the topology gate
+    already skips a group whose intermediate slots are ports in port_config,
+    which is the same condition. Pinned here on the real port_config because
+    nothing else covered it, and because that gate is now load-bearing for
+    correctness rather than only for native-port misdetection.
+    """
+    port_config = real_port_config("Accton-AS7726-32X")
+
+    device = _make_sonic_device()
+    interfaces = [
+        _make_iface(f"Ethernet{n}", speed=25_000_000) for n in (124, 125, 126, 127)
+    ]
+    patch_breakout_helpers(interfaces=interfaces, port_config=port_config)
+
+    result = detect_breakout_ports(device)
+
+    assert result["breakout_cfgs"] == {}
+    assert result["breakout_ports"] == {}
+
+
+def test_sonic_400g_breakout_refused_when_child_slot_is_another_port(
+    patch_breakout_helpers,
+):
+    """The 400G grouping path takes the same guard. No bundled HWSKU has an
+    8-lane master with an occupied child slot, so the port_config here is
+    built to that shape: an 8-lane master at Ethernet0 whose 4x100G children
+    would be Ethernet0/2/4/6, with Ethernet4 present as its own port.
+    """
+    port_config = {
+        **_port_config_for_port(lanes="1,2,3,4,5,6,7,8", speed="400000"),
+        **_port_config_for_port(
+            sonic_port="Ethernet4",
+            alias="hundredGigE99",
+            lanes="9",
+            index="99",
+            speed="10000",
+        ),
+    }
+
+    device = _make_sonic_device()
+    interfaces = [_make_iface(f"Ethernet{n}", speed=100_000_000) for n in (0, 2, 4, 6)]
+    patch_breakout_helpers(interfaces=interfaces, port_config=port_config)
+
+    result = detect_breakout_ports(device)
+
+    assert result["breakout_cfgs"] == {}
+    assert result["breakout_ports"] == {}


### PR DESCRIPTION
A detected breakout names its children after the master's lane offsets —
`Ethernet<base + n*lanes_per_child>` — which assumes every slot below the next
master is free. That holds for every port of every bundled HWSKU except one.

On **Accton-AS7726-32X** the last 100G port has four lanes, but the next two
port names are already taken by independent 10G SFP+ ports:

```
Ethernet124     125,126,127,128       hundredGigE32     32    100000
Ethernet125     129                   tenGigE33         33     10000
Ethernet126     128                   tenGigE34         34     10000
```

A 4x breakout of `Ethernet124` generates children `Ethernet124/125/126/127`, so
it claims `Ethernet125` and `Ethernet126` as sub-ports of a cage they are not
part of.

## What that does to the generated config

| port | before | after a 4x25G breakout of Ethernet124 |
|------|--------|----------------------------------------|
| `Ethernet125` | `lanes=129 speed=10000 alias=Eth1/33` | `lanes=126 speed=25000 alias=Eth1/33/1` |
| `Ethernet126` | `lanes=128 speed=10000 alias=Eth1/34` | `lanes=127 speed=25000 alias=Eth1/34/1` |

All three fields are wrong, and both ports are re-presented as breakout
sub-ports. Two things make this reach a real switch rather than staying
theoretical:

- a `breakout_ports` entry is **authoritative** for a port's lanes and speed —
  the declared path stashes them directly, the inferred path recomputes them
  from the *master's* lane list via `_calculate_breakout_port_lane()`;
- the `PORT` table is built from **every entry in `port_config`**, not only the
  interfaces present in NetBox, so no NetBox modelling of the SFP ports is
  needed for them to be emitted and corrupted. Every generated config for that
  HWSKU already contains all 34 ports.

`2x50G` collides the same way, on `Ethernet126` alone.

## The fix

`_breakout_child_collisions()` returns any child name that is a port of this
HWSKU in its own right. Both affected paths now check it **before mutating
anything**, so the group is dropped whole rather than half-applied and the
master keeps its own configuration:

- the `Eth<module>/<port>/<subport>` path, which computes child names from the
  master offset and had no check at all;
- the SONiC-name 400G grouping path, likewise.

The SONiC-name **standard** grouping path needed no change. Its existing
topology gate already skips a group whose intermediate slots are ports in
`port_config` — the same condition — so only a comment was added there,
recording that the gate is load-bearing for correctness and not only for the
native-port misdetection it was written to prevent.

The collision test is simply that a child name other than the master is itself a
key in `port_config`. Swept across every master of all nine bundled HWSKUs at
1x/2x/4x/8x, it flags exactly the three real cases on that one HWSKU and nothing
else, so it needs no per-HWSKU exception list and no false positives to
suppress.

## Why the existing tests could not have caught this

Every breakout test builds its `port_config` from a helper that returns a
**single entry** (occasionally two). A one-port `port_config` cannot express a
child slot occupied by another port, so this class of bug was structurally
unreachable by the suite — the fixtures encoded the same assumption as the code.

The new tests therefore load the `.ini` files shipped in this repo. The 400G case
keeps a synthetic `port_config`, because no bundled HWSKU has an 8-lane master
with an occupied child slot.

## Note on the underlying port config

Worth flagging for whoever owns those files, though it is deliberately **not**
changed here. Upstream `sonic-buildimage` ships 32 ports for this HWSKU —
`Ethernet125`/`Ethernet126` do not exist there — and its Broadcom config carries
them only as commented-out entries (`#portmap_130=128:10:m`,
`#portmap_66=129:10:m`). Lane 128 is muxed between the last 100G port's fourth
lane and a 10G port, so the vendor ships the 10G ports disabled to leave the
100G port all four lanes. `Accton-AS7326-56X.ini` has the same lane-128 overlap.

So these files declare port pairs the hardware cannot run simultaneously, which
is a data question separate from this change. Refusing to silently claim a port
that exists is correct either way, which is why the guard goes in regardless of
how that is settled.

## Verification

- Full unit suite green; `tests/unit/tasks/conductor/sonic` at 701 passed.
- Each new guard verified to fail loudly: with the guards disabled, exactly the
  two corresponding tests fail, while the topology-gate test and the
  breakout-still-works control keep passing.
- `flake8` and `black` clean.
