### PR TITLE
Make the SONiC port_config path configurable

### DIFF
--- a/osism/settings.py
+++ b/osism/settings.py
@@ -78,6 +78,10 @@ SONIC_EXPORT_PREFIX = os.getenv("SONIC_EXPORT_PREFIX", "osism_")
 SONIC_EXPORT_SUFFIX = os.getenv("SONIC_EXPORT_SUFFIX", "_config_db.json")
 SONIC_EXPORT_IDENTIFIER = os.getenv("SONIC_EXPORT_IDENTIFIER", "serial-number")
 
+# Directory holding the per-HWSKU port_config .ini files (bundled in the
+# repo under files/sonic/port_config and installed by the Dockerfile)
+SONIC_PORT_CONFIG_PATH = os.getenv("SONIC_PORT_CONFIG_PATH", "/etc/sonic/port_config")
+
 # SONiC ZTP firmware configuration
 #
 # The ZTP firmware install uses a dynamic-url built from

--- a/osism/tasks/conductor/sonic/constants.py
+++ b/osism/tasks/conductor/sonic/constants.py
@@ -2,6 +2,8 @@
 
 """Constants and mappings for SONiC configuration."""
 
+from osism import settings
+
 # Tag to add AF L2VPN EVPN to BGP neighbor
 BGP_AF_L2VPN_EVPN_TAG = "bgp-af-l2vpn-evpn"
 
@@ -87,7 +89,7 @@ BREAKOUT_MODE_BY_SPEED = {
 }
 
 # Path to SONiC port configuration files
-PORT_CONFIG_PATH = "/etc/sonic/port_config"
+PORT_CONFIG_PATH = settings.SONIC_PORT_CONFIG_PATH
 
 # List of supported vendors
 SUPPORTED_VENDORS = [

--- a/tests/unit/tasks/conductor/sonic/test_constants.py
+++ b/tests/unit/tasks/conductor/sonic/test_constants.py
@@ -1,7 +1,11 @@
 # SPDX-License-Identifier: Apache-2.0
 
+import importlib
+
 import pytest
 
+from osism import settings as settings_module
+from osism.tasks.conductor.sonic import constants as constants_module
 from osism.tasks.conductor.sonic.constants import (
     BGP_AF_L2VPN_EVPN_TAG,
     DEFAULT_LOCAL_AS_PREFIX,
@@ -151,3 +155,19 @@ def test_supported_hwskus_entry_invariants(hwsku):
     assert "-" in hwsku
     vendor = hwsku.split("-")[0]
     assert vendor in SUPPORTED_VENDORS
+
+
+# ---------------------------------------------------------------------------
+# PORT_CONFIG_PATH settings wiring
+# ---------------------------------------------------------------------------
+
+
+def test_port_config_path_follows_settings():
+    original = settings_module.SONIC_PORT_CONFIG_PATH
+    try:
+        settings_module.SONIC_PORT_CONFIG_PATH = "/custom/port_config"
+        reloaded = importlib.reload(constants_module)
+        assert reloaded.PORT_CONFIG_PATH == "/custom/port_config"
+    finally:
+        settings_module.SONIC_PORT_CONFIG_PATH = original
+        importlib.reload(constants_module)

--- a/tests/unit/test_settings.py
+++ b/tests/unit/test_settings.py
@@ -583,6 +583,20 @@ def test_sonic_export_identifier_override(reload_settings, monkeypatch):
     assert settings_module.SONIC_EXPORT_IDENTIFIER == "asset-tag"
 
 
+def test_sonic_port_config_path_default(reload_settings, monkeypatch):
+    monkeypatch.delenv("SONIC_PORT_CONFIG_PATH", raising=False)
+    reload_settings()
+
+    assert settings_module.SONIC_PORT_CONFIG_PATH == "/etc/sonic/port_config"
+
+
+def test_sonic_port_config_path_override(reload_settings, monkeypatch):
+    monkeypatch.setenv("SONIC_PORT_CONFIG_PATH", "/tmp/port_config")
+    reload_settings()
+
+    assert settings_module.SONIC_PORT_CONFIG_PATH == "/tmp/port_config"
+
+
 # ---------------------------------------------------------------------------
 # NETBOX_SECONDARIES
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
First of the series tracked in #2562, which explains the ordering and what each
PR covers. This one stands on its own — it is a production change with an
unchanged default, and nothing later in the series is needed to review it.

## The problem

`PORT_CONFIG_PATH` was hardcoded to `/etc/sonic/port_config`, which exists only
inside the conductor image: `Containerfile:21` copies `files/sonic/port_config/`
there. A generator run from a checkout instead — local development — finds
nothing at that path, and the workaround is to plant the `.ini` files under
`/etc/sonic`, which needs root.

## The change

Add `SONIC_PORT_CONFIG_PATH` to `osism/settings.py`, following the existing
`SONIC_*` environment variable convention, and wire
`constants.PORT_CONFIG_PATH` to it.

The default is the previous hardcoded path, so **container behaviour is
identical** and nothing in production moves. Setting the variable points the
generator at `files/sonic/port_config/` in the checkout instead.

## Tests

Three cases: the setting's default, the environment override, and the
settings-to-constants wiring — the last because `constants.PORT_CONFIG_PATH` is
assigned at import time, so a test that only checked the setting would not catch
the wiring being dropped.
