### PR TITLE
Provision the E2E NetBox with docker compose

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 *.egg-info
+.venv-sonic-e2e/
 *.pyc
 *.swp
 __pycache__

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,24 @@
+NETBOX_MANAGER_DIR ?= $(abspath ../netbox-manager)
+
+# SONiC config-generation E2E golden test (see tests/e2e/sonic_golden_test.sh).
+
+# Full cycle: start the NetBox compose stack (an existing stack is reused
+# and left in place), seed, generate, compare against tests/e2e/golden/.
+sonic-e2e:
+	NETBOX_MANAGER_DIR="$(NETBOX_MANAGER_DIR)" tests/e2e/sonic_golden_test.sh
+
+# Regenerate the golden files after an intentional generator change,
+# then review and commit the diff.
+sonic-e2e-regen:
+	NETBOX_MANAGER_DIR="$(NETBOX_MANAGER_DIR)" tests/e2e/sonic_golden_test.sh --regenerate
+
+# Start the NetBox stack and leave it running for debugging. Export a
+# NETBOX_TOKEN beforehand to get a known API token minted.
+sonic-e2e-up:
+	tests/e2e/deploy_netbox.sh
+
+# Stop the NetBox stack and remove its volumes.
+sonic-e2e-down:
+	docker compose -f tests/e2e/compose.yaml down --volumes --remove-orphans
+
+.PHONY: sonic-e2e sonic-e2e-regen sonic-e2e-up sonic-e2e-down

--- a/tests/e2e/compose.yaml
+++ b/tests/e2e/compose.yaml
@@ -1,0 +1,93 @@
+---
+# NetBox fixture for the SONiC config-generation E2E golden test.
+#
+# Three services, no Kubernetes: the test only needs a NetBox REST API,
+# its PostgreSQL and its Valkey. See
+# docs/superpowers/specs/2026-07-29-sonic-e2e-compose-design.md.
+#
+# NetBox is configured through the environment variables its own baked
+# /etc/netbox/config/configuration.py reads, so no configuration file is
+# mounted. API_TOKEN_PEPPERS is deliberately NOT set: the image's
+# super_user.py only creates a token when a pepper is configured, and then
+# only a v2 one, which pynetbox / netbox.netbox cannot use. deploy_netbox.sh
+# mints a v1 token instead. ("No API token will be created" in the netbox
+# log is therefore expected, not an error.)
+#
+# The secret key and superuser password are fixed literals, not
+# interpolated variables. This stack is ephemeral, published on loopback
+# only, and thrown away after each run, so they are not credentials. Keeping
+# them out of ${...} matters because docker compose interpolates the whole
+# file on *every* subcommand -- a `${VAR:?}` here would make plain
+# `docker compose down` fail whenever the caller's shell lacked the value.
+#
+# The NetBox version is pinned because the golden files were generated
+# against it -- changing it can change generated configs. postgres and
+# valkey are pinned to a patch level; they are tags, not digests, so this
+# bounds rather than freezes them.
+
+name: sonic-e2e
+
+services:
+  postgres:
+    image: postgres:17.10-alpine
+    environment:
+      # Must match netbox's DB_NAME / DB_USER / DB_PASSWORD below. The
+      # official image mandates POSTGRES_PASSWORD and would otherwise
+      # default the database and role to "postgres".
+      POSTGRES_DB: netbox
+      POSTGRES_USER: netbox
+      POSTGRES_PASSWORD: netbox
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U netbox -d netbox"]
+      interval: 5s
+      timeout: 5s
+      retries: 24
+
+  valkey:
+    image: valkey/valkey:8.1-alpine
+    # No authentication: valkey is reachable only on the compose-private
+    # network and publishes no port, so netbox needs no REDIS_PASSWORD.
+    healthcheck:
+      test: ["CMD", "valkey-cli", "ping"]
+      interval: 5s
+      timeout: 5s
+      retries: 24
+
+  netbox:
+    image: ghcr.io/netbox-community/netbox:v4.5.10
+    depends_on:
+      postgres:
+        condition: service_healthy
+      valkey:
+        condition: service_healthy
+    environment:
+      DB_HOST: postgres
+      DB_NAME: netbox
+      DB_USER: netbox
+      DB_PASSWORD: netbox
+      # NetBox needs two logical Redis databases; one valkey serves both.
+      REDIS_HOST: valkey
+      REDIS_PORT: "6379"
+      REDIS_DATABASE: "0"
+      REDIS_CACHE_HOST: valkey
+      REDIS_CACHE_PORT: "6379"
+      REDIS_CACHE_DATABASE: "1"
+      # Django wants >= 50 characters. Not a credential -- see the header.
+      SECRET_KEY: "insecure-sonic-e2e-secret-key-not-used-outside-tests"
+      SUPERUSER_NAME: admin
+      SUPERUSER_EMAIL: admin@example.com
+      SUPERUSER_PASSWORD: "insecure-sonic-e2e-admin-password"
+      ALLOWED_HOSTS: "*"
+    ports:
+      # Published on loopback only; the seeding and generation phases talk
+      # to http://127.0.0.1:${NETBOX_PORT}. No port-forward involved.
+      - "127.0.0.1:${NETBOX_PORT:-8080}:8080"
+    healthcheck:
+      # First boot runs the full migration set, which takes minutes; the
+      # start_period covers that without the container being marked
+      # unhealthy. Subsequent boots skip migrations and come up in ~1 min.
+      test: ["CMD", "curl", "-fsS", "-o", "/dev/null", "http://localhost:8080/login/"]
+      interval: 10s
+      timeout: 5s
+      retries: 3
+      start_period: 600s

--- a/tests/e2e/deploy_netbox.sh
+++ b/tests/e2e/deploy_netbox.sh
@@ -1,0 +1,79 @@
+#!/usr/bin/env bash
+#
+# Provision NetBox for the SONiC E2E golden test (phase 1), using docker
+# compose. See docs/superpowers/specs/2026-07-29-sonic-e2e-compose-design.md.
+#
+# This script starts the stack and mints the API token. It deliberately
+# installs NO teardown trap: sonic_golden_test.sh owns the lifecycle, and a trap here
+# would fire when this script exits -- before seeding and generation.
+#
+# Safe to run standalone for debugging (`make sonic-e2e-up`), which leaves
+# the stack running.
+#
+# The NetBox secret key and superuser password are fixed literals in
+# compose.yaml (ephemeral loopback-only fixture); only the API token and the
+# published port are parameterised here.
+#
+# Environment overrides:
+#   NETBOX_TOKEN            v1 API token to mint (default: random)
+#   NETBOX_PORT             host port for the NetBox API (default: 8080)
+#   PRINT_NETBOX_TOKEN=0    suppress echoing the token (set by sonic_golden_test.sh)
+
+set -euo pipefail
+
+HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+COMPOSE_FILE="${HERE}/compose.yaml"
+
+# Only generated when unset, so sonic_golden_test.sh's value wins when it calls us.
+export NETBOX_TOKEN="${NETBOX_TOKEN:-$(openssl rand -hex 20)}"
+# Guard against two failure modes of a caller-supplied token: it is
+# interpolated into a Python string literal in the heredoc below, so a
+# quote or newline would break out of that literal; and a token that is
+# not 40 hex characters is otherwise accepted here but silently rejected
+# by NetBox much later, far from this, the actual cause.
+[[ "${NETBOX_TOKEN}" =~ ^[0-9a-f]{40}$ ]] || {
+  echo "error: NETBOX_TOKEN must be 40 hex characters" >&2
+  exit 2
+}
+export NETBOX_PORT="${NETBOX_PORT:-8080}"
+
+compose() { docker compose -f "${COMPOSE_FILE}" "$@"; }
+
+echo ">>> Starting the NetBox stack (postgres, valkey, netbox)"
+# --wait blocks until every service is healthy. First boot runs the full
+# NetBox migration set, hence the generous timeout.
+compose up --detach --wait --wait-timeout 900
+
+# Mint a deterministic v1 API token for the superuser. NetBox 4.5 introduced
+# peppered "v2" API tokens; the image's bootstrap only ever creates a v2 one,
+# and only when API_TOKEN_PEPPERS is set (compose.yaml leaves it unset, so it
+# creates none). pynetbox / netbox.netbox authenticate with
+# `Authorization: Token <key>`, i.e. a v1 token, which NetBox accepts through
+# v4.6 -- legacy v1 support is removed in v4.7, so re-check this on a bump.
+#
+# The delete-then-create makes this idempotent: re-running against a reused
+# stack replaces the old token instead of colliding with it. Keep the delete.
+#
+# The script is fed over stdin (not `shell -c`) so the token never lands on a
+# command line inside the container.
+echo ">>> Creating a deterministic v1 API token for the superuser"
+compose exec -T netbox /opt/netbox/netbox/manage.py shell --interface python <<PYEOF
+from django.contrib.auth import get_user_model
+from users.models import Token
+from users.choices import TokenVersionChoices
+user = get_user_model().objects.get(username="admin")
+Token.objects.filter(user=user).delete()
+Token.objects.create(user=user, version=TokenVersionChoices.V1, token="${NETBOX_TOKEN}")
+print("Created v1 token for", user.username)
+PYEOF
+
+echo
+echo "NetBox is deployed."
+echo
+echo "  API       : http://127.0.0.1:${NETBOX_PORT}"
+# Echo the token only for the standalone debug workflow; sonic_golden_test.sh sets
+# PRINT_NETBOX_TOKEN=0 to keep it out of CI logs that may be retained.
+if [[ "${PRINT_NETBOX_TOKEN:-1}" != "0" ]]; then
+  echo "  API token : ${NETBOX_TOKEN}"
+fi
+echo

--- a/tests/e2e/sonic_golden_test.sh
+++ b/tests/e2e/sonic_golden_test.sh
@@ -1,0 +1,229 @@
+#!/usr/bin/env bash
+#
+# SONiC config-generation E2E golden test:
+#
+#   1. start NetBox with docker compose (tests/e2e/deploy_netbox.sh; an
+#      existing stack is reused and left in place)
+#   2. seed it with the fixtures in tests/e2e/scenario/ (netbox-manager is
+#      the seeding tool; its example/ data is deliberately not used)
+#   3. run sync_sonic() via tests/e2e/generate.py
+#   4. compare the exported config_db files against tests/e2e/golden/
+#      (or rewrite the goldens with --regenerate)
+#
+# Requirements: docker (with the compose plugin), openssl, a netbox-manager
+# checkout (sibling directory or NETBOX_MANAGER_DIR) for the seeding CLI, and
+# this repo's pipenv environment (pipenv install --dev).
+#
+# Phase 2 seeds every file under tests/e2e/scenario/resources/ regardless of
+# git status -- a stray untracked file in that directory joins the fixture
+# set and gets seeded too. This has broken a run twice; keep that directory
+# clean (git status --ignored) before regenerating or debugging a mismatch.
+#
+# Environment overrides:
+#   NETBOX_MANAGER_DIR    netbox-manager checkout (default: ../netbox-manager)
+#   NETBOX_TOKEN          API token (default: random; also minted in NetBox)
+#   NETBOX_PORT           host port for the NetBox API (default: 8080)
+#   KEEP_STACK=1          leave a stack created by this run running
+#   SEED_PARALLEL         files seeded concurrently per group (default: 1;
+#                         >1 deadlocks intermittently -- see Phase 2)
+#   ALLOW_WARM_REGEN=1    let --regenerate run against a reused stack (see
+#                         the CREATED_STACK check below; off by default
+#                         because it can produce goldens CI cannot reproduce)
+#
+# Usage: sonic_golden_test.sh [--regenerate [--allow-coverage-loss]]
+#   --regenerate            rewrite the golden files from a fresh export
+#   --allow-coverage-loss   with --regenerate, accept a table/device going
+#                           from populated to empty/removed instead of
+#                           failing (forwarded to tests.e2e.compare)
+
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+cd "${REPO_ROOT}"
+
+REGENERATE=0
+ALLOW_COVERAGE_LOSS=0
+for arg in "$@"; do
+  case "${arg}" in
+    --regenerate) REGENERATE=1 ;;
+    --allow-coverage-loss) ALLOW_COVERAGE_LOSS=1 ;;
+    *)
+      echo "usage: $0 [--regenerate [--allow-coverage-loss]]" >&2
+      exit 2
+      ;;
+  esac
+done
+
+NETBOX_MANAGER_DIR="${NETBOX_MANAGER_DIR:-${REPO_ROOT}/../netbox-manager}"
+NETBOX_MANAGER_DIR="$(cd "${NETBOX_MANAGER_DIR}" 2>/dev/null && pwd)" || {
+  echo "error: netbox-manager checkout not found; set NETBOX_MANAGER_DIR" >&2
+  exit 2
+}
+
+NETBOX_TOKEN="${NETBOX_TOKEN:-$(openssl rand -hex 20)}"
+NETBOX_PORT="${NETBOX_PORT:-8080}"
+GOLDEN_DIR="${REPO_ROOT}/tests/e2e/golden"
+COMPOSE_FILE="${REPO_ROOT}/tests/e2e/compose.yaml"
+export NETBOX_TOKEN NETBOX_PORT
+
+compose() { docker compose -f "${COMPOSE_FILE}" "$@"; }
+
+# Only tear down a stack this run actually created -- never a reused debug
+# stack (make sonic-e2e-up). --all so a stopped stack still counts as
+# pre-existing.
+CREATED_STACK=0
+if [[ -z "$(compose ps --all --quiet 2>/dev/null)" ]]; then
+  CREATED_STACK=1
+fi
+
+# Regenerating against a reused stack applies each fixture as an UPDATE over
+# whatever is already in the database, where a fresh stack creates every
+# object cleanly -- the two can produce different goldens with no warning.
+# Refuse by default; ALLOW_WARM_REGEN=1 is the escape hatch for someone who
+# knows the reused stack still matches the fixtures (e.g. iterating with
+# KEEP_STACK=1 and only editing generator code, not the fixtures).
+if [[ "${REGENERATE}" == "1" && "${CREATED_STACK}" == "0" && "${ALLOW_WARM_REGEN:-0}" != "1" ]]; then
+  echo "error: --regenerate refuses to run against a reused NetBox stack." >&2
+  echo "       Applying fixtures as an UPDATE over a stale database can" >&2
+  echo "       produce goldens a fresh stack (as CI always uses) would not" >&2
+  echo "       reproduce. Run 'make sonic-e2e-down' first, or set" >&2
+  echo "       ALLOW_WARM_REGEN=1 if you know the reused stack still" >&2
+  echo "       matches the fixtures being regenerated." >&2
+  exit 2
+fi
+
+EXPORT_DIR=""
+dump_diagnostics() {
+  echo "==================== NetBox stack diagnostics ===================="
+  compose ps --all 2>&1 || true
+  # The application log is what actually explains a failed start; the stack
+  # is torn down below, taking it with it, so snapshot it first. Capped to
+  # the last 200 lines: this fires on any non-zero exit, including the most
+  # common failure (a golden mismatch in phase 4, where compare.py has
+  # already printed the useful diff), and an uncapped dump buries that diff
+  # under megabytes of NetBox first-boot migration and postgres logs. 200
+  # lines still covers a genuine boot failure.
+  compose logs --no-color --timestamps --tail 200 2>&1 || true
+  echo "================================================================="
+}
+cleanup() {
+  rc=$?
+  if [[ "${rc}" -ne 0 ]]; then
+    echo ">>> E2E run failed (exit ${rc}); dumping stack diagnostics"
+    dump_diagnostics || true
+  fi
+  if [[ -n "${EXPORT_DIR}" ]]; then
+    rm -rf "${EXPORT_DIR}"
+  fi
+  if [[ "${CREATED_STACK}" == "1" && "${KEEP_STACK:-0}" != "1" ]]; then
+    echo ">>> Stopping the NetBox stack"
+    compose down --volumes --remove-orphans || true
+  else
+    echo ">>> Leaving the NetBox stack in place"
+  fi
+}
+trap cleanup EXIT
+
+# --- Phase 1: provision NetBox with docker compose --------------------------
+# The stack publishes the API on 127.0.0.1:${NETBOX_PORT} directly, so there
+# is no port-forward to supervise, and `up --wait` has already established
+# readiness via the services' healthchecks. A port clash fails at `up`.
+PRINT_NETBOX_TOKEN=0 "${REPO_ROOT}/tests/e2e/deploy_netbox.sh"
+
+# --- Phase 2: seed with netbox-manager -------------------------------------
+# The CLI is installed from the checkout so a Zuul Depends-On on a
+# netbox-manager change is honored for code and data alike. It goes into a
+# dedicated venv: netbox-manager pins different versions of packages that
+# python-osism also pins (e.g. pynetbox), and installing it into the
+# project venv would silently mutate those pins.
+SEED_VENV="${SEED_VENV:-${REPO_ROOT}/.venv-sonic-e2e}"
+if [[ ! -x "${SEED_VENV}/bin/pip" ]]; then
+  echo ">>> Creating seeding venv ${SEED_VENV}"
+  python3 -m venv "${SEED_VENV}"
+fi
+# netbox-manager drives Ansible through ansible-runner, which resolves
+# ansible-playbook via PATH -- the venv's bin must therefore be on PATH,
+# not merely used for the netbox-manager entry point itself.
+export PATH="${SEED_VENV}/bin:${PATH}"
+echo ">>> Installing netbox-manager from ${NETBOX_MANAGER_DIR}"
+"${SEED_VENV}/bin/pip" install --quiet "${NETBOX_MANAGER_DIR}"
+
+echo ">>> Installing the netbox.netbox Ansible collection"
+"${SEED_VENV}/bin/ansible-galaxy" collection install -r "${NETBOX_MANAGER_DIR}/requirements.yml"
+
+export NETBOX_MANAGER_URL="http://127.0.0.1:${NETBOX_PORT}"
+export NETBOX_MANAGER_TOKEN="${NETBOX_TOKEN}"
+export NETBOX_MANAGER_IGNORE_SSL_ERRORS=true
+
+# Seeding is serial by default because concurrent seeding DEADLOCKS.
+#
+# netbox-manager sorts resource files by leading number, runs the groups in
+# order, and parallelises only within a group. The synthetic fixtures under
+# tests/e2e/scenario/ follow the same numeric-group layout the retired example
+# data used, so the same parallelism opportunity applies here too.
+#
+# That object-level analysis was not sufficient. The files share *foreign key
+# parents*: every node file creates cables terminating on the shared switches,
+# and inserting a row that references a device takes a KEY SHARE lock on that
+# device's row for the FK check. Two transactions acquiring those parent locks
+# in opposite orders deadlock:
+#
+#   deadlock detected ... while locking tuple (1,3) in relation "dcim_device"
+#   SELECT 1 FROM ONLY "dcim_device" x WHERE "id" = $1 FOR KEY SHARE OF x
+#
+# Observed intermittently: two CI runs passed, the third failed this way, so
+# roughly a one-in-three flake rate -- unusable as a default. It fails loudly
+# rather than corrupting anything: the goldens are never at risk, because a
+# deadlock aborts the run instead of silently reordering writes.
+#
+# The hazard has not gone away with the synthetic fixtures: 200-fabric.yml
+# cables both leaves to a shared spine, so files in one numeric group still
+# take KEY SHARE locks on the same parent dcim_device rows. Set
+# SEED_PARALLEL=4 to opt back in -- worth revisiting only if netbox-manager
+# gains deadlock retry.
+SEED_PARALLEL="${SEED_PARALLEL:-1}"
+
+echo ">>> Seeding NetBox with the E2E fixtures (parallel: ${SEED_PARALLEL})"
+export NETBOX_MANAGER_DEVICETYPE_LIBRARY="${REPO_ROOT}/tests/e2e/scenario/devicetypes"
+export NETBOX_MANAGER_RESOURCES="${REPO_ROOT}/tests/e2e/scenario/resources"
+"${SEED_VENV}/bin/netbox-manager" run --fail-fast --skipmtl --parallel "${SEED_PARALLEL}"
+
+# --- Phase 3: generate SONiC configurations ---------------------------------
+# The conductor import chain needs ansible-core, which the unit tests stub
+# out in conftest.py -- so a venv that runs the unit suite does not
+# necessarily satisfy this import. Install the pins directly rather than
+# the ".[ansible]" extra: that would reinstall the project itself on every
+# run, replacing an editable install with a wheel built from the checkout.
+# Nothing here needs the installed copy anyway, since generate.py runs as
+# python -m from the repo root and imports osism from the working tree.
+echo ">>> Ensuring the Ansible runtime pins are installed"
+pipenv run pip install --quiet -r requirements.ansible.txt
+
+EXPORT_DIR="$(mktemp -d)"
+export NETBOX_API="http://127.0.0.1:${NETBOX_PORT}"
+export SONIC_EXPORT_DIR="${EXPORT_DIR}"
+export SONIC_EXPORT_IDENTIFIER="hostname"
+export SONIC_PORT_CONFIG_PATH="${REPO_ROOT}/files/sonic/port_config"
+
+echo ">>> Generating SONiC configurations (tests/e2e/generate.py)"
+if [[ "${REGENERATE}" == "1" ]]; then
+  pipenv run python -m tests.e2e.generate --no-expect
+else
+  pipenv run python -m tests.e2e.generate --golden "${GOLDEN_DIR}"
+fi
+
+# --- Phase 4: compare against (or regenerate) the golden files -------------
+if [[ "${REGENERATE}" == "1" ]]; then
+  echo ">>> Regenerating golden files in ${GOLDEN_DIR}"
+  COMPARE_ARGS=(--golden "${GOLDEN_DIR}" --export "${EXPORT_DIR}" --regenerate)
+  if [[ "${ALLOW_COVERAGE_LOSS}" == "1" ]]; then
+    COMPARE_ARGS+=(--allow-coverage-loss)
+  fi
+  pipenv run python -m tests.e2e.compare "${COMPARE_ARGS[@]}"
+  echo ">>> Golden files regenerated; review and commit the diff."
+else
+  echo ">>> Comparing exports against ${GOLDEN_DIR}"
+  pipenv run python -m tests.e2e.compare \
+    --golden "${GOLDEN_DIR}" --export "${EXPORT_DIR}"
+  echo ">>> SONiC E2E golden test passed."
+fi


### PR DESCRIPTION
Part of the series tracked in #2562, which explains the ordering and what each PR covers. Based on the preceding PR in the stack, so review only the top commits here.

The infrastructure: `compose.yaml` (Postgres, Valkey, NetBox), `deploy_netbox.sh`
to bring it up and mint an API token, `sonic_golden_test.sh` as the harness
entry point, and the `make sonic-e2e*` targets.

Two decisions worth knowing while reading it:

**Only `NETBOX_PORT` is interpolated into the compose file.** Compose
re-interpolates the whole file on *every* subcommand, not just `up`, so
`${VAR:?}` guards would break `down`, `ps` and `logs` too. The rest of the
configuration lives in the container environment instead.

**Seeding runs serially by default** (`SEED_PARALLEL=1`). Concurrent seeding
deadlocks intermittently on PostgreSQL `KEY SHARE` row locks on shared parent
`dcim_device` rows — object disjointness says nothing about lock contention.
The escape hatch is kept for anyone who wants to retry it.

**The Ansible pins are installed at run time, not the `.[ansible]` extra.** The
conductor import chain needs `ansible-core`, which the unit tests stub out in
`conftest.py` — so a venv that passes the unit suite does not necessarily
satisfy that import. Installing the extra would also reinstall the *project* on
every run, replacing a developer's editable install with a wheel built from the
checkout. It is not needed for currency either: `generate.py` runs as
`python -m` from the repo root, so `osism` is imported from the working tree
rather than site-packages. Installing `requirements.ansible.txt` directly avoids
both, and is 1.4s rather than 8.9s when already satisfied.

Still nothing to run: the fixtures and goldens arrive in the next PR.

