### PR TITLE
Support declared breakout_mode

### DIFF
--- a/osism/tasks/conductor/sonic/config_generator.py
+++ b/osism/tasks/conductor/sonic/config_generator.py
@@ -548,7 +548,11 @@ def generate_sonic_config(device, hwsku, device_as_mapping=None, config_version=
     if breakout_info["breakout_cfgs"]:
         config["BREAKOUT_CFG"].update(breakout_info["breakout_cfgs"])
     if breakout_info["breakout_ports"]:
-        config["BREAKOUT_PORTS"].update(breakout_info["breakout_ports"])
+        # Project each entry to the SONiC schema ({port: {"master": <port>}});
+        # the full stash (declared/lanes/speed) stays in breakout_info for the
+        # PORT-building helpers and must not leak into the owned table.
+        for child, entry in breakout_info["breakout_ports"].items():
+            config["BREAKOUT_PORTS"][child] = {"master": entry["master"]}
 
     # Add port channel configuration
     _add_portchannel_configuration(config, portchannel_info)
@@ -649,33 +653,45 @@ def _add_port_configurations(
                     port_speed = sonic_speed
 
         if port_name in breakout_info["breakout_ports"]:
+            bp = breakout_info["breakout_ports"][port_name]
             # Get the master port to determine original speed and lanes
-            master_port = breakout_info["breakout_ports"][port_name]["master"]
+            master_port = bp["master"]
 
-            # Override with individual breakout port speed from NetBox if available
-            if port_name in netbox_interfaces and netbox_interfaces[port_name]["speed"]:
-                port_speed = str(int(netbox_interfaces[port_name]["speed"]))
-                logger.debug(
-                    f"Using NetBox speed {port_speed} Mbps for breakout port {port_name}"
+            if bp.get("declared"):
+                # Declared-mode stash is authoritative: it takes precedence over
+                # the NetBox-speed override and the inferred lane calculation.
+                port_speed = str(bp["speed"])
+                port_lanes = bp["lanes"]
+            else:
+                # Override with individual breakout port speed from NetBox if available
+                if (
+                    port_name in netbox_interfaces
+                    and netbox_interfaces[port_name]["speed"]
+                ):
+                    port_speed = str(int(netbox_interfaces[port_name]["speed"]))
+                    logger.debug(
+                        f"Using NetBox speed {port_speed} Mbps for breakout port {port_name}"
+                    )
+                elif master_port in breakout_info["breakout_cfgs"]:
+                    # Fallback to extracting speed from breakout mode
+                    brkout_mode = breakout_info["breakout_cfgs"][master_port][
+                        "brkout_mode"
+                    ]
+                    if "10G" in brkout_mode:
+                        port_speed = "10000"
+                    elif "25G" in brkout_mode:
+                        port_speed = "25000"
+                    elif "50G" in brkout_mode:
+                        port_speed = "50000"
+                    elif "100G" in brkout_mode:
+                        port_speed = "100000"
+                    elif "200G" in brkout_mode:
+                        port_speed = "200000"
+
+                # Calculate individual lane for this breakout port
+                port_lanes = _calculate_breakout_port_lane(
+                    port_name, master_port, port_config
                 )
-            elif master_port in breakout_info["breakout_cfgs"]:
-                # Fallback to extracting speed from breakout mode
-                brkout_mode = breakout_info["breakout_cfgs"][master_port]["brkout_mode"]
-                if "10G" in brkout_mode:
-                    port_speed = "10000"
-                elif "25G" in brkout_mode:
-                    port_speed = "25000"
-                elif "50G" in brkout_mode:
-                    port_speed = "50000"
-                elif "100G" in brkout_mode:
-                    port_speed = "100000"
-                elif "200G" in brkout_mode:
-                    port_speed = "200000"
-
-            # Calculate individual lane for this breakout port
-            port_lanes = _calculate_breakout_port_lane(
-                port_name, master_port, port_config
-            )
 
         # Generate correct alias based on port name and speed
         interface_speed = int(port_speed) if port_speed else None
@@ -857,32 +873,47 @@ def _add_missing_breakout_ports(
     for port_name in breakout_info["breakout_ports"]:
         if port_name not in config["PORT"]:
             # Get the master port to determine configuration
-            master_port = breakout_info["breakout_ports"][port_name]["master"]
+            bp = breakout_info["breakout_ports"][port_name]
+            master_port = bp["master"]
 
-            # Override with individual breakout port speed from NetBox if available
-            # Note: netbox_interfaces speeds are already normalized to Mbps
-            if port_name in netbox_interfaces and netbox_interfaces[port_name]["speed"]:
-                port_speed = str(int(netbox_interfaces[port_name]["speed"]))
-                logger.debug(
-                    f"Using NetBox speed {port_speed} Mbps for missing breakout port {port_name}"
-                )
-            elif master_port in breakout_info["breakout_cfgs"]:
-                # Fallback to extracting speed from breakout mode
-                brkout_mode = breakout_info["breakout_cfgs"][master_port]["brkout_mode"]
-                if "10G" in brkout_mode:
-                    port_speed = "10000"
-                elif "25G" in brkout_mode:
-                    port_speed = "25000"
-                elif "50G" in brkout_mode:
-                    port_speed = "50000"
-                elif "100G" in brkout_mode:
-                    port_speed = "100000"
-                elif "200G" in brkout_mode:
-                    port_speed = "200000"
+            if bp.get("declared"):
+                port_speed = str(bp["speed"])
+                port_lanes = bp["lanes"]
+            else:
+                # Override with individual breakout port speed from NetBox if available
+                # Note: netbox_interfaces speeds are already normalized to Mbps
+                if (
+                    port_name in netbox_interfaces
+                    and netbox_interfaces[port_name]["speed"]
+                ):
+                    port_speed = str(int(netbox_interfaces[port_name]["speed"]))
+                    logger.debug(
+                        f"Using NetBox speed {port_speed} Mbps for missing breakout port {port_name}"
+                    )
+                elif master_port in breakout_info["breakout_cfgs"]:
+                    # Fallback to extracting speed from breakout mode
+                    brkout_mode = breakout_info["breakout_cfgs"][master_port][
+                        "brkout_mode"
+                    ]
+                    if "10G" in brkout_mode:
+                        port_speed = "10000"
+                    elif "25G" in brkout_mode:
+                        port_speed = "25000"
+                    elif "50G" in brkout_mode:
+                        port_speed = "50000"
+                    elif "100G" in brkout_mode:
+                        port_speed = "100000"
+                    elif "200G" in brkout_mode:
+                        port_speed = "200000"
+                    else:
+                        port_speed = "25000"  # Default fallback
                 else:
                     port_speed = "25000"  # Default fallback
-            else:
-                port_speed = "25000"  # Default fallback
+
+                # Calculate individual lane for this breakout port
+                port_lanes = _calculate_breakout_port_lane(
+                    port_name, master_port, port_config
+                )
 
             # Set admin_status based on connection or port channel membership
             admin_status = (
@@ -904,11 +935,6 @@ def _add_missing_breakout_ports(
             port_index = "1"  # Default fallback
             if master_port in port_config:
                 port_index = port_config[master_port]["index"]
-
-            # Calculate individual lane for this breakout port
-            port_lanes = _calculate_breakout_port_lane(
-                port_name, master_port, port_config
-            )
 
             port_data = {
                 "admin_status": admin_status,

--- a/osism/tasks/conductor/sonic/interface.py
+++ b/osism/tasks/conductor/sonic/interface.py
@@ -19,6 +19,51 @@ from .cache import get_cached_device_interfaces
 _port_config_cache: dict[str, dict[str, dict[str, str]]] = {}
 
 
+def get_declared_breakout_modes(device):
+    cf = getattr(device, "custom_fields", None)
+    if not isinstance(cf, dict):
+        return {}
+    sp = cf.get("sonic_parameters")
+    if not isinstance(sp, dict):
+        return {}
+    bk = sp.get("breakout")
+    return bk if isinstance(bk, dict) else {}
+
+
+_MODE_RE = re.compile(r"(\d+)x(\d+)G")
+
+
+def _parse_breakout_mode(mode):
+    if not isinstance(mode, str):
+        return None
+    m = _MODE_RE.fullmatch(mode.strip())
+    if not m:
+        return None
+    count, g = int(m.group(1)), int(m.group(2))
+    if count < 2 or g <= 0:
+        return None
+    return count, g * 1000
+
+
+def _parse_lanes(lanes):
+    if not isinstance(lanes, str):
+        return []
+    s = lanes.strip()
+    if not s:
+        return []
+    try:
+        if "," in s:
+            parts = [p.strip() for p in s.split(",")]
+            return parts if all(p.isdigit() for p in parts) else []
+        if "-" in s:
+            a, b = s.split("-", 1)
+            a, b = int(a), int(b)
+            return [str(n) for n in range(a, b + 1)] if a <= b else []
+        return [s] if s.isdigit() else []
+    except (ValueError, TypeError):
+        return []
+
+
 def get_speed_from_port_type(port_type):
     """Get speed from port type when speed is not provided.
 
@@ -641,6 +686,12 @@ def get_connected_interfaces(device, portchannel_info=None):
     return _get_connected_interfaces(device, portchannel_info)
 
 
+def _breakout_child_names(master, count, lanes_per_child):
+    """Names a breakout of ``master`` into ``count`` children would occupy."""
+    base = int(master[len("Ethernet") :])
+    return [f"Ethernet{base + i * lanes_per_child}" for i in range(count)]
+
+
 def _breakout_child_collisions(children, master, port_config):
     """Children that are separate ports of this HWSKU rather than free slots.
 
@@ -653,6 +704,49 @@ def _breakout_child_collisions(children, master, port_config):
     would do it has to be refused.
     """
     return [c for c in children if c != master and c in port_config]
+
+
+def _emit_breakout(
+    master,
+    count,
+    speed_mbps,
+    port_config,
+    breakout_cfgs,
+    breakout_ports,
+    suppressed_masters,
+):
+    lanes = _parse_lanes(port_config[master]["lanes"])
+    lpc = len(lanes) // count
+    # Refuse before mutating anything: a child slot that is a port in its own
+    # right must keep its own configuration. Leaving breakout_cfgs unset keeps
+    # the master a normal port, so the whole declaration is dropped rather
+    # than half-applied.
+    children = _breakout_child_names(master, count, lpc)
+    collisions = _breakout_child_collisions(children, master, port_config)
+    if collisions:
+        logger.error(
+            f"Declared breakout {count}x{speed_mbps // 1000}G for {master} "
+            f"would claim {', '.join(collisions)}, which are separate ports "
+            f"on this HWSKU; refusing the declaration"
+        )
+        return
+    # Read the master index and build its breakout_cfgs entry before staging
+    # any children, so a missing "index" fails cleanly without leaving orphan
+    # breakout_ports entries behind.
+    master_cfg = {
+        "breakout_owner": "MANUAL",
+        "brkout_mode": f"{count}x{speed_mbps // 1000}G",
+        "port": f"1/{port_config[master]['index']}",
+    }
+    for i, child in enumerate(children):
+        breakout_ports[child] = {
+            "master": master,
+            "declared": True,
+            "lanes": ",".join(lanes[i * lpc : (i + 1) * lpc]),
+            "speed": speed_mbps,
+        }
+    breakout_cfgs[master] = master_cfg
+    suppressed_masters.add(master)
 
 
 def detect_breakout_ports(device):
@@ -702,6 +796,81 @@ def detect_breakout_ports(device):
         except Exception as e:
             logger.warning(f"Could not load port config for {device_hwsku}: {e}")
             return {"breakout_cfgs": breakout_cfgs, "breakout_ports": breakout_ports}
+
+        suppressed_masters: set = set()
+
+        # Declared-mode pass: honor explicit breakout map before inference
+        modes = get_declared_breakout_modes(device)
+        master_to_keys: dict = {}
+        for key, mode in modes.items():
+            try:
+                if not isinstance(key, str):
+                    master = None
+                elif re.fullmatch(r"Ethernet\d+", key):
+                    master = key
+                elif re.fullmatch(r"Eth1/\d+", key):
+                    resolved = _map_interface_name_to_sonic(
+                        key, interface_names, port_config, device_hwsku
+                    )
+                    master = (
+                        resolved if re.fullmatch(r"Ethernet\d+", resolved) else None
+                    )
+                else:
+                    master = None
+                master_to_keys.setdefault(master, []).append((key, mode))
+            except Exception as e:
+                logger.error(f"Error normalizing declared breakout key {key!r}: {e}")
+
+        for master, key_mode_list in master_to_keys.items():
+            try:
+                if master is None:
+                    # Multiple keys can normalize to None simply because none of
+                    # them resolves to a known port; that is not a collision.
+                    for key, _mode in key_mode_list:
+                        logger.error(
+                            f"Declared breakout key {key!r} could not be "
+                            f"resolved to a known port"
+                        )
+                    continue
+                if len(key_mode_list) >= 2:
+                    suppressed_masters.add(master)
+                    logger.error(
+                        f"Declared breakout collision for {master}: "
+                        f"keys {[k for k, _ in key_mode_list]}"
+                    )
+                    continue
+                key, mode = key_mode_list[0]
+                if master not in port_config:
+                    logger.error(
+                        f"Declared breakout key {key!r} could not be resolved to a known port"
+                    )
+                    continue
+                suppressed_masters.add(master)
+                parsed = _parse_breakout_mode(mode)
+                if parsed is None:
+                    logger.error(
+                        f"Declared breakout mode {mode!r} for {master} is invalid"
+                    )
+                    continue
+                count, speed_mbps = parsed
+                L = len(_parse_lanes(port_config[master]["lanes"]))
+                if L == 0 or L % count != 0:
+                    logger.error(
+                        f"Declared breakout {mode!r} for {master}: "
+                        f"{L} lanes not divisible by {count}"
+                    )
+                    continue
+                _emit_breakout(
+                    master,
+                    count,
+                    speed_mbps,
+                    port_config,
+                    breakout_cfgs,
+                    breakout_ports,
+                    suppressed_masters,
+                )
+            except Exception as e:
+                logger.error(f"Error processing declared breakout for {master!r}: {e}")
 
         # Process interfaces that match breakout patterns
         processed_groups = set()
@@ -776,6 +945,9 @@ def detect_breakout_ports(device):
                                     logger.debug(
                                         f"Unsupported breakout configuration: {num_subports} ports at {interface_speed} Mbps"
                                     )
+                                    continue
+
+                                if master_port in suppressed_masters:
                                     continue
 
                                 # Calculate physical port number (1/1 -> port 1, 1/2 -> port 2, etc.)
@@ -879,6 +1051,10 @@ def detect_breakout_ports(device):
                                 if len(sonic_400g_breakout_group) == 4:
                                     processed_groups.add(group_key_400g)
                                     master_port = f"Ethernet{base_port_400g}"
+
+                                    if master_port in suppressed_masters:
+                                        continue
+
                                     brkout_mode = "4x100G"
 
                                     # Calculate physical port number for 400G ports
@@ -989,6 +1165,9 @@ def detect_breakout_ports(device):
                     brkout_mode = BREAKOUT_MODE_BY_SPEED.get(interface_speed)
                     if not brkout_mode:
                         continue  # Skip unsupported speeds
+
+                    if master_port in suppressed_masters:
+                        continue
 
                     # Calculate physical port number (Ethernet0-3 -> port 1/1, Ethernet4-7 -> port 1/2, etc.)
                     physical_port_index = (base_port // 4) + 1

--- a/tests/e2e/golden/osism_e2e-breakout-declared_config_db.json
+++ b/tests/e2e/golden/osism_e2e-breakout-declared_config_db.json
@@ -1,0 +1,775 @@
+{
+  "BGP_GLOBALS": {
+    "default": {
+      "always_compare_med": "true",
+      "ebgp_requires_policy": "false",
+      "external_compare_router_id": "false",
+      "fast_external_failover": "true",
+      "holdtime": "180",
+      "ignore_as_path_length": "false",
+      "keepalive": "60",
+      "load_balance_mp_relax": "false",
+      "log_nbr_state_changes": "true",
+      "network_import_check": "true"
+    }
+  },
+  "BGP_GLOBALS_AF": {
+    "default|ipv4_unicast": {
+      "ibgp_equal_cluster_length": "false",
+      "max_ebgp_paths": "2",
+      "max_ibgp_paths": "2",
+      "route_flap_dampen": "false"
+    },
+    "default|ipv6_unicast": {
+      "ibgp_equal_cluster_length": "false",
+      "max_ebgp_paths": "2",
+      "max_ibgp_paths": "2"
+    },
+    "default|l2vpn_evpn": {
+      "advertise-all-vni": "true",
+      "advertise-svi-ip": "true",
+      "dad-enabled": "true"
+    }
+  },
+  "BGP_GLOBALS_AF_NETWORK": {},
+  "BGP_GLOBALS_ROUTE_ADVERTISE": {
+    "default|L2VPN_EVPN|IPV4_UNICAST": {},
+    "default|L2VPN_EVPN|IPV6_UNICAST": {}
+  },
+  "BGP_NEIGHBOR": {},
+  "BGP_NEIGHBOR_AF": {},
+  "BREAKOUT_CFG": {
+    "Ethernet0": {
+      "breakout_owner": "MANUAL",
+      "brkout_mode": "4x100G",
+      "port": "1/1"
+    },
+    "Ethernet64": {
+      "breakout_owner": "MANUAL",
+      "brkout_mode": "8x50G",
+      "port": "1/9"
+    },
+    "Ethernet8": {
+      "breakout_owner": "MANUAL",
+      "brkout_mode": "2x50G",
+      "port": "1/2"
+    }
+  },
+  "BREAKOUT_PORTS": {
+    "Ethernet0": {
+      "master": "Ethernet0"
+    },
+    "Ethernet12": {
+      "master": "Ethernet8"
+    },
+    "Ethernet2": {
+      "master": "Ethernet0"
+    },
+    "Ethernet4": {
+      "master": "Ethernet0"
+    },
+    "Ethernet6": {
+      "master": "Ethernet0"
+    },
+    "Ethernet64": {
+      "master": "Ethernet64"
+    },
+    "Ethernet65": {
+      "master": "Ethernet64"
+    },
+    "Ethernet66": {
+      "master": "Ethernet64"
+    },
+    "Ethernet67": {
+      "master": "Ethernet64"
+    },
+    "Ethernet68": {
+      "master": "Ethernet64"
+    },
+    "Ethernet69": {
+      "master": "Ethernet64"
+    },
+    "Ethernet70": {
+      "master": "Ethernet64"
+    },
+    "Ethernet71": {
+      "master": "Ethernet64"
+    },
+    "Ethernet8": {
+      "master": "Ethernet8"
+    }
+  },
+  "DEVICE_METADATA": {
+    "localhost": {
+      "hostname": "e2e-breakout-declared",
+      "hwsku": "Accton-AS9726-32D",
+      "mac": "00:00:00:00:00:00",
+      "platform": "x86_64-accton_as9726_32d-r0"
+    }
+  },
+  "DNS_NAMESERVER": {},
+  "INTERFACE": {},
+  "LOOPBACK": {},
+  "LOOPBACK_INTERFACE": {},
+  "MGMT_INTERFACE": {},
+  "NTP_SERVER": {},
+  "PORT": {
+    "Ethernet0": {
+      "admin_status": "down",
+      "adv_speeds": "all",
+      "alias": "Eth1/1/1",
+      "autoneg": "off",
+      "index": "1",
+      "lanes": "73,74",
+      "link_training": "off",
+      "mtu": "9100",
+      "speed": "100000",
+      "unreliable_los": "auto",
+      "valid_speeds": "100000,50000,25000,10000,1000"
+    },
+    "Ethernet104": {
+      "admin_status": "down",
+      "adv_speeds": "all",
+      "alias": "Eth1/14",
+      "autoneg": "off",
+      "index": "14",
+      "lanes": "137,138,139,140,141,142,143,144",
+      "link_training": "off",
+      "mtu": "9100",
+      "speed": "400000",
+      "unreliable_los": "auto",
+      "valid_speeds": "400000"
+    },
+    "Ethernet112": {
+      "admin_status": "down",
+      "adv_speeds": "all",
+      "alias": "Eth1/15",
+      "autoneg": "off",
+      "index": "15",
+      "lanes": "145,146,147,148,149,150,151,152",
+      "link_training": "off",
+      "mtu": "9100",
+      "speed": "400000",
+      "unreliable_los": "auto",
+      "valid_speeds": "400000"
+    },
+    "Ethernet12": {
+      "admin_status": "down",
+      "adv_speeds": "all",
+      "alias": "Eth1/2/5",
+      "autoneg": "off",
+      "index": "2",
+      "lanes": "69,70,71,72",
+      "link_training": "off",
+      "mtu": "9100",
+      "speed": "50000",
+      "unreliable_los": "auto",
+      "valid_speeds": "50000,25000,10000,1000"
+    },
+    "Ethernet120": {
+      "admin_status": "down",
+      "adv_speeds": "all",
+      "alias": "Eth1/16",
+      "autoneg": "off",
+      "index": "16",
+      "lanes": "153,154,155,156,157,158,159,160",
+      "link_training": "off",
+      "mtu": "9100",
+      "speed": "400000",
+      "unreliable_los": "auto",
+      "valid_speeds": "400000"
+    },
+    "Ethernet128": {
+      "admin_status": "down",
+      "adv_speeds": "all",
+      "alias": "Eth1/17",
+      "autoneg": "off",
+      "index": "17",
+      "lanes": "169,170,171,172,173,174,175,176",
+      "link_training": "off",
+      "mtu": "9100",
+      "speed": "400000",
+      "unreliable_los": "auto",
+      "valid_speeds": "400000"
+    },
+    "Ethernet136": {
+      "admin_status": "down",
+      "adv_speeds": "all",
+      "alias": "Eth1/18",
+      "autoneg": "off",
+      "index": "18",
+      "lanes": "161,162,163,164,165,166,167,168",
+      "link_training": "off",
+      "mtu": "9100",
+      "speed": "400000",
+      "unreliable_los": "auto",
+      "valid_speeds": "400000"
+    },
+    "Ethernet144": {
+      "admin_status": "down",
+      "adv_speeds": "all",
+      "alias": "Eth1/19",
+      "autoneg": "off",
+      "index": "19",
+      "lanes": "177,178,179,180,181,182,183,184",
+      "link_training": "off",
+      "mtu": "9100",
+      "speed": "400000",
+      "unreliable_los": "auto",
+      "valid_speeds": "400000"
+    },
+    "Ethernet152": {
+      "admin_status": "down",
+      "adv_speeds": "all",
+      "alias": "Eth1/20",
+      "autoneg": "off",
+      "index": "20",
+      "lanes": "185,186,187,188,189,190,191,192",
+      "link_training": "off",
+      "mtu": "9100",
+      "speed": "400000",
+      "unreliable_los": "auto",
+      "valid_speeds": "400000"
+    },
+    "Ethernet16": {
+      "admin_status": "down",
+      "adv_speeds": "all",
+      "alias": "Eth1/3",
+      "autoneg": "off",
+      "index": "3",
+      "lanes": "81,82,83,84,85,86,87,88",
+      "link_training": "off",
+      "mtu": "9100",
+      "speed": "400000",
+      "unreliable_los": "auto",
+      "valid_speeds": "400000"
+    },
+    "Ethernet160": {
+      "admin_status": "down",
+      "adv_speeds": "all",
+      "alias": "Eth1/21",
+      "autoneg": "off",
+      "index": "21",
+      "lanes": "1,2,3,4,5,6,7,8",
+      "link_training": "off",
+      "mtu": "9100",
+      "speed": "400000",
+      "unreliable_los": "auto",
+      "valid_speeds": "400000"
+    },
+    "Ethernet168": {
+      "admin_status": "down",
+      "adv_speeds": "all",
+      "alias": "Eth1/22",
+      "autoneg": "off",
+      "index": "22",
+      "lanes": "9,10,11,12,13,14,15,16",
+      "link_training": "off",
+      "mtu": "9100",
+      "speed": "400000",
+      "unreliable_los": "auto",
+      "valid_speeds": "400000"
+    },
+    "Ethernet176": {
+      "admin_status": "down",
+      "adv_speeds": "all",
+      "alias": "Eth1/23",
+      "autoneg": "off",
+      "index": "23",
+      "lanes": "17,18,19,20,21,22,23,24",
+      "link_training": "off",
+      "mtu": "9100",
+      "speed": "400000",
+      "unreliable_los": "auto",
+      "valid_speeds": "400000"
+    },
+    "Ethernet184": {
+      "admin_status": "down",
+      "adv_speeds": "all",
+      "alias": "Eth1/24",
+      "autoneg": "off",
+      "index": "24",
+      "lanes": "25,26,27,28,29,30,31,32",
+      "link_training": "off",
+      "mtu": "9100",
+      "speed": "400000",
+      "unreliable_los": "auto",
+      "valid_speeds": "400000"
+    },
+    "Ethernet192": {
+      "admin_status": "down",
+      "adv_speeds": "all",
+      "alias": "Eth1/25",
+      "autoneg": "off",
+      "index": "25",
+      "lanes": "201,202,203,204,205,206,207,208",
+      "link_training": "off",
+      "mtu": "9100",
+      "speed": "400000",
+      "unreliable_los": "auto",
+      "valid_speeds": "400000"
+    },
+    "Ethernet2": {
+      "admin_status": "down",
+      "adv_speeds": "all",
+      "alias": "Eth1/1/3",
+      "autoneg": "off",
+      "index": "1",
+      "lanes": "75,76",
+      "link_training": "off",
+      "mtu": "9100",
+      "speed": "100000",
+      "unreliable_los": "auto",
+      "valid_speeds": "100000,50000,25000,10000,1000"
+    },
+    "Ethernet200": {
+      "admin_status": "down",
+      "adv_speeds": "all",
+      "alias": "Eth1/26",
+      "autoneg": "off",
+      "index": "26",
+      "lanes": "193,194,195,196,197,198,199,200",
+      "link_training": "off",
+      "mtu": "9100",
+      "speed": "400000",
+      "unreliable_los": "auto",
+      "valid_speeds": "400000"
+    },
+    "Ethernet208": {
+      "admin_status": "down",
+      "adv_speeds": "all",
+      "alias": "Eth1/27",
+      "autoneg": "off",
+      "index": "27",
+      "lanes": "217,218,219,220,221,222,223,224",
+      "link_training": "off",
+      "mtu": "9100",
+      "speed": "400000",
+      "unreliable_los": "auto",
+      "valid_speeds": "400000"
+    },
+    "Ethernet216": {
+      "admin_status": "down",
+      "adv_speeds": "all",
+      "alias": "Eth1/28",
+      "autoneg": "off",
+      "index": "28",
+      "lanes": "209,210,211,212,213,214,215,216",
+      "link_training": "off",
+      "mtu": "9100",
+      "speed": "400000",
+      "unreliable_los": "auto",
+      "valid_speeds": "400000"
+    },
+    "Ethernet224": {
+      "admin_status": "down",
+      "adv_speeds": "all",
+      "alias": "Eth1/29",
+      "autoneg": "off",
+      "index": "29",
+      "lanes": "233,234,235,236,237,238,239,240",
+      "link_training": "off",
+      "mtu": "9100",
+      "speed": "400000",
+      "unreliable_los": "auto",
+      "valid_speeds": "400000"
+    },
+    "Ethernet232": {
+      "admin_status": "down",
+      "adv_speeds": "all",
+      "alias": "Eth1/30",
+      "autoneg": "off",
+      "index": "30",
+      "lanes": "225,226,227,228,229,230,231,232",
+      "link_training": "off",
+      "mtu": "9100",
+      "speed": "400000",
+      "unreliable_los": "auto",
+      "valid_speeds": "400000"
+    },
+    "Ethernet24": {
+      "admin_status": "down",
+      "adv_speeds": "all",
+      "alias": "Eth1/4",
+      "autoneg": "off",
+      "index": "4",
+      "lanes": "89,90,91,92,93,94,95,96",
+      "link_training": "off",
+      "mtu": "9100",
+      "speed": "400000",
+      "unreliable_los": "auto",
+      "valid_speeds": "400000"
+    },
+    "Ethernet240": {
+      "admin_status": "down",
+      "adv_speeds": "all",
+      "alias": "Eth1/31",
+      "autoneg": "off",
+      "index": "31",
+      "lanes": "249,250,251,252,253,254,255,256",
+      "link_training": "off",
+      "mtu": "9100",
+      "speed": "400000",
+      "unreliable_los": "auto",
+      "valid_speeds": "400000"
+    },
+    "Ethernet248": {
+      "admin_status": "down",
+      "adv_speeds": "all",
+      "alias": "Eth1/32",
+      "autoneg": "off",
+      "index": "32",
+      "lanes": "241,242,243,244,245,246,247,248",
+      "link_training": "off",
+      "mtu": "9100",
+      "speed": "400000",
+      "unreliable_los": "auto",
+      "valid_speeds": "400000"
+    },
+    "Ethernet256": {
+      "admin_status": "down",
+      "adv_speeds": "all",
+      "alias": "Eth1/33",
+      "autoneg": "off",
+      "index": "33",
+      "lanes": "259",
+      "link_training": "off",
+      "mtu": "9100",
+      "speed": "10000",
+      "unreliable_los": "auto",
+      "valid_speeds": "10000"
+    },
+    "Ethernet257": {
+      "admin_status": "down",
+      "adv_speeds": "all",
+      "alias": "Eth1/34",
+      "autoneg": "off",
+      "index": "34",
+      "lanes": "260",
+      "link_training": "off",
+      "mtu": "9100",
+      "speed": "10000",
+      "unreliable_los": "auto",
+      "valid_speeds": "10000"
+    },
+    "Ethernet32": {
+      "admin_status": "down",
+      "adv_speeds": "all",
+      "alias": "Eth1/5",
+      "autoneg": "off",
+      "index": "5",
+      "lanes": "97,98,99,100,101,102,103,104",
+      "link_training": "off",
+      "mtu": "9100",
+      "speed": "400000",
+      "unreliable_los": "auto",
+      "valid_speeds": "400000"
+    },
+    "Ethernet4": {
+      "admin_status": "down",
+      "adv_speeds": "all",
+      "alias": "Eth1/1/5",
+      "autoneg": "off",
+      "index": "1",
+      "lanes": "77,78",
+      "link_training": "off",
+      "mtu": "9100",
+      "speed": "100000",
+      "unreliable_los": "auto",
+      "valid_speeds": "100000,50000,25000,10000,1000"
+    },
+    "Ethernet40": {
+      "admin_status": "down",
+      "adv_speeds": "all",
+      "alias": "Eth1/6",
+      "autoneg": "off",
+      "index": "6",
+      "lanes": "105,106,107,108,109,110,111,112",
+      "link_training": "off",
+      "mtu": "9100",
+      "speed": "400000",
+      "unreliable_los": "auto",
+      "valid_speeds": "400000"
+    },
+    "Ethernet48": {
+      "admin_status": "down",
+      "adv_speeds": "all",
+      "alias": "Eth1/7",
+      "autoneg": "off",
+      "index": "7",
+      "lanes": "113,114,115,116,117,118,119,120",
+      "link_training": "off",
+      "mtu": "9100",
+      "speed": "400000",
+      "unreliable_los": "auto",
+      "valid_speeds": "400000"
+    },
+    "Ethernet56": {
+      "admin_status": "down",
+      "adv_speeds": "all",
+      "alias": "Eth1/8",
+      "autoneg": "off",
+      "index": "8",
+      "lanes": "121,122,123,124,125,126,127,128",
+      "link_training": "off",
+      "mtu": "9100",
+      "speed": "400000",
+      "unreliable_los": "auto",
+      "valid_speeds": "400000"
+    },
+    "Ethernet6": {
+      "admin_status": "down",
+      "adv_speeds": "all",
+      "alias": "Eth1/1/7",
+      "autoneg": "off",
+      "index": "1",
+      "lanes": "79,80",
+      "link_training": "off",
+      "mtu": "9100",
+      "speed": "100000",
+      "unreliable_los": "auto",
+      "valid_speeds": "100000,50000,25000,10000,1000"
+    },
+    "Ethernet64": {
+      "admin_status": "down",
+      "adv_speeds": "all",
+      "alias": "Eth1/9/1",
+      "autoneg": "off",
+      "index": "9",
+      "lanes": "41",
+      "link_training": "off",
+      "mtu": "9100",
+      "speed": "50000",
+      "unreliable_los": "auto",
+      "valid_speeds": "50000,25000,10000,1000"
+    },
+    "Ethernet65": {
+      "admin_status": "down",
+      "adv_speeds": "all",
+      "alias": "Eth1/9/2",
+      "autoneg": "off",
+      "index": "9",
+      "lanes": "42",
+      "link_training": "off",
+      "mtu": "9100",
+      "speed": "50000",
+      "unreliable_los": "auto",
+      "valid_speeds": "50000,25000,10000,1000"
+    },
+    "Ethernet66": {
+      "admin_status": "down",
+      "adv_speeds": "all",
+      "alias": "Eth1/9/3",
+      "autoneg": "off",
+      "index": "9",
+      "lanes": "43",
+      "link_training": "off",
+      "mtu": "9100",
+      "speed": "50000",
+      "unreliable_los": "auto",
+      "valid_speeds": "50000,25000,10000,1000"
+    },
+    "Ethernet67": {
+      "admin_status": "down",
+      "adv_speeds": "all",
+      "alias": "Eth1/9/4",
+      "autoneg": "off",
+      "index": "9",
+      "lanes": "44",
+      "link_training": "off",
+      "mtu": "9100",
+      "speed": "50000",
+      "unreliable_los": "auto",
+      "valid_speeds": "50000,25000,10000,1000"
+    },
+    "Ethernet68": {
+      "admin_status": "down",
+      "adv_speeds": "all",
+      "alias": "Eth1/9/5",
+      "autoneg": "off",
+      "index": "9",
+      "lanes": "45",
+      "link_training": "off",
+      "mtu": "9100",
+      "speed": "50000",
+      "unreliable_los": "auto",
+      "valid_speeds": "50000,25000,10000,1000"
+    },
+    "Ethernet69": {
+      "admin_status": "down",
+      "adv_speeds": "all",
+      "alias": "Eth1/9/6",
+      "autoneg": "off",
+      "index": "9",
+      "lanes": "46",
+      "link_training": "off",
+      "mtu": "9100",
+      "speed": "50000",
+      "unreliable_los": "auto",
+      "valid_speeds": "50000,25000,10000,1000"
+    },
+    "Ethernet70": {
+      "admin_status": "down",
+      "adv_speeds": "all",
+      "alias": "Eth1/9/7",
+      "autoneg": "off",
+      "index": "9",
+      "lanes": "47",
+      "link_training": "off",
+      "mtu": "9100",
+      "speed": "50000",
+      "unreliable_los": "auto",
+      "valid_speeds": "50000,25000,10000,1000"
+    },
+    "Ethernet71": {
+      "admin_status": "down",
+      "adv_speeds": "all",
+      "alias": "Eth1/9/8",
+      "autoneg": "off",
+      "index": "9",
+      "lanes": "48",
+      "link_training": "off",
+      "mtu": "9100",
+      "speed": "50000",
+      "unreliable_los": "auto",
+      "valid_speeds": "50000,25000,10000,1000"
+    },
+    "Ethernet72": {
+      "admin_status": "down",
+      "adv_speeds": "all",
+      "alias": "Eth1/10",
+      "autoneg": "off",
+      "index": "10",
+      "lanes": "33,34,35,36,37,38,39,40",
+      "link_training": "off",
+      "mtu": "9100",
+      "speed": "400000",
+      "unreliable_los": "auto",
+      "valid_speeds": "400000"
+    },
+    "Ethernet8": {
+      "admin_status": "down",
+      "adv_speeds": "all",
+      "alias": "Eth1/2/1",
+      "autoneg": "off",
+      "index": "2",
+      "lanes": "65,66,67,68",
+      "link_training": "off",
+      "mtu": "9100",
+      "speed": "50000",
+      "unreliable_los": "auto",
+      "valid_speeds": "50000,25000,10000,1000"
+    },
+    "Ethernet80": {
+      "admin_status": "down",
+      "adv_speeds": "all",
+      "alias": "Eth1/11",
+      "autoneg": "off",
+      "index": "11",
+      "lanes": "49,50,51,52,53,54,55,56",
+      "link_training": "off",
+      "mtu": "9100",
+      "speed": "400000",
+      "unreliable_los": "auto",
+      "valid_speeds": "400000"
+    },
+    "Ethernet88": {
+      "admin_status": "down",
+      "adv_speeds": "all",
+      "alias": "Eth1/12",
+      "autoneg": "off",
+      "index": "12",
+      "lanes": "57,58,59,60,61,62,63,64",
+      "link_training": "off",
+      "mtu": "9100",
+      "speed": "400000",
+      "unreliable_los": "auto",
+      "valid_speeds": "400000"
+    },
+    "Ethernet96": {
+      "admin_status": "down",
+      "adv_speeds": "all",
+      "alias": "Eth1/13",
+      "autoneg": "off",
+      "index": "13",
+      "lanes": "129,130,131,132,133,134,135,136",
+      "link_training": "off",
+      "mtu": "9100",
+      "speed": "400000",
+      "unreliable_los": "auto",
+      "valid_speeds": "400000"
+    }
+  },
+  "PORTCHANNEL": {},
+  "PORTCHANNEL_INTERFACE": {},
+  "PORTCHANNEL_MEMBER": {},
+  "ROUTE_REDISTRIBUTE": {
+    "default|connected|bgp|ipv4": {},
+    "default|connected|bgp|ipv6": {}
+  },
+  "SNMP_SERVER": {
+    "SYSTEM": {
+      "sysContact": "e2e@example.com",
+      "sysLocation": "E2E Lab",
+      "traps": "enable"
+    }
+  },
+  "SNMP_SERVER_GROUP_MEMBER": {
+    "monitoring|e2e-monitor": {
+      "securityModel": [
+        "usm"
+      ]
+    }
+  },
+  "SNMP_SERVER_PARAMS": {
+    "targetEntry1": {
+      "security-level": "auth-priv",
+      "user": "e2e-monitor"
+    }
+  },
+  "SNMP_SERVER_TARGET": {
+    "targetEntry1": {
+      "ip": "172.16.10.254",
+      "port": "162",
+      "retries": "3",
+      "tag": [
+        "trapNotify",
+        "mgmt"
+      ],
+      "targetParams": "targetEntry1",
+      "timeout": "1500"
+    }
+  },
+  "SNMP_SERVER_USER": {
+    "e2e-monitor": {
+      "aesKey": "OBFUSCATEDPRIVSECRET",
+      "shaKey": "OBFUSCATEDAUTHSECRET"
+    }
+  },
+  "STATIC_ROUTE": {},
+  "SYSLOG_SERVER": {
+    "172.16.10.254": {
+      "message-type": "log",
+      "protocol": "UDP",
+      "remote-port": "514",
+      "severity": "info",
+      "vrf_name": "mgmt"
+    }
+  },
+  "VERSIONS": {
+    "DATABASE": {
+      "VERSION": "version_4_0_1"
+    }
+  },
+  "VLAN": {},
+  "VLAN_INTERFACE": {},
+  "VLAN_MEMBER": {},
+  "VRF": {
+    "default": {
+      "enabled": "true"
+    }
+  },
+  "VXLAN_EVPN_NVO": {},
+  "VXLAN_TUNNEL": {},
+  "VXLAN_TUNNEL_MAP": {}
+}

--- a/tests/e2e/scenario/devicetypes/Edgecore/9726-32D-E2E.yaml
+++ b/tests/e2e/scenario/devicetypes/Edgecore/9726-32D-E2E.yaml
@@ -1,11 +1,13 @@
 ---
-# Minimal device type for the SONiC E2E breakout regression scenarios.
+# Minimal device type for the SONiC E2E breakout scenarios: the two
+# inference scenarios (e2e-breakout-derived, e2e-breakout-explicit) and,
+# from the declared-breakout-mode work, e2e-breakout-declared.
 #
 # This is not a faithful model of the real 9726-32D; it defines only the
-# interfaces the scenarios need. Config generation is driven by the hwsku
-# custom field (Accton-AS9726-32D on the scenario devices), not by this
-# device type -- the device type only controls which NetBox interfaces
-# exist.
+# interfaces the inference scenarios need. Config generation is driven by
+# the hwsku custom field (Accton-AS9726-32D on the scenario devices), not
+# by this device type -- the device type only controls which NetBox
+# interfaces exist.
 #
 # The interface layout mirrors how real deployments model breakouts (the
 # NetBox EthX/Y/Z sub-port notation, speed derived from the interface
@@ -16,6 +18,11 @@
 # where the sub-port speed is read back from the collected NetBox data.
 #
 # Eth1/5 is a plain (non-breakout) 100G port used for VLAN coverage.
+#
+# e2e-breakout-declared instead exercises the declared sonic_parameters.
+# breakout code path: it carries no sub-ports of its own in NetBox (the
+# splits are declared entirely via the device-level custom field), so it
+# needs nothing beyond the master ports already provided here.
 manufacturer: Edgecore
 model: 9726-32D-E2E
 slug: edgecore-9726-32d-e2e

--- a/tests/e2e/scenario/resources/500-breakout.yml
+++ b/tests/e2e/scenario/resources/500-breakout.yml
@@ -8,7 +8,7 @@
 # fields created by 100-base.yml, and take the next free positions in the
 # shared E2E rack so they never collide with the base devices.
 #
-# Both devices use the edgecore-9726-32d-e2e device type (hwsku
+# The first two devices use the edgecore-9726-32d-e2e device type (hwsku
 # Accton-AS9726-32D) and break Eth1/1 into a 4x100G group. They differ
 # only in how the sub-port speed reaches NetBox:
 #
@@ -21,6 +21,9 @@
 #                          collection step must normalise.
 #
 # Both must yield sub-port speed 100000 in the generated config.
+#
+# A third device, e2e-breakout-declared, covers the explicit
+# sonic_parameters.breakout declaration path (see its block below).
 
 # --- Derived-speed breakout (the real-deployment shape) --------------------
 
@@ -96,3 +99,45 @@
     name: Eth1/1/4
     type: 100gbase-x-qsfp28
     speed: 100000000
+
+# --- Declared breakout map (the explicit sonic_parameters.breakout path) ---
+#
+# e2e-breakout-declared carries an authoritative device-level breakout map
+# instead of modelling sub-ports in NetBox. It exercises the declared-mode
+# code path end to end on the 8-lane Accton-AS9726-32D:
+#
+#   Ethernet0: 4x100G   canonical key; 8 lanes -> 4 children (Ethernet0/2/4/6),
+#                       2 lanes each (73,74 / 75,76 / 77,78 / 79,80), 100000
+#   Ethernet8: 2x50G    canonical key; 8 lanes -> 2 children (Ethernet8/12),
+#                       4 lanes each (65,66,67,68 / 69,70,71,72), 50000
+#   Eth1/9:    8x50G    physical key normalised to Ethernet64; 8 lanes -> 8
+#                       children (Ethernet64..71), 1 lane each (41..48), 50000
+#
+# The map is the sole breakout signal: no sub-port interfaces are modelled,
+# so a golden diff here proves the declared path, not inference. Each
+# BREAKOUT_CFG entry must carry breakout_owner MANUAL, the canonical mode
+# string, and the port_config index (1/1, 1/2, 1/9 -- correct on this
+# mixed-lane platform); each BREAKOUT_PORTS child must contain only its
+# master; and the per-child PORT lanes/speed must match the mode.
+
+- device:
+    name: e2e-breakout-declared
+    tenant: Testbed
+    site: Discworld
+    location: Ankh-Morpork
+    rack: E2E
+    device_type: edgecore-9726-32d-e2e
+    device_role: leaf
+    face: front
+    position: 8
+    status: active
+    tags:
+      - managed-by-metalbox
+    custom_fields:
+      sonic_parameters:
+        hwsku: Accton-AS9726-32D
+        version: 4.5.0
+        breakout:
+          Ethernet0: 4x100G
+          Ethernet8: 2x50G
+          Eth1/9: 8x50G

--- a/tests/unit/tasks/conductor/sonic/_detection_helpers.py
+++ b/tests/unit/tasks/conductor/sonic/_detection_helpers.py
@@ -9,6 +9,8 @@ the module is private (``_``-prefixed) so pytest does not collect it.
 from pathlib import Path
 from types import SimpleNamespace
 
+_DEFAULT = object()
+
 
 def repo_root():
     """Return the repository root, found by its ``setup.cfg`` marker.
@@ -23,12 +25,16 @@ def repo_root():
     raise RuntimeError("no repository root with setup.cfg above this file")
 
 
-def _make_sonic_device(device_id=1, name="sw1", hwsku="TEST-HWSKU"):
+def _make_sonic_device(
+    device_id=1, name="sw1", hwsku="TEST-HWSKU", custom_fields=_DEFAULT
+):
     """Build a NetBox device stub carrying ``custom_fields.sonic_parameters.hwsku``."""
+    if custom_fields is _DEFAULT:
+        custom_fields = {"sonic_parameters": {"hwsku": hwsku}}
     return SimpleNamespace(
         id=device_id,
         name=name,
-        custom_fields={"sonic_parameters": {"hwsku": hwsku}},
+        custom_fields=custom_fields,
     )
 
 

--- a/tests/unit/tasks/conductor/sonic/test_breakout_detection.py
+++ b/tests/unit/tasks/conductor/sonic/test_breakout_detection.py
@@ -14,7 +14,13 @@ from types import SimpleNamespace
 import pytest
 
 from osism.tasks.conductor.sonic import interface as interface_module
-from osism.tasks.conductor.sonic.interface import detect_breakout_ports
+from osism.tasks.conductor.sonic.interface import (
+    detect_breakout_ports,
+    _emit_breakout,
+    _parse_lanes,
+    _parse_breakout_mode,
+    get_declared_breakout_modes,
+)
 
 from ._detection_helpers import _make_iface, _make_sonic_device, repo_root
 
@@ -571,6 +577,363 @@ def test_detect_breakout_ports_sonic_standard_speed_resolved_from_port_type(
 
 
 # ---------------------------------------------------------------------------
+# _parse_lanes
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "s,out",
+    [
+        ("1,2,3,4", ["1", "2", "3", "4"]),
+        (
+            "73,74,75,76,77,78,79,80",
+            ["73", "74", "75", "76", "77", "78", "79", "80"],
+        ),
+        ("1-4", ["1", "2", "3", "4"]),
+        ("29", ["29"]),
+        ("", []),
+        ("  ", []),
+        ("a,b", []),
+        ("4-1", []),
+        ("1-", []),
+        ("x-3", []),
+        (None, []),
+        (29, []),
+        (["1", "2"], []),
+    ],
+)
+def test_parse_lanes(s, out):
+    assert _parse_lanes(s) == out
+
+
+# ---------------------------------------------------------------------------
+# _parse_breakout_mode
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "m,out",
+    [
+        ("4x10G", (4, 10000)),
+        ("2x50G", (2, 50000)),
+        ("8x50G", (8, 50000)),
+        ("4x100G", (4, 100000)),
+        ("2x200G", (2, 200000)),
+        ("1x400G", None),
+        ("0x10G", None),
+        ("4x0G", None),
+        ("4x10g", None),
+        (" 4x10G ", (4, 10000)),
+        ("bogus", None),
+        ("4x", None),
+        ("x10G", None),
+        ("", None),
+        (None, None),
+        (10, None),
+        ({}, None),
+    ],
+)
+def test_parse_breakout_mode(m, out):
+    assert _parse_breakout_mode(m) == out
+
+
+# ---------------------------------------------------------------------------
+# get_declared_breakout_modes
+# ---------------------------------------------------------------------------
+
+
+def test_declared_modes_map():
+    d = _make_sonic_device(
+        custom_fields={
+            "sonic_parameters": {
+                "hwsku": "x",
+                "breakout": {"Ethernet0": "4x10G", "Eth1/9": "2x50G"},
+            }
+        }
+    )
+    assert get_declared_breakout_modes(d) == {"Ethernet0": "4x10G", "Eth1/9": "2x50G"}
+
+
+@pytest.mark.parametrize(
+    "cf",
+    [
+        {"sonic_parameters": {"hwsku": "x"}},
+        {"sonic_parameters": {"breakout": None}},
+        {"sonic_parameters": {"breakout": "Ethernet0: 4x10G"}},
+        {"sonic_parameters": {"breakout": []}},
+        {"sonic_parameters": None},
+        {},
+        None,
+    ],
+)
+def test_declared_modes_malformed_or_absent(cf):
+    assert get_declared_breakout_modes(_make_sonic_device(custom_fields=cf)) == {}
+
+
+# ---------------------------------------------------------------------------
+# detect_breakout_ports — declared-mode pass (Task 5)
+# ---------------------------------------------------------------------------
+
+
+_GATE_PC = {
+    "Ethernet0": {
+        "lanes": "1,2,3,4",
+        "alias": "Eth1/1",
+        "index": "1",
+        "speed": "25000",
+    }
+}  # Eth1/1/2/3 absent -> gate accepts
+
+
+def test_declared_4x10g(patch_breakout_helpers):
+    d = _make_sonic_device(
+        custom_fields={
+            "sonic_parameters": {"hwsku": "x", "breakout": {"Ethernet0": "4x10G"}}
+        }
+    )
+    patch_breakout_helpers(
+        interfaces=[], port_config=_port_config_for_port(lanes="1,2,3,4")
+    )
+    r = detect_breakout_ports(d)
+    assert r["breakout_cfgs"]["Ethernet0"]["brkout_mode"] == "4x10G"
+    assert {k: v["lanes"] for k, v in r["breakout_ports"].items()} == {
+        "Ethernet0": "1",
+        "Ethernet1": "2",
+        "Ethernet2": "3",
+        "Ethernet3": "4",
+    }
+    assert all(v["declared"] for v in r["breakout_ports"].values())
+
+
+def test_declared_2x50g(patch_breakout_helpers):
+    d = _make_sonic_device(
+        custom_fields={
+            "sonic_parameters": {"hwsku": "x", "breakout": {"Ethernet0": "2x50G"}}
+        }
+    )
+    patch_breakout_helpers(
+        interfaces=[], port_config=_port_config_for_port(lanes="1,2,3,4")
+    )
+    assert {
+        k: v["lanes"] for k, v in detect_breakout_ports(d)["breakout_ports"].items()
+    } == {"Ethernet0": "1,2", "Ethernet2": "3,4"}
+
+
+def test_declared_8x50g(patch_breakout_helpers):
+    d = _make_sonic_device(
+        custom_fields={
+            "sonic_parameters": {"hwsku": "x", "breakout": {"Ethernet0": "8x50G"}}
+        }
+    )
+    patch_breakout_helpers(
+        interfaces=[], port_config=_port_config_for_port(lanes="1,2,3,4,5,6,7,8")
+    )
+    r = detect_breakout_ports(d)
+    assert set(r["breakout_ports"]) == {f"Ethernet{n}" for n in range(8)}
+    assert r["breakout_ports"]["Ethernet0"]["lanes"] == "1"
+
+
+def test_declared_4x100g_8lane(patch_breakout_helpers):
+    d = _make_sonic_device(
+        custom_fields={
+            "sonic_parameters": {"hwsku": "x", "breakout": {"Ethernet0": "4x100G"}}
+        }
+    )
+    patch_breakout_helpers(
+        interfaces=[], port_config=_port_config_for_port(lanes="1,2,3,4,5,6,7,8")
+    )
+    assert {
+        k: v["lanes"] for k, v in detect_breakout_ports(d)["breakout_ports"].items()
+    } == {
+        "Ethernet0": "1,2",
+        "Ethernet2": "3,4",
+        "Ethernet4": "5,6",
+        "Ethernet6": "7,8",
+    }
+
+
+def test_declared_key_eth1(patch_breakout_helpers):
+    d = _make_sonic_device(
+        custom_fields={
+            "sonic_parameters": {
+                "hwsku": "x",
+                "breakout": {"Eth1/1": "4x10G"},
+            }
+        }
+    )
+    patch_breakout_helpers(
+        interfaces=[],
+        port_config=_port_config_for_port(lanes="1,2,3,4", alias="Eth1/1"),
+    )
+    assert (
+        detect_breakout_ports(d)["breakout_cfgs"]["Ethernet0"]["brkout_mode"] == "4x10G"
+    )
+
+
+def test_declared_mixed_layout_port_index(patch_breakout_helpers):
+    pc = {
+        **{
+            f"Ethernet{n}": {
+                "lanes": str(29 + n),
+                "alias": f"Eth{n + 1}(Port{n + 1})",
+                "index": str(n + 1),
+                "speed": "25000",
+            }
+            for n in range(12)
+        },
+        "Ethernet12": {
+            "lanes": "41,42,43,44",
+            "alias": "Eth13(Port13)",
+            "index": "13",
+            "speed": "100000",
+        },
+    }
+    d = _make_sonic_device(
+        custom_fields={
+            "sonic_parameters": {
+                "hwsku": "x",
+                "breakout": {"Ethernet12": "4x25G"},
+            }
+        }
+    )
+    patch_breakout_helpers(interfaces=[], port_config=pc)
+    assert detect_breakout_ports(d)["breakout_cfgs"]["Ethernet12"]["port"] == "1/13"
+
+
+def test_inference_control(patch_breakout_helpers):
+    ifaces = [_make_iface(f"Ethernet{n}", speed=25_000_000) for n in range(4)]
+    patch_breakout_helpers(interfaces=ifaces, port_config=_GATE_PC)
+    assert (
+        detect_breakout_ports(_make_sonic_device())["breakout_cfgs"]["Ethernet0"][
+            "brkout_mode"
+        ]
+        == "4x25G"
+    )
+
+
+def test_invalid_mode_suppresses_inference(patch_breakout_helpers):
+    ifaces = [_make_iface(f"Ethernet{n}", speed=25_000_000) for n in range(4)]
+    d = _make_sonic_device(
+        custom_fields={
+            "sonic_parameters": {
+                "hwsku": "x",
+                "breakout": {"Ethernet0": "3x25G"},
+            }
+        }
+    )  # 4 % 3 != 0
+    patch_breakout_helpers(interfaces=ifaces, port_config=_GATE_PC)
+    assert detect_breakout_ports(d) == {"breakout_cfgs": {}, "breakout_ports": {}}
+
+
+def test_collision_fail_closed(patch_breakout_helpers):
+    ifaces = [_make_iface(f"Ethernet{n}", speed=25_000_000) for n in range(4)]
+    d = _make_sonic_device(
+        custom_fields={
+            "sonic_parameters": {
+                "hwsku": "x",
+                "breakout": {"Ethernet0": "4x25G", "Eth1/1": "4x25G"},
+            }
+        }
+    )
+    patch_breakout_helpers(interfaces=ifaces, port_config=_GATE_PC)
+    assert detect_breakout_ports(d) == {"breakout_cfgs": {}, "breakout_ports": {}}
+
+
+def test_unresolvable_and_malformed(patch_breakout_helpers):
+    for bmap in (
+        {"Ethernetfoo": "4x10G"},
+        {"Eth1/1/1": "4x10G"},
+        {"Eth2/1": "4x10G"},
+        {"Ethernet99": "4x10G"},
+        {123: "4x10G"},
+    ):
+        d = _make_sonic_device(
+            custom_fields={"sonic_parameters": {"hwsku": "x", "breakout": bmap}}
+        )
+        patch_breakout_helpers(
+            interfaces=[], port_config=_port_config_for_port(lanes="1,2,3,4")
+        )
+        assert detect_breakout_ports(d) == {
+            "breakout_cfgs": {},
+            "breakout_ports": {},
+        }
+
+
+def test_declared_single_lane_master_no_emit_and_suppressed(patch_breakout_helpers):
+    """A declared 4x25G on a single-lane master fails L%count validation
+    (L=1). No breakout is emitted, and the master is suppressed so the
+    NetBox-format inference that would otherwise fire (Eth1/49/1..4 at 25G)
+    also emits nothing."""
+    d = _make_sonic_device(
+        custom_fields={
+            "sonic_parameters": {"hwsku": "x", "breakout": {"Ethernet0": "4x25G"}}
+        }
+    )
+    interfaces = _netbox_breakout_interfaces(speed=25_000_000)
+    port_config = _port_config_for_port(lanes="29", speed="25000")
+    patch_breakout_helpers(interfaces=interfaces, port_config=port_config)
+    assert detect_breakout_ports(d) == {"breakout_cfgs": {}, "breakout_ports": {}}
+
+
+def test_multiple_unresolvable_keys_logged_per_key(patch_breakout_helpers, loguru_logs):
+    """Two unresolvable keys both normalize to master=None and land in the
+    same bucket. That is not a collision: each key should get its own
+    "could not be resolved" message, not a misleading "collision for None"."""
+    d = _make_sonic_device(
+        custom_fields={
+            "sonic_parameters": {
+                "hwsku": "x",
+                "breakout": {"Ethernetfoo": "4x10G", "Eth2/1": "4x10G"},
+            }
+        }
+    )
+    patch_breakout_helpers(
+        interfaces=[], port_config=_port_config_for_port(lanes="1,2,3,4")
+    )
+    assert detect_breakout_ports(d) == {"breakout_cfgs": {}, "breakout_ports": {}}
+
+    messages = [r["message"] for r in loguru_logs]
+    assert not any("collision for None" in m for m in messages)
+    for key in ("Ethernetfoo", "Eth2/1"):
+        assert any("could not be resolved" in m and key in m for m in messages), key
+
+
+def test_declared_malformed_master_lanes_no_emit(patch_breakout_helpers):
+    """Malformed lanes on the declared master parse to [] (L==0): no emit,
+    master suppressed (the NetBox-format inference is silenced too)."""
+    d = _make_sonic_device(
+        custom_fields={
+            "sonic_parameters": {"hwsku": "x", "breakout": {"Ethernet0": "4x25G"}}
+        }
+    )
+    interfaces = _netbox_breakout_interfaces(speed=25_000_000)
+    port_config = _port_config_for_port(lanes="a,b", speed="25000")
+    patch_breakout_helpers(interfaces=interfaces, port_config=port_config)
+    assert detect_breakout_ports(d) == {"breakout_cfgs": {}, "breakout_ports": {}}
+
+
+def test_emit_breakout_missing_index_leaves_no_partial_state():
+    """A master lacking ``index`` must fail before any children are staged,
+    so no orphan breakout_ports entries survive the error."""
+    port_config = {"Ethernet0": {"lanes": "1,2,3,4"}}  # no "index"
+    breakout_cfgs: dict = {}
+    breakout_ports: dict = {}
+    suppressed: set = set()
+    with pytest.raises(KeyError):
+        _emit_breakout(
+            "Ethernet0",
+            2,
+            50000,
+            port_config,
+            breakout_cfgs,
+            breakout_ports,
+            suppressed,
+        )
+    assert breakout_ports == {}
+    assert breakout_cfgs == {}
+
+
+# ---------------------------------------------------------------------------
 # Child slots occupied by another port
 # ---------------------------------------------------------------------------
 
@@ -693,3 +1056,56 @@ def test_sonic_400g_breakout_refused_when_child_slot_is_another_port(
 
     assert result["breakout_cfgs"] == {}
     assert result["breakout_ports"] == {}
+
+
+@pytest.mark.parametrize("mode", ["4x25G", "2x50G"])
+def test_declared_breakout_refused_when_child_slot_is_another_port(
+    patch_breakout_helpers, real_port_config, mode
+):
+    """Ethernet124 on Accton-AS7726-32X carries four lanes, but Ethernet125
+    and Ethernet126 are independent 10G SFP+ ports sitting in two of its four
+    child slots. Emitting the breakout would rewrite their lanes, speed and
+    alias, so the declaration has to be dropped whole -- no BREAKOUT_CFG entry
+    either, which keeps Ethernet124 a normal 100G port.
+    """
+    port_config = real_port_config("Accton-AS7726-32X")
+    assert {"Ethernet124", "Ethernet125", "Ethernet126"} <= set(port_config)
+
+    device = _make_sonic_device(
+        custom_fields={
+            "sonic_parameters": {"hwsku": "x", "breakout": {"Ethernet124": mode}}
+        }
+    )
+    patch_breakout_helpers(interfaces=[], port_config=port_config)
+
+    result = detect_breakout_ports(device)
+
+    assert result["breakout_ports"] == {}
+    assert result["breakout_cfgs"] == {}
+
+
+def test_declared_breakout_allowed_when_child_slots_are_free(
+    patch_breakout_helpers, real_port_config
+):
+    """The guard must not reject an ordinary port on the same HWSKU: the
+    children of Ethernet0 are Ethernet1-3, none of which is a port in its own
+    right, so 4x25G there stays valid.
+    """
+    port_config = real_port_config("Accton-AS7726-32X")
+
+    device = _make_sonic_device(
+        custom_fields={
+            "sonic_parameters": {"hwsku": "x", "breakout": {"Ethernet0": "4x25G"}}
+        }
+    )
+    patch_breakout_helpers(interfaces=[], port_config=port_config)
+
+    result = detect_breakout_ports(device)
+
+    assert result["breakout_cfgs"]["Ethernet0"]["brkout_mode"] == "4x25G"
+    assert sorted(result["breakout_ports"]) == [
+        "Ethernet0",
+        "Ethernet1",
+        "Ethernet2",
+        "Ethernet3",
+    ]

--- a/tests/unit/tasks/conductor/sonic/test_config_generator_orchestrator.py
+++ b/tests/unit/tasks/conductor/sonic/test_config_generator_orchestrator.py
@@ -543,6 +543,30 @@ def test_generate_sonic_config_merges_breakout_cfgs_and_ports(
     assert config["BREAKOUT_PORTS"]["Ethernet0"] == {"master": "Ethernet0"}
 
 
+def test_generate_sonic_config_breakout_ports_projected_to_master_only(
+    mocker, patch_orchestrator_helpers, make_orchestrator_device
+):
+    """Declared-mode stash keys must not leak into the owned BREAKOUT_PORTS
+    table; only ``{"master": <port>}`` belongs in the device config."""
+    patch_base_config(mocker)
+    patch_orchestrator_helpers.detect_breakout_ports.return_value = {
+        "breakout_cfgs": {"Ethernet0": {"brkout_mode": "2x50G"}},
+        "breakout_ports": {
+            "Ethernet0": {
+                "master": "Ethernet0",
+                "declared": True,
+                "lanes": "1,2",
+                "speed": 50000,
+            }
+        },
+    }
+    device = make_orchestrator_device()
+
+    config = generate_sonic_config(device, "HWSKU")
+
+    assert config["BREAKOUT_PORTS"]["Ethernet0"] == {"master": "Ethernet0"}
+
+
 # ---------------------------------------------------------------------------
 # generate_sonic_config — config_version normalization
 # ---------------------------------------------------------------------------

--- a/tests/unit/tasks/conductor/sonic/test_config_generator_ports.py
+++ b/tests/unit/tasks/conductor/sonic/test_config_generator_ports.py
@@ -352,6 +352,55 @@ class TestAddPortConfigurations:
 
         assert config["PORT"]["Ethernet1"]["index"] == "42"
 
+    def test_declared_child_in_port_config_uses_declared_speed_lanes(
+        self, config, device, mocker
+    ):
+        """A declared non-master child that also exists in port_config is
+        processed by the main loop; the declared stash must win over the
+        NetBox-speed override and the inferred lane calculation."""
+        mocker.patch.object(
+            config_generator, "convert_sonic_interface_to_alias", return_value="a"
+        )
+        port_config = {
+            "Ethernet0": _port_info(index="1", lanes="1,2,3,4", speed="100000"),
+            "Ethernet2": _port_info(index="1", lanes="3,4", speed="25000"),
+        }
+        breakout_info = {
+            "breakout_cfgs": {
+                "Ethernet0": {"breakout_owner": "MANUAL", "brkout_mode": "2x50G"}
+            },
+            "breakout_ports": {
+                "Ethernet0": {
+                    "master": "Ethernet0",
+                    "declared": True,
+                    "lanes": "1,2",
+                    "speed": 50000,
+                },
+                "Ethernet2": {
+                    "master": "Ethernet0",
+                    "declared": True,
+                    "lanes": "3,4",
+                    "speed": 50000,
+                },
+            },
+        }
+        # STALE explicit NetBox 25G that must be overridden by the declared stash
+        netbox_interfaces = {"Ethernet2": _nb_iface(speed=25000, speed_explicit=True)}
+
+        _add_port_configurations(
+            config,
+            port_config,
+            connected_interfaces=set(),
+            portchannel_info={"portchannels": {}, "member_mapping": {}},
+            breakout_info=breakout_info,
+            netbox_interfaces=netbox_interfaces,
+            vlan_info={"vlan_members": {}},
+            device=device,
+        )
+
+        assert config["PORT"]["Ethernet2"]["speed"] == "50000"
+        assert config["PORT"]["Ethernet2"]["lanes"] == "3,4"
+
     def test_default_port_data_keys(
         self, config, device, mocker, patch_post_loop_hooks
     ):
@@ -849,6 +898,82 @@ class TestAddMissingBreakoutPorts:
         alias.assert_called_once_with(
             "Ethernet1", 25000, is_breakout=True, port_config=port_config
         )
+
+    def test_declared_authoritative(self, config):
+        breakout_info = {
+            "breakout_cfgs": {
+                "Ethernet0": {
+                    "breakout_owner": "MANUAL",
+                    "brkout_mode": "2x50G",
+                    "port": "1/1",
+                }
+            },
+            "breakout_ports": {
+                "Ethernet0": {
+                    "master": "Ethernet0",
+                    "declared": True,
+                    "lanes": "1,2",
+                    "speed": 50000,
+                },
+                "Ethernet2": {
+                    "master": "Ethernet0",
+                    "declared": True,
+                    "lanes": "3,4",
+                    "speed": 50000,
+                },
+            },
+        }
+        pc = {
+            "Ethernet0": {
+                "lanes": "1,2,3,4",
+                "alias": "Eth1/1",
+                "index": "1",
+                "speed": "100000",
+            }
+        }
+        nb = {
+            "Ethernet0": {"speed": 25000},
+            "Ethernet2": {"speed": 25000},
+        }  # STALE explicit 25G
+        _add_missing_breakout_ports(
+            config,
+            breakout_info,
+            pc,
+            connected_interfaces=set(),
+            portchannel_info={"portchannels": {}, "member_mapping": {}},
+            netbox_interfaces=nb,
+        )
+        assert config["PORT"]["Ethernet0"]["speed"] == "50000"
+        assert config["PORT"]["Ethernet0"]["lanes"] == "1,2"
+        assert config["PORT"]["Ethernet2"]["speed"] == "50000"
+        assert config["PORT"]["Ethernet2"]["lanes"] == "3,4"
+
+    def test_inferred_unchanged(self, config, mocker):
+        mocker.patch.object(
+            config_generator, "convert_sonic_interface_to_alias", return_value="a"
+        )
+        breakout_info = {
+            "breakout_cfgs": {"Ethernet0": {"brkout_mode": "4x25G"}},
+            "breakout_ports": {"Ethernet1": {"master": "Ethernet0"}},
+        }
+        pc = {
+            "Ethernet0": {
+                "lanes": "1,2,3,4",
+                "alias": "Eth1/1",
+                "index": "1",
+                "speed": "100000",
+            }
+        }
+        nb = {"Ethernet1": {"speed": 25000}}
+        _add_missing_breakout_ports(
+            config,
+            breakout_info,
+            pc,
+            connected_interfaces=set(),
+            portchannel_info={"portchannels": {}, "member_mapping": {}},
+            netbox_interfaces=nb,
+        )
+        assert config["PORT"]["Ethernet1"]["speed"] == "25000"  # existing behavior
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
Part of the series tracked in #2562, which explains the ordering and what each PR covers. Based on the preceding PR in the stack, so review only the top commits here.

The only PR in the series that changes generator behaviour rather than adding
coverage: support for an authoritative device-level `sonic_parameters.breakout`
map, pinning the explicit-declaration path rather than the inference fallback.

It also extends the collision guard from #2560 to this new path. A declared
breakout names its children after the master's lane offsets, so on
Accton-AS7726-32X a 4x declaration on Ethernet124 would claim Ethernet125 and
Ethernet126 — two independent 10G SFP+ ports — and silently rewrite their lanes,
speed and alias. It reuses `_breakout_child_collisions()` and the
`real_port_config` fixture that PR already put on main, rather than adding its
own copies.
