### PR TITLE
Cover port-channel generation

### DIFF
--- a/tests/e2e/golden/osism_e2e-portchannel_config_db.json
+++ b/tests/e2e/golden/osism_e2e-portchannel_config_db.json
@@ -1,0 +1,587 @@
+{
+  "BGP_GLOBALS": {
+    "default": {
+      "always_compare_med": "true",
+      "ebgp_requires_policy": "false",
+      "external_compare_router_id": "false",
+      "fast_external_failover": "true",
+      "holdtime": "180",
+      "ignore_as_path_length": "false",
+      "keepalive": "60",
+      "load_balance_mp_relax": "false",
+      "log_nbr_state_changes": "true",
+      "network_import_check": "true"
+    }
+  },
+  "BGP_GLOBALS_AF": {
+    "default|ipv4_unicast": {
+      "ibgp_equal_cluster_length": "false",
+      "max_ebgp_paths": "2",
+      "max_ibgp_paths": "2",
+      "route_flap_dampen": "false"
+    },
+    "default|ipv6_unicast": {
+      "ibgp_equal_cluster_length": "false",
+      "max_ebgp_paths": "2",
+      "max_ibgp_paths": "2"
+    },
+    "default|l2vpn_evpn": {
+      "advertise-all-vni": "true",
+      "advertise-svi-ip": "true",
+      "dad-enabled": "true"
+    }
+  },
+  "BGP_GLOBALS_AF_NETWORK": {},
+  "BGP_GLOBALS_ROUTE_ADVERTISE": {
+    "default|L2VPN_EVPN|IPV4_UNICAST": {},
+    "default|L2VPN_EVPN|IPV6_UNICAST": {}
+  },
+  "BGP_NEIGHBOR": {},
+  "BGP_NEIGHBOR_AF": {},
+  "BREAKOUT_CFG": {},
+  "BREAKOUT_PORTS": {},
+  "DEVICE_METADATA": {
+    "localhost": {
+      "hostname": "e2e-portchannel",
+      "hwsku": "Accton-AS7726-32X",
+      "mac": "00:00:00:00:00:00",
+      "platform": "x86_64-accton_as7726_32x-r0"
+    }
+  },
+  "DNS_NAMESERVER": {},
+  "INTERFACE": {},
+  "LOOPBACK": {},
+  "LOOPBACK_INTERFACE": {},
+  "MGMT_INTERFACE": {},
+  "NTP_SERVER": {},
+  "PORT": {
+    "Ethernet0": {
+      "admin_status": "up",
+      "adv_speeds": "all",
+      "alias": "Eth1/1",
+      "autoneg": "off",
+      "index": "1",
+      "lanes": "1,2,3,4",
+      "link_training": "off",
+      "mtu": "9100",
+      "speed": "100000",
+      "unreliable_los": "auto",
+      "valid_speeds": "100000,40000"
+    },
+    "Ethernet100": {
+      "admin_status": "down",
+      "adv_speeds": "all",
+      "alias": "Eth1/26",
+      "autoneg": "off",
+      "index": "26",
+      "lanes": "101,102,103,104",
+      "link_training": "off",
+      "mtu": "9100",
+      "speed": "100000",
+      "unreliable_los": "auto",
+      "valid_speeds": "100000,40000"
+    },
+    "Ethernet104": {
+      "admin_status": "down",
+      "adv_speeds": "all",
+      "alias": "Eth1/27",
+      "autoneg": "off",
+      "index": "27",
+      "lanes": "105,106,107,108",
+      "link_training": "off",
+      "mtu": "9100",
+      "speed": "100000",
+      "unreliable_los": "auto",
+      "valid_speeds": "100000,40000"
+    },
+    "Ethernet108": {
+      "admin_status": "down",
+      "adv_speeds": "all",
+      "alias": "Eth1/28",
+      "autoneg": "off",
+      "index": "28",
+      "lanes": "109,110,111,112",
+      "link_training": "off",
+      "mtu": "9100",
+      "speed": "100000",
+      "unreliable_los": "auto",
+      "valid_speeds": "100000,40000"
+    },
+    "Ethernet112": {
+      "admin_status": "down",
+      "adv_speeds": "all",
+      "alias": "Eth1/29",
+      "autoneg": "off",
+      "index": "29",
+      "lanes": "113,114,115,116",
+      "link_training": "off",
+      "mtu": "9100",
+      "speed": "100000",
+      "unreliable_los": "auto",
+      "valid_speeds": "100000,40000"
+    },
+    "Ethernet116": {
+      "admin_status": "down",
+      "adv_speeds": "all",
+      "alias": "Eth1/30",
+      "autoneg": "off",
+      "index": "30",
+      "lanes": "117,118,119,120",
+      "link_training": "off",
+      "mtu": "9100",
+      "speed": "100000",
+      "unreliable_los": "auto",
+      "valid_speeds": "100000,40000"
+    },
+    "Ethernet12": {
+      "admin_status": "down",
+      "adv_speeds": "all",
+      "alias": "Eth1/4",
+      "autoneg": "off",
+      "index": "4",
+      "lanes": "13,14,15,16",
+      "link_training": "off",
+      "mtu": "9100",
+      "speed": "100000",
+      "unreliable_los": "auto",
+      "valid_speeds": "100000,40000"
+    },
+    "Ethernet120": {
+      "admin_status": "down",
+      "adv_speeds": "all",
+      "alias": "Eth1/31",
+      "autoneg": "off",
+      "index": "31",
+      "lanes": "121,122,123,124",
+      "link_training": "off",
+      "mtu": "9100",
+      "speed": "100000",
+      "unreliable_los": "auto",
+      "valid_speeds": "100000,40000"
+    },
+    "Ethernet124": {
+      "admin_status": "down",
+      "adv_speeds": "all",
+      "alias": "Eth1/32",
+      "autoneg": "off",
+      "index": "32",
+      "lanes": "125,126,127,128",
+      "link_training": "off",
+      "mtu": "9100",
+      "speed": "100000",
+      "unreliable_los": "auto",
+      "valid_speeds": "100000,40000"
+    },
+    "Ethernet125": {
+      "admin_status": "down",
+      "adv_speeds": "all",
+      "alias": "Eth1/33",
+      "autoneg": "off",
+      "index": "33",
+      "lanes": "129",
+      "link_training": "off",
+      "mtu": "9100",
+      "speed": "10000",
+      "unreliable_los": "auto",
+      "valid_speeds": "10000,1000"
+    },
+    "Ethernet126": {
+      "admin_status": "down",
+      "adv_speeds": "all",
+      "alias": "Eth1/34",
+      "autoneg": "off",
+      "index": "34",
+      "lanes": "128",
+      "link_training": "off",
+      "mtu": "9100",
+      "speed": "10000",
+      "unreliable_los": "auto",
+      "valid_speeds": "10000,1000"
+    },
+    "Ethernet16": {
+      "admin_status": "down",
+      "adv_speeds": "all",
+      "alias": "Eth1/5",
+      "autoneg": "off",
+      "index": "5",
+      "lanes": "17,18,19,20",
+      "link_training": "off",
+      "mtu": "9100",
+      "speed": "100000",
+      "unreliable_los": "auto",
+      "valid_speeds": "100000,40000"
+    },
+    "Ethernet20": {
+      "admin_status": "down",
+      "adv_speeds": "all",
+      "alias": "Eth1/6",
+      "autoneg": "off",
+      "index": "6",
+      "lanes": "21,22,23,24",
+      "link_training": "off",
+      "mtu": "9100",
+      "speed": "100000",
+      "unreliable_los": "auto",
+      "valid_speeds": "100000,40000"
+    },
+    "Ethernet24": {
+      "admin_status": "down",
+      "adv_speeds": "all",
+      "alias": "Eth1/7",
+      "autoneg": "off",
+      "index": "7",
+      "lanes": "25,26,27,28",
+      "link_training": "off",
+      "mtu": "9100",
+      "speed": "100000",
+      "unreliable_los": "auto",
+      "valid_speeds": "100000,40000"
+    },
+    "Ethernet28": {
+      "admin_status": "down",
+      "adv_speeds": "all",
+      "alias": "Eth1/8",
+      "autoneg": "off",
+      "index": "8",
+      "lanes": "29,30,31,32",
+      "link_training": "off",
+      "mtu": "9100",
+      "speed": "100000",
+      "unreliable_los": "auto",
+      "valid_speeds": "100000,40000"
+    },
+    "Ethernet32": {
+      "admin_status": "down",
+      "adv_speeds": "all",
+      "alias": "Eth1/9",
+      "autoneg": "off",
+      "index": "9",
+      "lanes": "33,34,35,36",
+      "link_training": "off",
+      "mtu": "9100",
+      "speed": "100000",
+      "unreliable_los": "auto",
+      "valid_speeds": "100000,40000"
+    },
+    "Ethernet36": {
+      "admin_status": "down",
+      "adv_speeds": "all",
+      "alias": "Eth1/10",
+      "autoneg": "off",
+      "index": "10",
+      "lanes": "37,38,39,40",
+      "link_training": "off",
+      "mtu": "9100",
+      "speed": "100000",
+      "unreliable_los": "auto",
+      "valid_speeds": "100000,40000"
+    },
+    "Ethernet4": {
+      "admin_status": "up",
+      "adv_speeds": "all",
+      "alias": "Eth1/2",
+      "autoneg": "off",
+      "index": "2",
+      "lanes": "5,6,7,8",
+      "link_training": "off",
+      "mtu": "9100",
+      "speed": "100000",
+      "unreliable_los": "auto",
+      "valid_speeds": "100000,40000"
+    },
+    "Ethernet40": {
+      "admin_status": "down",
+      "adv_speeds": "all",
+      "alias": "Eth1/11",
+      "autoneg": "off",
+      "index": "11",
+      "lanes": "41,42,43,44",
+      "link_training": "off",
+      "mtu": "9100",
+      "speed": "100000",
+      "unreliable_los": "auto",
+      "valid_speeds": "100000,40000"
+    },
+    "Ethernet44": {
+      "admin_status": "down",
+      "adv_speeds": "all",
+      "alias": "Eth1/12",
+      "autoneg": "off",
+      "index": "12",
+      "lanes": "45,46,47,48",
+      "link_training": "off",
+      "mtu": "9100",
+      "speed": "100000",
+      "unreliable_los": "auto",
+      "valid_speeds": "100000,40000"
+    },
+    "Ethernet48": {
+      "admin_status": "down",
+      "adv_speeds": "all",
+      "alias": "Eth1/13",
+      "autoneg": "off",
+      "index": "13",
+      "lanes": "49,50,51,52",
+      "link_training": "off",
+      "mtu": "9100",
+      "speed": "100000",
+      "unreliable_los": "auto",
+      "valid_speeds": "100000,40000"
+    },
+    "Ethernet52": {
+      "admin_status": "down",
+      "adv_speeds": "all",
+      "alias": "Eth1/14",
+      "autoneg": "off",
+      "index": "14",
+      "lanes": "53,54,55,56",
+      "link_training": "off",
+      "mtu": "9100",
+      "speed": "100000",
+      "unreliable_los": "auto",
+      "valid_speeds": "100000,40000"
+    },
+    "Ethernet56": {
+      "admin_status": "down",
+      "adv_speeds": "all",
+      "alias": "Eth1/15",
+      "autoneg": "off",
+      "index": "15",
+      "lanes": "57,58,59,60",
+      "link_training": "off",
+      "mtu": "9100",
+      "speed": "100000",
+      "unreliable_los": "auto",
+      "valid_speeds": "100000,40000"
+    },
+    "Ethernet60": {
+      "admin_status": "down",
+      "adv_speeds": "all",
+      "alias": "Eth1/16",
+      "autoneg": "off",
+      "index": "16",
+      "lanes": "61,62,63,64",
+      "link_training": "off",
+      "mtu": "9100",
+      "speed": "100000",
+      "unreliable_los": "auto",
+      "valid_speeds": "100000,40000"
+    },
+    "Ethernet64": {
+      "admin_status": "down",
+      "adv_speeds": "all",
+      "alias": "Eth1/17",
+      "autoneg": "off",
+      "index": "17",
+      "lanes": "65,66,67,68",
+      "link_training": "off",
+      "mtu": "9100",
+      "speed": "100000",
+      "unreliable_los": "auto",
+      "valid_speeds": "100000,40000"
+    },
+    "Ethernet68": {
+      "admin_status": "down",
+      "adv_speeds": "all",
+      "alias": "Eth1/18",
+      "autoneg": "off",
+      "index": "18",
+      "lanes": "69,70,71,72",
+      "link_training": "off",
+      "mtu": "9100",
+      "speed": "100000",
+      "unreliable_los": "auto",
+      "valid_speeds": "100000,40000"
+    },
+    "Ethernet72": {
+      "admin_status": "down",
+      "adv_speeds": "all",
+      "alias": "Eth1/19",
+      "autoneg": "off",
+      "index": "19",
+      "lanes": "73,74,75,76",
+      "link_training": "off",
+      "mtu": "9100",
+      "speed": "100000",
+      "unreliable_los": "auto",
+      "valid_speeds": "100000,40000"
+    },
+    "Ethernet76": {
+      "admin_status": "down",
+      "adv_speeds": "all",
+      "alias": "Eth1/20",
+      "autoneg": "off",
+      "index": "20",
+      "lanes": "77,78,79,80",
+      "link_training": "off",
+      "mtu": "9100",
+      "speed": "100000",
+      "unreliable_los": "auto",
+      "valid_speeds": "100000,40000"
+    },
+    "Ethernet8": {
+      "admin_status": "down",
+      "adv_speeds": "all",
+      "alias": "Eth1/3",
+      "autoneg": "off",
+      "index": "3",
+      "lanes": "9,10,11,12",
+      "link_training": "off",
+      "mtu": "9100",
+      "speed": "100000",
+      "unreliable_los": "auto",
+      "valid_speeds": "100000,40000"
+    },
+    "Ethernet80": {
+      "admin_status": "down",
+      "adv_speeds": "all",
+      "alias": "Eth1/21",
+      "autoneg": "off",
+      "index": "21",
+      "lanes": "81,82,83,84",
+      "link_training": "off",
+      "mtu": "9100",
+      "speed": "100000",
+      "unreliable_los": "auto",
+      "valid_speeds": "100000,40000"
+    },
+    "Ethernet84": {
+      "admin_status": "down",
+      "adv_speeds": "all",
+      "alias": "Eth1/22",
+      "autoneg": "off",
+      "index": "22",
+      "lanes": "85,86,87,88",
+      "link_training": "off",
+      "mtu": "9100",
+      "speed": "100000",
+      "unreliable_los": "auto",
+      "valid_speeds": "100000,40000"
+    },
+    "Ethernet88": {
+      "admin_status": "down",
+      "adv_speeds": "all",
+      "alias": "Eth1/23",
+      "autoneg": "off",
+      "index": "23",
+      "lanes": "89,90,91,92",
+      "link_training": "off",
+      "mtu": "9100",
+      "speed": "100000",
+      "unreliable_los": "auto",
+      "valid_speeds": "100000,40000"
+    },
+    "Ethernet92": {
+      "admin_status": "down",
+      "adv_speeds": "all",
+      "alias": "Eth1/24",
+      "autoneg": "off",
+      "index": "24",
+      "lanes": "93,94,95,96",
+      "link_training": "off",
+      "mtu": "9100",
+      "speed": "100000",
+      "unreliable_los": "auto",
+      "valid_speeds": "100000,40000"
+    },
+    "Ethernet96": {
+      "admin_status": "down",
+      "adv_speeds": "all",
+      "alias": "Eth1/25",
+      "autoneg": "off",
+      "index": "25",
+      "lanes": "97,98,99,100",
+      "link_training": "off",
+      "mtu": "9100",
+      "speed": "100000",
+      "unreliable_los": "auto",
+      "valid_speeds": "100000,40000"
+    }
+  },
+  "PORTCHANNEL": {
+    "PortChannel1": {
+      "admin_status": "up",
+      "fast_rate": "true",
+      "min_links": "1",
+      "mtu": "9100"
+    }
+  },
+  "PORTCHANNEL_INTERFACE": {
+    "PortChannel1": {
+      "ipv6_use_link_local_only": "enable"
+    }
+  },
+  "PORTCHANNEL_MEMBER": {
+    "PortChannel1|Ethernet0": {},
+    "PortChannel1|Ethernet4": {}
+  },
+  "ROUTE_REDISTRIBUTE": {
+    "default|connected|bgp|ipv4": {},
+    "default|connected|bgp|ipv6": {}
+  },
+  "SNMP_SERVER": {
+    "SYSTEM": {
+      "sysContact": "e2e@example.com",
+      "sysLocation": "E2E Lab",
+      "traps": "enable"
+    }
+  },
+  "SNMP_SERVER_GROUP_MEMBER": {
+    "monitoring|e2e-monitor": {
+      "securityModel": [
+        "usm"
+      ]
+    }
+  },
+  "SNMP_SERVER_PARAMS": {
+    "targetEntry1": {
+      "security-level": "auth-priv",
+      "user": "e2e-monitor"
+    }
+  },
+  "SNMP_SERVER_TARGET": {
+    "targetEntry1": {
+      "ip": "172.16.10.254",
+      "port": "162",
+      "retries": "3",
+      "tag": [
+        "trapNotify",
+        "mgmt"
+      ],
+      "targetParams": "targetEntry1",
+      "timeout": "1500"
+    }
+  },
+  "SNMP_SERVER_USER": {
+    "e2e-monitor": {
+      "aesKey": "OBFUSCATEDPRIVSECRET",
+      "shaKey": "OBFUSCATEDAUTHSECRET"
+    }
+  },
+  "STATIC_ROUTE": {},
+  "SYSLOG_SERVER": {
+    "172.16.10.254": {
+      "message-type": "log",
+      "protocol": "UDP",
+      "remote-port": "514",
+      "severity": "info",
+      "vrf_name": "mgmt"
+    }
+  },
+  "VERSIONS": {
+    "DATABASE": {
+      "VERSION": "version_4_0_1"
+    }
+  },
+  "VLAN": {},
+  "VLAN_INTERFACE": {},
+  "VLAN_MEMBER": {},
+  "VRF": {
+    "default": {
+      "enabled": "true"
+    }
+  },
+  "VXLAN_EVPN_NVO": {},
+  "VXLAN_TUNNEL": {},
+  "VXLAN_TUNNEL_MAP": {}
+}

--- a/tests/e2e/scenario/resources/600-portchannel.yml
+++ b/tests/e2e/scenario/resources/600-portchannel.yml
@@ -1,0 +1,42 @@
+---
+# Port-channel (LAG) scenario for the SONiC E2E golden test.
+#
+# The base fixtures model no LAGs, so PORTCHANNEL / PORTCHANNEL_MEMBER /
+# PORTCHANNEL_INTERFACE are emitted-but-empty. This device bonds two data
+# ports into PortChannel1: a NetBox LAG interface (type: lag) with the two
+# ports referencing it via their lag field, exactly as real deployments
+# model it. Reuses the site / location / tenant from 100-base.yml, and
+# takes the next free position in the shared E2E rack.
+
+- device:
+    name: e2e-portchannel
+    tenant: Testbed
+    site: Discworld
+    location: Ankh-Morpork
+    rack: E2E
+    device_type: edgecore-7726-32x-e2e
+    device_role: leaf
+    face: front
+    position: 9
+    status: active
+    tags:
+      - managed-by-metalbox
+    custom_fields:
+      sonic_parameters:
+        hwsku: Accton-AS7726-32X
+        version: 4.5.0
+
+- device_interface:
+    device: e2e-portchannel
+    name: PortChannel1
+    type: lag
+
+- device_interface:
+    device: e2e-portchannel
+    name: Ethernet0
+    lag: PortChannel1
+
+- device_interface:
+    device: e2e-portchannel
+    name: Ethernet4
+    lag: PortChannel1


### PR DESCRIPTION
Part of the series tracked in #2562, which explains the ordering and what each PR covers. Based on the preceding PR in the stack, so review only the top commits here.

Scenario overlay for port-channels, covering `PORTCHANNEL`,
`PORTCHANNEL_MEMBER` and `PORTCHANNEL_INTERFACE`.
