### PR TITLE
Gate on full config_db table coverage

### DIFF
--- a/tests/unit/e2e/test_golden_coverage.py
+++ b/tests/unit/e2e/test_golden_coverage.py
@@ -1,0 +1,30 @@
+# SPDX-License-Identifier: Apache-2.0
+
+"""Gate on the golden set covering every config_db table the generator emits.
+
+tests/e2e/coverage.py is the human-facing report; this is the check that
+actually fails. It lives in the unit suite rather than in the E2E job because
+it needs neither NetBox nor a generated config -- only the generator source
+and the committed goldens -- so it costs milliseconds and runs on every
+change, instead of only when the E2E job's file matcher fires.
+
+What it catches is the one coverage failure nothing else does: a newly
+emitted table that arrives with no golden. Coverage going the other way (a
+table that had a golden becoming empty) already fails the golden comparison,
+because the golden file itself changes.
+"""
+
+from tests.e2e.coverage import covered_tables, emitted_tables
+
+
+def test_every_emitted_table_has_golden_coverage():
+    missing = sorted(emitted_tables() - covered_tables())
+
+    assert not missing, (
+        "the generator can emit these config_db tables, but they are empty in "
+        "every file under tests/e2e/golden/: " + ", ".join(missing) + ". Seed a "
+        "device that populates them under tests/e2e/scenario/resources/ and "
+        "rewrite the goldens with `make sonic-e2e-regen`, or -- if the table "
+        "cannot be reached by any fixture -- exclude it here with a comment "
+        "saying why."
+    )


### PR DESCRIPTION
Part of the series tracked in #2562, which explains the ordering and what each PR covers. Based on the preceding PR in the stack, so review only the top commits here.

Thirty lines, and the reason the coverage number cannot quietly rot: a unit test
asserting that no table the generator can emit is left without a golden.

It closes the one coverage failure nothing else catches — a **newly** emitted
table arriving with no golden. Coverage lost the other way (a table that had a
golden becoming empty) already fails the golden comparison, because the golden
file itself changes.

It lives in the unit suite rather than the E2E job because it needs neither
NetBox nor a generated config, only the generator source and the committed
goldens. So it costs milliseconds and runs on every change, where the E2E job
runs on a file matcher and a 2400s budget. No `.zuul.yaml` change is needed.

It lands last because it can only pass once the golden set is complete — which
is what the PR below achieves.
