### PR TITLE
rabbitmq: honour the console_interface fallback

### DIFF
--- a/osism/utils/rabbitmq.py
+++ b/osism/utils/rabbitmq.py
@@ -14,12 +14,21 @@ from osism.utils.inventory import (
     resolve_in_host_context,
 )
 
-# The node's internal address. Ansible names interface facts with "-" replaced
-# by "_" and dots left alone (PrefixFactNamespace._underscore), so "br-ex" is
-# ansible_br_ex while "bond0.100" is ansible_bond0.100.
+# The node's internal address, resolved the way osism/defaults resolves it
+# (defaults/manager/000-defaults.yml), including the console_interface
+# fallback: an operator may set console_interface explicitly and leave
+# internal_interface unset, which works in the deployment and must work here.
+# With neither set, defaults/all/099-interfaces.yml resolves console_interface
+# to the undefined "loopback0", so this fails loudly rather than inventing an
+# address.
+#
+# Ansible names interface facts with "-" replaced by "_" and dots left alone
+# (PrefixFactNamespace._underscore), so "br-ex" is ansible_br_ex while
+# "bond0.100" is ansible_bond0.100.
 INTERNAL_ADDRESS_EXPRESSION = (
     "hostvars[inventory_hostname]"
-    "['ansible_' + (internal_interface | replace('-', '_'))]"
+    "['ansible_' + ((internal_interface | default(console_interface))"
+    " | replace('-', '_'))]"
     "['ipv4']['address']"
 )
 

--- a/tests/integration/test_rabbitmq_addresses.py
+++ b/tests/integration/test_rabbitmq_addresses.py
@@ -151,6 +151,18 @@ def test_interface_from_inventory_variable(scenario):
     assert rabbitmq.get_rabbitmq_node_addresses() == [("10.74.34.11", host)]
 
 
+def test_console_interface_fallback(scenario):
+    # osism/defaults resolves this address as
+    # internal_interface|default(console_interface), so a host that sets only
+    # console_interface resolves in the deployment and has to resolve here.
+    host = scenario(
+        "ctl9",
+        {"console_interface": "eth7"},
+        {"ansible_eth7": {"ipv4": {"address": "10.9.9.9"}}},
+    )
+    assert rabbitmq.get_rabbitmq_node_addresses() == [("10.9.9.9", host)]
+
+
 def test_missing_internal_interface_yields_no_addresses(scenario):
     scenario("ctl6", {}, {"ansible_eth0": {"ipv4": {"address": "10.0.0.9"}}})
     assert rabbitmq.get_rabbitmq_node_addresses() is None

--- a/tests/unit/utils/test_rabbitmq.py
+++ b/tests/unit/utils/test_rabbitmq.py
@@ -263,6 +263,16 @@ class TestGetRabbitmqNodeAddresses:
             )
         ]
 
+    def test_expression_falls_back_to_console_interface(self):
+        # osism/defaults resolves this address as
+        # internal_interface|default(console_interface); an operator may set
+        # console_interface explicitly and leave internal_interface unset, which
+        # works in the deployment and must therefore work here too.
+        assert (
+            "internal_interface | default(console_interface)"
+            in rabbitmq.INTERNAL_ADDRESS_EXPRESSION
+        )
+
     def test_expression_normalizes_dashes_but_not_dots(self):
         # Ansible names interface facts with "-" replaced by "_" and leaves
         # dots alone (PrefixFactNamespace._underscore), so the expression must


### PR DESCRIPTION
`osism/defaults` resolves a node's internal address as

```jinja
{{ hostvars[inventory_hostname]['ansible_' +
   internal_interface|default(console_interface)]['ipv4']['address'] }}
```

(`defaults/manager/000-defaults.yml`). The expression used here left the fallback out and referenced `internal_interface` directly, so a host that sets `console_interface` explicitly and leaves `internal_interface` unset — a configuration that resolves in the deployment — did not resolve here.

This adds the fallback so the two agree.

Where neither variable is set it still fails, and loudly: `defaults/all/099-interfaces.yml` defines `console_interface: "{{ internal_interface|default(loopback0) }}"`, and `loopback0` is **not defined as a variable anywhere** in `osism/defaults` (the name occurs only as an interface key in netplan and cloud-init files), so the lookup raises `'loopback0' is undefined` rather than returning an address that was never configured.

**Verification.** On ansible-core 2.19.11, both the case this fixes (`console_interface` set to a real interface, `internal_interface` absent → resolves to that interface's address) and the case it must not paper over (neither set → raises).

Note this **widens** what resolves rather than narrowing it: the code preceding this stack required `internal_interface` outright and skipped the host without it.

Separable — this is not needed to fix osism/issues#1425, and can be deferred or dropped without affecting the rest of the stack.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
