### PR TITLE
inventory: resolve via a controller action plugin

### DIFF
--- a/osism/utils/inventory.py
+++ b/osism/utils/inventory.py
@@ -7,6 +7,25 @@ import tempfile
 
 from loguru import logger
 
+_RESOLVE_ACTION_PLUGIN = """\
+from ansible.plugins.action import ActionBase
+
+
+class ActionModule(ActionBase):
+    TRANSFERS_FILES = False
+
+    def run(self, tmp=None, task_vars=None):
+        result = super().run(tmp, task_vars)
+        with open(self._task.args["dest"], "w") as fp:
+            # Ansible types the templated result, so a numeric expression
+            # arrives as an int, which write() rejects. Convert it, so any
+            # expression resolves and not just the ones that happen to yield
+            # a string.
+            fp.write(str(self._task.args["content"]))
+        result["changed"] = False
+        return result
+"""
+
 
 class HostContextResolutionError(Exception):
     """Raised when an expression cannot be templated in a host's context."""
@@ -82,14 +101,14 @@ def resolve_in_host_context(
     code". Re-implementing the templating in the consumer is not an option: it
     only ever covers the shapes that were thought of.
 
-    The value is produced by having Ansible ``copy`` the templated expression
-    into a file, run with ``-c local`` so the module executes on the controller.
-    No connection is made to the host, so this works for hosts that are down or
-    unreachable, and the value is read back byte-exact instead of being parsed
-    out of human-readable output. That matters because the callback formats
-    differ between the ansible-core versions this package runs under, and
-    because ``--tree``, the other way to get structured output, is deprecated
-    for removal in ansible-core 2.23.
+    The value is produced by a controller-side Ansible action plugin. Ansible
+    templates the plugin arguments in the target host's variable context, but
+    the plugin writes the result locally without making a connection or
+    launching a module with the target's Python interpreter. This works for
+    hosts that are down or unreachable and preserves the value byte-exact
+    instead of parsing it out of human-readable output. That matters because
+    callback formats differ between the ansible-core versions this package
+    runs under.
 
     Facts are passed as extra vars rather than through a fact-cache plugin.
     That keeps the call independent of which cache plugin is configured (the
@@ -122,6 +141,14 @@ def resolve_in_host_context(
     env["ANSIBLE_NOCOLOR"] = "1"
 
     with tempfile.TemporaryDirectory(prefix="osism-resolve-") as workdir:
+        action_path = os.path.join(workdir, "osism_resolve.py")
+        with open(action_path, "w") as fp:
+            fp.write(_RESOLVE_ACTION_PLUGIN)
+        configured_action_plugins = env.get("ANSIBLE_ACTION_PLUGINS")
+        env["ANSIBLE_ACTION_PLUGINS"] = os.pathsep.join(
+            part for part in (workdir, configured_action_plugins) if part
+        )
+
         value_path = os.path.join(workdir, "value")
         # JSON module args rather than key=value, so a value containing spaces
         # survives.
@@ -136,7 +163,7 @@ def resolve_in_host_context(
             "-c",
             "local",
             "-m",
-            "copy",
+            "osism_resolve",
             "-a",
             module_args,
         ]

--- a/tests/integration/test_host_context_resolution.py
+++ b/tests/integration/test_host_context_resolution.py
@@ -1,0 +1,119 @@
+# SPDX-License-Identifier: Apache-2.0
+
+"""Integration tests for ``resolve_in_host_context()`` against real Ansible.
+
+The unit tests in ``tests/unit/utils/test_inventory.py`` mock ``subprocess``,
+so they pin the shape of the command that gets built and nothing about what
+Ansible does with it. Three properties of this helper can only be established
+by running Ansible, and each of them has already been wrong once:
+
+- the expression is evaluated in the *target host's* variable context;
+- resolution does not depend on the target's ``ansible_python_interpreter``
+  existing on the controller -- it is a path chosen for the host, and the
+  controller is a different machine (in production, a different container
+  image);
+- the resolved value is returned as text even when the expression yields a
+  non-string, which Ansible types as such.
+
+These drive the public function, so they stay meaningful across changes to how
+resolution is implemented.
+
+Requires ``ansible`` on PATH; ``ansible-core`` is not a dependency of this
+package -- it comes from the container images -- so these skip without it.
+"""
+
+import os
+import shutil
+
+import pytest
+
+from osism.utils.inventory import resolve_in_host_context
+
+pytestmark = pytest.mark.integration
+
+
+@pytest.fixture(scope="module", autouse=True)
+def _require_ansible():
+    """Skip unless ``ansible`` is on PATH.
+
+    Set OSISM_REQUIRE_ANSIBLE to turn the skip into a failure, so a job that is
+    meant to have Ansible cannot pass by skipping everything.
+    """
+    if shutil.which("ansible"):
+        return
+    if os.environ.get("OSISM_REQUIRE_ANSIBLE"):
+        pytest.fail("OSISM_REQUIRE_ANSIBLE is set but 'ansible' is not on PATH")
+    pytest.skip("ansible not on PATH")
+
+
+@pytest.fixture
+def inventory(tmp_path):
+    """Build a one-host inventory carrying the given host variables."""
+
+    def _build(**variables):
+        path = tmp_path / "hosts.yml"
+        lines = ["all:", "  hosts:", "    node1:"]
+        # RFC 5737 documentation range: unreachable on purpose, so an
+        # implementation that tried to connect would fail here rather than
+        # pass quietly.
+        variables.setdefault("ansible_host", "192.0.2.10")
+        lines += [f"      {key}: {value}" for key, value in variables.items()]
+        path.write_text("\n".join(lines) + "\n")
+        return str(path)
+
+    return _build
+
+
+def test_expression_is_evaluated_in_the_host_context(inventory):
+    inv = inventory(internal_interface="eth3")
+
+    assert resolve_in_host_context("node1", "internal_interface", inv) == "eth3"
+
+
+@pytest.mark.parametrize(
+    "interpreter",
+    ["/usr/bin/python3", "/opt/osism/venv/bin/python3", "/nonexistent/python3"],
+    ids=["default", "venv", "absent"],
+)
+def test_resolution_does_not_need_the_target_interpreter(inventory, interpreter):
+    """The interpreter a host declares need not exist on the controller.
+
+    Resolution runs a controller-side action plugin and launches no module, so
+    no interpreter is selected. Before that, Ansible used the target's
+    ansible_python_interpreter to run the module locally and every lookup in
+    the osismclient image died with "/bin/sh: /usr/bin/python3: not found".
+    The venv case is not hypothetical -- OSISM's own testbed sets a venv
+    interpreter, and /usr/bin/python3 is a default rather than a constant, so
+    providing that one path on the controller would not be enough.
+    """
+    inv = inventory(ansible_python_interpreter=interpreter, internal_interface="eth3")
+
+    assert resolve_in_host_context("node1", "internal_interface", inv) == "eth3"
+
+
+def test_target_interpreter_is_readable_as_a_host_variable(inventory):
+    """The host's own interpreter value must survive resolution.
+
+    Overriding it with an extra var would make the module run locally too, but
+    extra vars outrank everything, so the variable would read back as the
+    controller's interpreter -- a silently wrong answer from a helper whose
+    whole job is to evaluate in the host's context.
+    """
+    inv = inventory(ansible_python_interpreter="/opt/osism/venv/bin/python3")
+
+    resolved = resolve_in_host_context("node1", "ansible_python_interpreter", inv)
+
+    assert resolved == "/opt/osism/venv/bin/python3"
+
+
+def test_non_string_result_is_returned_as_text(inventory):
+    """A numeric expression resolves rather than raising.
+
+    Ansible types the templated result, so this arrives as an int, which
+    write() rejects unless the value is converted. Without that conversion a
+    helper documented as generic silently handles only the expressions that
+    happen to yield a string.
+    """
+    inv = inventory(workers=4)
+
+    assert resolve_in_host_context("node1", "workers * 2", inv) == "8"

--- a/tests/unit/utils/test_inventory.py
+++ b/tests/unit/utils/test_inventory.py
@@ -173,8 +173,11 @@ class TestResolveInHostContext:
                 # The temp dir is gone by the time the test inspects anything,
                 # so read the extra-vars file here.
                 extra_vars = None
-                if "-e" in command:
-                    with open(command[command.index("-e") + 1][1:]) as fp:
+                facts_args = [
+                    a for a in command if isinstance(a, str) and a.startswith("@")
+                ]
+                if facts_args:
+                    with open(facts_args[0][1:]) as fp:
                         extra_vars = json.load(fp)
                 capture.append((command, kwargs, args, extra_vars))
             if value is not None:
@@ -207,12 +210,14 @@ class TestResolveInHostContext:
         command, kwargs, args, _ = calls[0]
         assert command[:2] == ["ansible", "host1"]
         assert command[command.index("-i") + 1] == "/inv/hosts.yml"
-        assert command[command.index("-m") + 1] == "copy"
-        # -c local keeps the module on the controller, so a host that is down
-        # still resolves and no SSH is attempted.
+        assert command[command.index("-m") + 1] == "osism_resolve"
+        # The action plugin runs entirely on the controller, so a host that is
+        # down still resolves and no SSH is attempted.
         assert command[command.index("-c") + 1] == "local"
         assert args["content"] == "{{ internal_interface }}"
         assert kwargs["env"]["ANSIBLE_GATHERING"] == "explicit"
+        action_plugins = kwargs["env"]["ANSIBLE_ACTION_PLUGINS"].split(os.pathsep)
+        assert os.path.dirname(args["dest"]) in action_plugins
 
     def test_module_args_are_json_not_key_value(self, mocker):
         # key=value args would split a value containing spaces.
@@ -235,13 +240,28 @@ class TestResolveInHostContext:
         assert command[command.index("-e") + 1].startswith("@")
         assert extra_vars == facts
 
-    def test_no_extra_vars_argument_without_facts(self, mocker):
+    def test_no_facts_file_without_facts(self, mocker):
         calls = []
         self._run(mocker, value="10.0.0.5", capture=calls)
 
         resolve_in_host_context("host1", "expr", "/inv")
 
-        assert "-e" not in calls[0][0]
+        # No @-prefixed extra-vars file.
+        assert not [a for a in calls[0][0] if a.startswith("@")]
+
+    def test_target_interpreter_is_not_overridden(self, mocker):
+        # The action plugin does not launch a target module, so the target's
+        # interpreter remains available to the expression as an ordinary host
+        # variable.
+        calls = []
+        self._run(mocker, value="10.0.0.5", capture=calls)
+
+        resolve_in_host_context("host1", "ansible_python_interpreter", "/inv")
+
+        command = calls[0][0]
+        assert "ansible_python_interpreter" not in command
+        args = json.loads(command[command.index("-a") + 1])
+        assert args["content"] == "{{ ansible_python_interpreter }}"
 
     def test_nonzero_exit_raises_with_ansible_message(self, mocker):
         # Ansible names the undefined attribute; that is what the operator needs.


### PR DESCRIPTION
`resolve_in_host_context()` fails for every host whose
`ansible_python_interpreter` does not also exist on the controller. In the
`osismclient` image that is every host, so `osism status messaging` reports all
RabbitMQ nodes unresolvable on a perfectly healthy cluster.

Follows on from:

- osism/python-osism#2578
- osism/python-osism#2579

## The bug

The helper templated its expression with `ansible <host> -c local -m copy`. The
`-c local` is deliberate and right — the module runs on the controller, so no
connection is made and the lookup also works for hosts that are down.

But `-c local` only decides **where** the module runs. Ansible still picks the
interpreter from the *target host's* `ansible_python_interpreter`, which
`osism/defaults` sets to `/usr/bin/python3`. That path is correct on the nodes
and need not exist on the controller — and it does not exist in `osismclient`,
where the CLI actually runs (`/usr/local/bin/osism` execs
`docker exec -i … osismclient osism`):

```
Failed to get information on remote file (/tmp/osism-resolve-…/value):
  /bin/sh: /usr/bin/python3: not found
```

Ansible reports that against the host context, so the error names the host and
reads as if the node were broken. The node is fine; so is RabbitMQ.

`osism-ansible` *does* have `/usr/bin/python3`, which is likely why this went
unnoticed — only the client container is affected.

Reproducible without RabbitMQ, inside `osismclient`:

```sh
ansible testbed-node-0 -i /ansible/inventory/hosts.yml -c local \
  -m copy -a '{"content":"{{ 40 + 2 }}","dest":"/tmp/v"}'
```

## The fix

Run the resolution through a controller-side **action plugin**. An action
plugin executes on the controller by design and launches no module, so no
interpreter is selected at all — while Ansible still templates the task
arguments in the target host's variable context, which is the property this
helper exists for. The failure mode is removed rather than compensated for, and
any future caller benefits.

## Alternatives rejected

**Override the interpreter with an extra var.** Removes the crash, but extra
vars outrank every other source, so it does not merely steer module execution —
it replaces the *value* of `ansible_python_interpreter` during templating. Any
expression reading that variable would get the controller's answer instead of
the host's: a silently wrong result from a helper whose whole purpose is to
evaluate in the host's context. Measured against real Ansible, resolving
`ansible_python_interpreter` for a host declaring `/usr/bin/python3` returned
the controller's virtualenv python.

**Add `/usr/bin/python3` to the `osismclient` image.** Smaller, but it only
covers hosts using the default. The value is a *default*, not a constant —
OSISM's own testbed sets a venv interpreter — so a host declaring one still
fails on a controller that has `/usr/bin/python3` (verified). It would also
leave the code dependent on an image detail, so anything running the CLI
outside that image stays broken.

## Testing

New integration tests drive the public function against **real Ansible**; the
existing unit tests mock `subprocess` and can only pin the shape of the command,
not what Ansible does with it. They cover host-context evaluation, resolution
under three target interpreters (default, venv, absent), the host's own
interpreter reading back unchanged, and a non-string result.

- `pytest tests/integration/` — 56 passed
- `pytest tests/unit/` — 3132 passed, 4 xfailed
- flake8 + black clean

**Verified on a live cluster** by patching the module into the running
`osismclient` container: `osism status messaging` goes from `Failed to get
RabbitMQ node addresses` to reading each node's management API on its resolved
address and reporting the cluster healthy (3 nodes, no partitions). The full
infrastructure check suite then passed 7/7. The container was restored to the
shipped version afterwards.

Draft: not yet reviewed by anyone but its authors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)